### PR TITLE
- Addresses future deprecation of .render method for pandas.io.format…

### DIFF
--- a/chainladder/core/display.py
+++ b/chainladder/core/display.py
@@ -131,7 +131,7 @@ class TriangleDisplay:
                         subset=subset,
                         gmap=gmap,
                     )
-                    .render()
+                    .to_html()
                 )
             else:
                 default_output = (

--- a/chainladder/core/tests/test_display.py
+++ b/chainladder/core/tests/test_display.py
@@ -1,0 +1,6 @@
+import pytest
+
+
+def test_heatmap_render(raa):
+    """ The heatmap method should render correctly given the sample."""
+    return raa.heatmap()


### PR DESCRIPTION
…s.style.Styler class in pandas version 1.4.0, mentioned in #274.

- No tests concerning display.py were found, so I added one that simply renders the heatmap to catch any exceptions or warnings.

- I thought about either adding another condition to https://github.com/casact/chainladder-python/blob/bc8a52b72f2e202335ca48df5192c85ee0306e44/chainladder/core/display.py#L123-L134, or to just replace .render() with .to_html(). I tried the latter and the test passed, so I think it should be ok as this method was introduced in pandas 1.3.0. As expected, running the test on the original code with pandas 1.4.1 triggers the warning but does not if run with pandas 1.3.5.

- Running pytest on the whole repository at HEAD triggered a bunch of errors and warnings so I focused on just this one test I added. It did trigger 2 warnings prior to any edits to display.py.