### PR TITLE
Address origin_as_datetime bug

### DIFF
--- a/chainladder/core/pandas.py
+++ b/chainladder/core/pandas.py
@@ -7,6 +7,11 @@ import warnings
 from sklearn.utils import deprecated
 from chainladder.utils.utility_functions import num_to_nan
 
+try:
+    import dask.bag as db
+except:
+    db = None
+
 
 class TriangleGroupBy:
     def __init__(self, obj, by, axis=0, **kwargs):
@@ -60,7 +65,6 @@ class TrianglePandas:
         """
 
         if origin_as_datetime == None:  # origin_as_datetime not specified
-
             warning = "In an upcoming version of the package, `origin_as_datetime` " + \
                 "will be defaulted to `True` in to_frame(...), use " + \
                 "`origin_as_datetime=False` to preserve current setting."

--- a/chainladder/core/pandas.py
+++ b/chainladder/core/pandas.py
@@ -7,6 +7,7 @@ import warnings
 from sklearn.utils import deprecated
 
 from chainladder.utils.utility_functions import num_to_nan
+
 try:
     import dask.bag as db
 except:
@@ -18,8 +19,8 @@ class TriangleGroupBy:
         self.obj = obj.copy()
         self.axis = self.obj._get_axis(axis)
         self.by = by
-        if kwargs.get('groups', None):
-            self.groups = kwargs.get('groups', None)
+        if kwargs.get("groups", None):
+            self.groups = kwargs.get("groups", None)
         elif self.axis == 0:
             self.groups = obj.index.groupby(by)
         elif axis == 1:
@@ -28,18 +29,30 @@ class TriangleGroupBy:
             self.groups = pd.DataFrame(by).groupby(by)
 
     def __getitem__(self, key):
-        return TriangleGroupBy(obj=self.obj.__getitem__(key), by=self.by,
-                               axis=self.axis, groups=self.groups)
+        return TriangleGroupBy(
+            obj=self.obj.__getitem__(key),
+            by=self.by,
+            axis=self.axis,
+            groups=self.groups,
+        )
+
 
 class TrianglePandas:
-    def to_frame(self, origin_as_datetime=None, keepdims=False,
-                 implicit_axis=False, *args, **kwargs):
-        """ Converts a triangle to a pandas.DataFrame.
+    def to_frame(
+        self,
+        origin_as_datetime=None,
+        keepdims=False,
+        implicit_axis=False,
+        *args,
+        **kwargs
+    ):
+        """Converts a triangle to a pandas.DataFrame.
         Parameters
         ----------
         origin_as_datetime : bool
             Whether the origin vector should be converted from PeriodIndex
-            into a datetime dtype. Default is False.
+            into a datetime dtype. Default is False, but will be changed to
+            True in an upcoming version.
         keepdims : bool
             If True, the triangle will be converted to a DataFrame with all
             dimensions intact.  The argument will force a consistent DataFrame
@@ -64,7 +77,7 @@ class TrianglePandas:
             obj = self.val_to_dev().set_backend("sparse")
             out = pd.DataFrame(obj.index.iloc[obj.values.coords[0]])
             out["columns"] = obj.columns[obj.values.coords[1]]
-            missing_cols = list(set(self.columns) - set(out['columns']))
+            missing_cols = list(set(self.columns) - set(out["columns"]))
             if origin_as_datetime:
                 out["origin"] = obj.odims[obj.values.coords[2]]
             else:
@@ -79,32 +92,43 @@ class TrianglePandas:
                 out.columns.get_level_values(1)[2:]
             )
 
-            valuation = pd.DataFrame(
-                obj.valuation.values.reshape(obj.shape[-2:], order='F'),
-                index=obj.odims if origin_as_datetime else obj.origin, 
-                columns=obj.ddims
-            ).unstack().rename('valuation').reset_index().rename(
-                columns={'level_0': 'development', 'level_1': 'origin'})
+            valuation = (
+                pd.DataFrame(
+                    obj.valuation.values.reshape(obj.shape[-2:], order="F"),
+                    index=obj.odims if origin_as_datetime else obj.origin,
+                    columns=obj.ddims,
+                )
+                .unstack()
+                .rename("valuation")
+                .reset_index()
+                .rename(columns={"level_0": "development", "level_1": "origin"})
+            )
 
-            val_dict = dict(zip(list(zip(
-                valuation['origin'], valuation['development'])),
-                valuation['valuation']))
+            val_dict = dict(
+                zip(
+                    list(zip(valuation["origin"], valuation["development"])),
+                    valuation["valuation"],
+                )
+            )
             if len(out) > 0:
-                out['valuation'] = out.apply(
-                    lambda x: val_dict[(x['origin'], x['development'])], axis=1)
+                out["valuation"] = out.apply(
+                    lambda x: val_dict[(x["origin"], x["development"])], axis=1
+                )
             else:
-                out['valuation'] = self.valuation_date
+                out["valuation"] = self.valuation_date
             col_order = list(self.columns)
             if implicit_axis:
-                col_order = ['origin', 'development', 'valuation'] + col_order
+                col_order = ["origin", "development", "valuation"] + col_order
             else:
                 if is_val_tri:
-                    col_order = ['origin', 'valuation'] + col_order
+                    col_order = ["origin", "valuation"] + col_order
                 else:
-                    col_order = ['origin', 'development'] + col_order
+                    col_order = ["origin", "development"] + col_order
             for col in set(missing_cols) - self.virtual_columns.columns.keys():
                 out[col] = np.nan
-            for col in set(missing_cols).intersection(self.virtual_columns.columns.keys()):
+            for col in set(missing_cols).intersection(
+                self.virtual_columns.columns.keys()
+            ):
                 out[col] = out.fillna(0).apply(self.virtual_columns.columns[col], 1)
                 out.loc[out[col] == 0, col] = np.nan
 
@@ -139,15 +163,17 @@ class TrianglePandas:
 
             else:
                 return self.to_frame(
-                    origin_as_datetime=origin_as_datetime, keepdims=True,
-                    implicit_axis=implicit_axis)
+                    origin_as_datetime=origin_as_datetime,
+                    keepdims=True,
+                    implicit_axis=implicit_axis,
+                )
 
     def plot(self, *args, **kwargs):
-        """ Passthrough of pandas functionality """
+        """Passthrough of pandas functionality"""
         return self.to_frame(origin_as_datetime=False).plot(*args, **kwargs)
 
     def hvplot(self, *args, **kwargs):
-        """ Passthrough of pandas functionality """
+        """Passthrough of pandas functionality"""
         df = self.to_frame(origin_as_datetime=True)
         if type(df.index) == pd.PeriodIndex and len(df.columns) > 1:
             df.index = df.index.to_timestamp(how="s")
@@ -162,7 +188,7 @@ class TrianglePandas:
         return ax.get(axis, 0)
 
     def dropna(self):
-        """  Method that removes orgin/development vectors from edge of a
+        """Method that removes orgin/development vectors from edge of a
         triangle that are all missing values. This may come in handy for a
         new line of business that doesn't have origins/developments of an
         existing line in the same triangle.
@@ -183,7 +209,7 @@ class TrianglePandas:
         return obj
 
     def fillna(self, value=None, inplace=False):
-        """  Fill nan with 'value' by axis.
+        """Fill nan with 'value' by axis.
         Parameters
         -----------
         value: single value or array-like values, default = None
@@ -198,19 +224,17 @@ class TrianglePandas:
         Triangle
         """
         if inplace:
-            frame = (self + value*0)
+            frame = self + value * 0
             xp = self.get_array_module()
-            fill = (xp.nan_to_num(frame.values)==0)*(self*0 + value)
+            fill = (xp.nan_to_num(frame.values) == 0) * (self * 0 + value)
             self.values = (frame + fill).values
             return self
         else:
             new_obj = self.copy()
             return new_obj.fillna(value=value, inplace=True)
 
- 
-
     def drop(self, labels=None, axis=1):
-        """ Drop specified labels from rows or columns.
+        """Drop specified labels from rows or columns.
 
         Remove rows or columns by specifying label names and corresponding axis,
         or by specifying directly index or column names.
@@ -241,7 +265,7 @@ class TrianglePandas:
         return self.to_frame(origin_as_datetime=False).T
 
     def groupby(self, by, axis=0, *args, **kwargs):
-        """ Group Triangle by index values.  If the triangle is convertable to a
+        """Group Triangle by index values.  If the triangle is convertable to a
         DataFrame, then it defaults to pandas groupby functionality.
 
         Parameters
@@ -256,7 +280,7 @@ class TrianglePandas:
         return TriangleGroupBy(self, by, axis)
 
     def append(self, other):
-        """ Append rows of other to the end of caller, returning a new object.
+        """Append rows of other to the end of caller, returning a new object.
 
         Parameters
         ----------
@@ -272,7 +296,7 @@ class TrianglePandas:
         return concat((self, other), 0)
 
     def rename(self, axis, value):
-        """ Alter axes labels.
+        """Alter axes labels.
 
         Parameters
         ----------
@@ -300,7 +324,7 @@ class TrianglePandas:
         return self
 
     def astype(self, dtype, inplace=True):
-        """ Copy of the array, cast to a specified type.
+        """Copy of the array, cast to a specified type.
 
         Parameters
         ----------
@@ -346,7 +370,7 @@ class TrianglePandas:
 
 
 def add_triangle_agg_func(cls, k, v):
-    """ Aggregate Overrides in Triangle """
+    """Aggregate Overrides in Triangle"""
 
     def agg_func(self, axis=None, *args, **kwargs):
         keepdims = kwargs.get("keepdims", None)
@@ -386,7 +410,7 @@ def add_triangle_agg_func(cls, k, v):
 
 
 def add_groupby_agg_func(cls, k, v):
-    """ Aggregate Overrides in GroupBy """
+    """Aggregate Overrides in GroupBy"""
 
     def agg_func(self, *args, **kwargs):
         from chainladder.utils import concat
@@ -394,19 +418,21 @@ def add_groupby_agg_func(cls, k, v):
         xp = self.obj.get_array_module()
         obj = self.obj.copy()
         auto_sparse = kwargs.pop("auto_sparse", True)
-        if db and obj.array_backend == 'sparse':
+        if db and obj.array_backend == "sparse":
+
             def aggregate(i, obj, axis, v):
                 return getattr(
                     obj.iloc.__getitem__(tuple([slice(None)] * axis + [i])), v
                 )(axis, auto_sparse=False, keepdims=True)
+
             bag = db.from_sequence(self.groups.indices.values())
             bag = bag.map(aggregate, obj, self.axis, v)
-            values = bag.compute(scheduler='threads')
+            values = bag.compute(scheduler="threads")
         else:
             values = [
-                getattr(obj.iloc.__getitem__(tuple([slice(None)] * self.axis + [i])), v)(
-                    self.axis, auto_sparse=False, keepdims=True
-                )
+                getattr(
+                    obj.iloc.__getitem__(tuple([slice(None)] * self.axis + [i])), v
+                )(self.axis, auto_sparse=False, keepdims=True)
                 for i in self.groups.indices.values()
             ]
         obj = concat(values, axis=self.axis, ignore_index=True)
@@ -430,10 +456,11 @@ def add_groupby_agg_func(cls, k, v):
             obj.vdims = pd.DataFrame(self.groups.dtypes.index).values[:, 0]
         if self.axis == 2:
             odims = self.obj._to_datetime(
-                pd.Series(self.groups.indices.keys()).to_frame(), [0])
+                pd.Series(self.groups.indices.keys()).to_frame(), [0]
+            )
             obj.origin_grain = self.obj._get_grain(odims)
-            split = obj.origin_grain.split('-')
-            obj.origin_grain = {'A': 'Y', '2Q': 'S'}.get(split[0], split[0])
+            split = obj.origin_grain.split("-")
+            obj.origin_grain = {"A": "Y", "2Q": "S"}.get(split[0], split[0])
             obj.odims = odims.values
         obj._set_slicers()
         if auto_sparse:
@@ -444,7 +471,7 @@ def add_groupby_agg_func(cls, k, v):
 
 
 def add_df_passthru(cls, k):
-    """Pass Through of pandas functionality """
+    """Pass Through of pandas functionality"""
 
     def df_passthru(self, *args, **kwargs):
         return getattr(pd.DataFrame, k)(self.to_frame(), *args, **kwargs)
@@ -453,16 +480,31 @@ def add_df_passthru(cls, k):
 
 
 def set_method(cls, func, k):
-    """ Assigns methods to a class """
+    """Assigns methods to a class"""
     func.__doc__ = "Refer to pandas for ``{}`` functionality.".format(k)
     func.__name__ = k
     setattr(cls, func.__name__, func)
 
 
 df_passthru = (
-    ["to_clipboard", "to_csv", "to_excel", "to_json", "to_html",]
-    + ["to_dict", "unstack", "pivot", "drop_duplicates", "describe", "melt",]
-    + ["pct_chg",]
+    [
+        "to_clipboard",
+        "to_csv",
+        "to_excel",
+        "to_json",
+        "to_html",
+    ]
+    + [
+        "to_dict",
+        "unstack",
+        "pivot",
+        "drop_duplicates",
+        "describe",
+        "melt",
+    ]
+    + [
+        "pct_chg",
+    ]
 )
 for item in df_passthru:
     add_df_passthru(TrianglePandas, item)

--- a/chainladder/core/pandas.py
+++ b/chainladder/core/pandas.py
@@ -7,6 +7,7 @@ import warnings
 from sklearn.utils import deprecated
 
 from chainladder.utils.utility_functions import num_to_nan
+
 try:
     import dask.bag as db
 except:
@@ -18,8 +19,8 @@ class TriangleGroupBy:
         self.obj = obj.copy()
         self.axis = self.obj._get_axis(axis)
         self.by = by
-        if kwargs.get('groups', None):
-            self.groups = kwargs.get('groups', None)
+        if kwargs.get("groups", None):
+            self.groups = kwargs.get("groups", None)
         elif self.axis == 0:
             self.groups = obj.index.groupby(by)
         elif axis == 1:
@@ -28,18 +29,29 @@ class TriangleGroupBy:
             self.groups = pd.DataFrame(by).groupby(by)
 
     def __getitem__(self, key):
-        return TriangleGroupBy(obj=self.obj.__getitem__(key), by=self.by,
-                               axis=self.axis, groups=self.groups)
+        return TriangleGroupBy(
+            obj=self.obj.__getitem__(key),
+            by=self.by,
+            axis=self.axis,
+            groups=self.groups,
+        )
+
 
 class TrianglePandas:
-    def to_frame(self, origin_as_datetime=None, keepdims=False,
-                 implicit_axis=False, *args, **kwargs):
-        """ Converts a triangle to a pandas.DataFrame.
+    def to_frame(
+        self,
+        origin_as_datetime=None,
+        keepdims=False,
+        implicit_axis=False,
+        *args,
+        **kwargs
+    ):
+        """Converts a triangle to a pandas.DataFrame.
         Parameters
         ----------
         origin_as_datetime : bool
             Whether the origin vector should be converted from PeriodIndex
-            into a datetime dtype. Default is False.
+            into a datetime dtype. Default is False, but will be defaulted to True in an upcoming version.
         keepdims : bool
             If True, the triangle will be converted to a DataFrame with all
             dimensions intact.  The argument will force a consistent DataFrame
@@ -51,103 +63,157 @@ class TrianglePandas:
         -------
             pandas.DataFrame representation of the Triangle.
         """
-        if origin_as_datetime == None:
-            # this will be set to True as the default in an upcoming version of the package
-            warning = "In an upcoming version of the package, `origin_as_datetime` will be defaulted to `True` in to_frame(...), use `origin_as_datetime=False` to preserve current setting."
-            warnings.warn(warning)
-            origin_as_datetime = False
 
-        axes = [num for num, item in enumerate(self.shape) if item > 1]
+        def _to_frame_helper(
+            self,
+            origin_as_datetime=None,
+            keepdims=False,
+            implicit_axis=False,
+            *args,
+            **kwargs
+        ):
+            if origin_as_datetime == None:
+                # this will be set to True as the default in an upcoming version of the package
+                warning = "In an upcoming version of the package, `origin_as_datetime` will be defaulted to `True` in to_frame(...), use `origin_as_datetime=False` to preserve current setting."
+                warnings.warn(warning)
+                origin_as_datetime = False
 
-        if keepdims:
-            is_val_tri = self.is_val_tri
-            obj = self.val_to_dev().set_backend("sparse")
-            out = pd.DataFrame(obj.index.iloc[obj.values.coords[0]])
-            out["columns"] = obj.columns[obj.values.coords[1]]
-            missing_cols = list(set(self.columns) - set(out['columns']))
-            if origin_as_datetime:
-                out["origin"] = obj.odims[obj.values.coords[2]]
-            else:
-                out["origin"] = obj.origin[obj.values.coords[2]]
-            out["development"] = obj.ddims[obj.values.coords[3]]
-            out["values"] = obj.values.data
-            out = pd.pivot_table(
-                out, index=obj.key_labels + ["origin", "development"], columns="columns"
-            )
-            out = out.reset_index().set_index(obj.key_labels)
-            out.columns = ["origin", "development"] + list(
-                out.columns.get_level_values(1)[2:]
-            )
+            axes = [num for num, item in enumerate(self.shape) if item > 1]
 
-            valuation = pd.DataFrame(
-                obj.valuation.values.reshape(obj.shape[-2:], order='F'),
-                index=obj.odims if origin_as_datetime else obj.origin, 
-                columns=obj.ddims
-            ).unstack().rename('valuation').reset_index().rename(
-                columns={'level_0': 'development', 'level_1': 'origin'})
-
-            val_dict = dict(zip(list(zip(
-                valuation['origin'], valuation['development'])),
-                valuation['valuation']))
-            if len(out) > 0:
-                out['valuation'] = out.apply(
-                    lambda x: val_dict[(x['origin'], x['development'])], axis=1)
-            else:
-                out['valuation'] = self.valuation_date
-            col_order = list(self.columns)
-            if implicit_axis:
-                col_order = ['origin', 'development', 'valuation'] + col_order
-            else:
-                if is_val_tri:
-                    col_order = ['origin', 'valuation'] + col_order
+            if keepdims:
+                is_val_tri = self.is_val_tri
+                obj = self.val_to_dev().set_backend("sparse")
+                out = pd.DataFrame(obj.index.iloc[obj.values.coords[0]])
+                out["columns"] = obj.columns[obj.values.coords[1]]
+                missing_cols = list(set(self.columns) - set(out["columns"]))
+                if origin_as_datetime:
+                    out["origin"] = obj.odims[obj.values.coords[2]]
                 else:
-                    col_order = ['origin', 'development'] + col_order
-            for col in set(missing_cols) - self.virtual_columns.columns.keys():
-                out[col] = np.nan
-            for col in set(missing_cols).intersection(self.virtual_columns.columns.keys()):
-                out[col] = out.fillna(0).apply(self.virtual_columns.columns[col], 1)
-                out.loc[out[col] == 0, col] = np.nan
+                    out["origin"] = obj.origin[obj.values.coords[2]]
+                out["development"] = obj.ddims[obj.values.coords[3]]
+                out["values"] = obj.values.data
+                out = pd.pivot_table(
+                    out,
+                    index=obj.key_labels + ["origin", "development"],
+                    columns="columns",
+                )
+                out = out.reset_index().set_index(obj.key_labels)
+                out.columns = ["origin", "development"] + list(
+                    out.columns.get_level_values(1)[2:]
+                )
 
-            return out[col_order]
+                valuation = (
+                    pd.DataFrame(
+                        obj.valuation.values.reshape(obj.shape[-2:], order="F"),
+                        index=obj.odims if origin_as_datetime else obj.origin,
+                        columns=obj.ddims,
+                    )
+                    .unstack()
+                    .rename("valuation")
+                    .reset_index()
+                    .rename(columns={"level_0": "development", "level_1": "origin"})
+                )
 
-        # keepdims = False
+                val_dict = dict(
+                    zip(
+                        list(zip(valuation["origin"], valuation["development"])),
+                        valuation["valuation"],
+                    )
+                )
+                if len(out) > 0:
+                    out["valuation"] = out.apply(
+                        lambda x: val_dict[(x["origin"], x["development"])], axis=1
+                    )
+                else:
+                    out["valuation"] = self.valuation_date
+                col_order = list(self.columns)
+                if implicit_axis:
+                    col_order = ["origin", "development", "valuation"] + col_order
+                else:
+                    if is_val_tri:
+                        col_order = ["origin", "valuation"] + col_order
+                    else:
+                        col_order = ["origin", "development"] + col_order
+                for col in set(missing_cols) - self.virtual_columns.columns.keys():
+                    out[col] = np.nan
+                for col in set(missing_cols).intersection(
+                    self.virtual_columns.columns.keys()
+                ):
+                    out[col] = out.fillna(0).apply(self.virtual_columns.columns[col], 1)
+                    out.loc[out[col] == 0, col] = np.nan
+
+                return out[col_order]
+
+            else:  # keepdims = False
+                if self.shape[:2] == (1, 1):
+                    return self._repr_format(origin_as_datetime)
+
+                elif len(axes) in [1, 2]:
+                    tri = np.squeeze(self.set_backend("numpy").values)
+                    axes_lookup = {
+                        0: self.kdims,
+                        1: self.vdims,
+                        2: self.origin,
+                        3: self.development,
+                    }
+
+                    if axes[0] == 0:
+                        idx = self.index.set_index(self.key_labels).index
+                    else:
+                        idx = axes_lookup[axes[0]]
+
+                    if len(axes) == 1:
+                        return pd.Series(tri, index=idx).fillna(0)
+
+                    elif len(axes) == 2:
+                        return pd.DataFrame(
+                            tri, index=idx, columns=axes_lookup[axes[1]]
+                        ).fillna(0)
+
+                else:
+                    return self.to_frame(
+                        origin_as_datetime=origin_as_datetime,
+                        keepdims=True,
+                        implicit_axis=implicit_axis,
+                    )
+
+        if origin_as_datetime == False:
+            return _to_frame_helper(
+                self,
+                origin_as_datetime=origin_as_datetime,
+                keepdims=keepdims,
+                implicit_axis=implicit_axis,
+                *args,
+                **kwargs
+            )
         else:
-            if self.shape[:2] == (1, 1):
-                return self._repr_format(origin_as_datetime)
-
-            elif len(axes) in [1, 2]:
-                tri = np.squeeze(self.set_backend("numpy").values)
-                axes_lookup = {
-                    0: self.kdims,
-                    1: self.vdims,
-                    2: self.origin,
-                    3: self.development,
-                }
-
-                if axes[0] == 0:
-                    idx = self.index.set_index(self.key_labels).index
-                else:
-                    idx = axes_lookup[axes[0]]
-
-                if len(axes) == 1:
-                    return pd.Series(tri, index=idx).fillna(0)
-
-                elif len(axes) == 2:
-                    return pd.DataFrame(
-                        tri, index=idx, columns=axes_lookup[axes[1]]
-                    ).fillna(0)
-
-            else:
-                return self.to_frame(
-                    origin_as_datetime=origin_as_datetime, keepdims=True,
-                    implicit_axis=implicit_axis)
+            try:
+                return _to_frame_helper(
+                    self,
+                    origin_as_datetime=True,
+                    keepdims=keepdims,
+                    implicit_axis=implicit_axis,
+                    *args,
+                    **kwargs
+                )
+            except:
+                warning = "Unable to convert origin as datetime, the origin_as_datetime = True parameter is ignored."
+                warnings.warn(warning)
+                return _to_frame_helper(
+                    self,
+                    origin_as_datetime=False,
+                    keepdims=keepdims,
+                    implicit_axis=implicit_axis,
+                    *args,
+                    **kwargs
+                )
 
     def plot(self, *args, **kwargs):
-        """ Passthrough of pandas functionality """
+        """Passthrough of pandas functionality"""
         return self.to_frame(origin_as_datetime=False).plot(*args, **kwargs)
 
     def hvplot(self, *args, **kwargs):
-        """ Passthrough of pandas functionality """
+        """Passthrough of pandas functionality"""
         df = self.to_frame(origin_as_datetime=True)
         if type(df.index) == pd.PeriodIndex and len(df.columns) > 1:
             df.index = df.index.to_timestamp(how="s")
@@ -162,7 +228,7 @@ class TrianglePandas:
         return ax.get(axis, 0)
 
     def dropna(self):
-        """  Method that removes orgin/development vectors from edge of a
+        """Method that removes orgin/development vectors from edge of a
         triangle that are all missing values. This may come in handy for a
         new line of business that doesn't have origins/developments of an
         existing line in the same triangle.
@@ -183,7 +249,7 @@ class TrianglePandas:
         return obj
 
     def fillna(self, value=None, inplace=False):
-        """  Fill nan with 'value' by axis.
+        """Fill nan with 'value' by axis.
         Parameters
         -----------
         value: single value or array-like values, default = None
@@ -198,19 +264,17 @@ class TrianglePandas:
         Triangle
         """
         if inplace:
-            frame = (self + value*0)
+            frame = self + value * 0
             xp = self.get_array_module()
-            fill = (xp.nan_to_num(frame.values)==0)*(self*0 + value)
+            fill = (xp.nan_to_num(frame.values) == 0) * (self * 0 + value)
             self.values = (frame + fill).values
             return self
         else:
             new_obj = self.copy()
             return new_obj.fillna(value=value, inplace=True)
 
- 
-
     def drop(self, labels=None, axis=1):
-        """ Drop specified labels from rows or columns.
+        """Drop specified labels from rows or columns.
 
         Remove rows or columns by specifying label names and corresponding axis,
         or by specifying directly index or column names.
@@ -241,7 +305,7 @@ class TrianglePandas:
         return self.to_frame(origin_as_datetime=False).T
 
     def groupby(self, by, axis=0, *args, **kwargs):
-        """ Group Triangle by index values.  If the triangle is convertable to a
+        """Group Triangle by index values.  If the triangle is convertable to a
         DataFrame, then it defaults to pandas groupby functionality.
 
         Parameters
@@ -256,7 +320,7 @@ class TrianglePandas:
         return TriangleGroupBy(self, by, axis)
 
     def append(self, other):
-        """ Append rows of other to the end of caller, returning a new object.
+        """Append rows of other to the end of caller, returning a new object.
 
         Parameters
         ----------
@@ -272,7 +336,7 @@ class TrianglePandas:
         return concat((self, other), 0)
 
     def rename(self, axis, value):
-        """ Alter axes labels.
+        """Alter axes labels.
 
         Parameters
         ----------
@@ -300,7 +364,7 @@ class TrianglePandas:
         return self
 
     def astype(self, dtype, inplace=True):
-        """ Copy of the array, cast to a specified type.
+        """Copy of the array, cast to a specified type.
 
         Parameters
         ----------
@@ -346,7 +410,7 @@ class TrianglePandas:
 
 
 def add_triangle_agg_func(cls, k, v):
-    """ Aggregate Overrides in Triangle """
+    """Aggregate Overrides in Triangle"""
 
     def agg_func(self, axis=None, *args, **kwargs):
         keepdims = kwargs.get("keepdims", None)
@@ -386,7 +450,7 @@ def add_triangle_agg_func(cls, k, v):
 
 
 def add_groupby_agg_func(cls, k, v):
-    """ Aggregate Overrides in GroupBy """
+    """Aggregate Overrides in GroupBy"""
 
     def agg_func(self, *args, **kwargs):
         from chainladder.utils import concat
@@ -394,19 +458,21 @@ def add_groupby_agg_func(cls, k, v):
         xp = self.obj.get_array_module()
         obj = self.obj.copy()
         auto_sparse = kwargs.pop("auto_sparse", True)
-        if db and obj.array_backend == 'sparse':
+        if db and obj.array_backend == "sparse":
+
             def aggregate(i, obj, axis, v):
                 return getattr(
                     obj.iloc.__getitem__(tuple([slice(None)] * axis + [i])), v
                 )(axis, auto_sparse=False, keepdims=True)
+
             bag = db.from_sequence(self.groups.indices.values())
             bag = bag.map(aggregate, obj, self.axis, v)
-            values = bag.compute(scheduler='threads')
+            values = bag.compute(scheduler="threads")
         else:
             values = [
-                getattr(obj.iloc.__getitem__(tuple([slice(None)] * self.axis + [i])), v)(
-                    self.axis, auto_sparse=False, keepdims=True
-                )
+                getattr(
+                    obj.iloc.__getitem__(tuple([slice(None)] * self.axis + [i])), v
+                )(self.axis, auto_sparse=False, keepdims=True)
                 for i in self.groups.indices.values()
             ]
         obj = concat(values, axis=self.axis, ignore_index=True)
@@ -430,10 +496,11 @@ def add_groupby_agg_func(cls, k, v):
             obj.vdims = pd.DataFrame(self.groups.dtypes.index).values[:, 0]
         if self.axis == 2:
             odims = self.obj._to_datetime(
-                pd.Series(self.groups.indices.keys()).to_frame(), [0])
+                pd.Series(self.groups.indices.keys()).to_frame(), [0]
+            )
             obj.origin_grain = self.obj._get_grain(odims)
-            split = obj.origin_grain.split('-')
-            obj.origin_grain = {'A': 'Y', '2Q': 'S'}.get(split[0], split[0])
+            split = obj.origin_grain.split("-")
+            obj.origin_grain = {"A": "Y", "2Q": "S"}.get(split[0], split[0])
             obj.odims = odims.values
         obj._set_slicers()
         if auto_sparse:
@@ -444,7 +511,7 @@ def add_groupby_agg_func(cls, k, v):
 
 
 def add_df_passthru(cls, k):
-    """Pass Through of pandas functionality """
+    """Pass Through of pandas functionality"""
 
     def df_passthru(self, *args, **kwargs):
         return getattr(pd.DataFrame, k)(self.to_frame(), *args, **kwargs)
@@ -453,16 +520,31 @@ def add_df_passthru(cls, k):
 
 
 def set_method(cls, func, k):
-    """ Assigns methods to a class """
+    """Assigns methods to a class"""
     func.__doc__ = "Refer to pandas for ``{}`` functionality.".format(k)
     func.__name__ = k
     setattr(cls, func.__name__, func)
 
 
 df_passthru = (
-    ["to_clipboard", "to_csv", "to_excel", "to_json", "to_html",]
-    + ["to_dict", "unstack", "pivot", "drop_duplicates", "describe", "melt",]
-    + ["pct_chg",]
+    [
+        "to_clipboard",
+        "to_csv",
+        "to_excel",
+        "to_json",
+        "to_html",
+    ]
+    + [
+        "to_dict",
+        "unstack",
+        "pivot",
+        "drop_duplicates",
+        "describe",
+        "melt",
+    ]
+    + [
+        "pct_chg",
+    ]
 )
 for item in df_passthru:
     add_df_passthru(TrianglePandas, item)

--- a/chainladder/core/pandas.py
+++ b/chainladder/core/pandas.py
@@ -7,7 +7,6 @@ import warnings
 from sklearn.utils import deprecated
 
 from chainladder.utils.utility_functions import num_to_nan
-
 try:
     import dask.bag as db
 except:
@@ -19,8 +18,8 @@ class TriangleGroupBy:
         self.obj = obj.copy()
         self.axis = self.obj._get_axis(axis)
         self.by = by
-        if kwargs.get("groups", None):
-            self.groups = kwargs.get("groups", None)
+        if kwargs.get('groups', None):
+            self.groups = kwargs.get('groups', None)
         elif self.axis == 0:
             self.groups = obj.index.groupby(by)
         elif axis == 1:
@@ -29,29 +28,18 @@ class TriangleGroupBy:
             self.groups = pd.DataFrame(by).groupby(by)
 
     def __getitem__(self, key):
-        return TriangleGroupBy(
-            obj=self.obj.__getitem__(key),
-            by=self.by,
-            axis=self.axis,
-            groups=self.groups,
-        )
-
+        return TriangleGroupBy(obj=self.obj.__getitem__(key), by=self.by,
+                               axis=self.axis, groups=self.groups)
 
 class TrianglePandas:
-    def to_frame(
-        self,
-        origin_as_datetime=None,
-        keepdims=False,
-        implicit_axis=False,
-        *args,
-        **kwargs
-    ):
-        """Converts a triangle to a pandas.DataFrame.
+    def to_frame(self, origin_as_datetime=None, keepdims=False,
+                 implicit_axis=False, *args, **kwargs):
+        """ Converts a triangle to a pandas.DataFrame.
         Parameters
         ----------
         origin_as_datetime : bool
             Whether the origin vector should be converted from PeriodIndex
-            into a datetime dtype. Default is False, but will be defaulted to True in an upcoming version.
+            into a datetime dtype. Default is False.
         keepdims : bool
             If True, the triangle will be converted to a DataFrame with all
             dimensions intact.  The argument will force a consistent DataFrame
@@ -63,157 +51,103 @@ class TrianglePandas:
         -------
             pandas.DataFrame representation of the Triangle.
         """
+        if origin_as_datetime == None:
+            # this will be set to True as the default in an upcoming version of the package
+            warning = "In an upcoming version of the package, `origin_as_datetime` will be defaulted to `True` in to_frame(...), use `origin_as_datetime=False` to preserve current setting."
+            warnings.warn(warning)
+            origin_as_datetime = False
 
-        def _to_frame_helper(
-            self,
-            origin_as_datetime=None,
-            keepdims=False,
-            implicit_axis=False,
-            *args,
-            **kwargs
-        ):
-            if origin_as_datetime == None:
-                # this will be set to True as the default in an upcoming version of the package
-                warning = "In an upcoming version of the package, `origin_as_datetime` will be defaulted to `True` in to_frame(...), use `origin_as_datetime=False` to preserve current setting."
-                warnings.warn(warning)
-                origin_as_datetime = False
+        axes = [num for num, item in enumerate(self.shape) if item > 1]
 
-            axes = [num for num, item in enumerate(self.shape) if item > 1]
-
-            if keepdims:
-                is_val_tri = self.is_val_tri
-                obj = self.val_to_dev().set_backend("sparse")
-                out = pd.DataFrame(obj.index.iloc[obj.values.coords[0]])
-                out["columns"] = obj.columns[obj.values.coords[1]]
-                missing_cols = list(set(self.columns) - set(out["columns"]))
-                if origin_as_datetime:
-                    out["origin"] = obj.odims[obj.values.coords[2]]
-                else:
-                    out["origin"] = obj.origin[obj.values.coords[2]]
-                out["development"] = obj.ddims[obj.values.coords[3]]
-                out["values"] = obj.values.data
-                out = pd.pivot_table(
-                    out,
-                    index=obj.key_labels + ["origin", "development"],
-                    columns="columns",
-                )
-                out = out.reset_index().set_index(obj.key_labels)
-                out.columns = ["origin", "development"] + list(
-                    out.columns.get_level_values(1)[2:]
-                )
-
-                valuation = (
-                    pd.DataFrame(
-                        obj.valuation.values.reshape(obj.shape[-2:], order="F"),
-                        index=obj.odims if origin_as_datetime else obj.origin,
-                        columns=obj.ddims,
-                    )
-                    .unstack()
-                    .rename("valuation")
-                    .reset_index()
-                    .rename(columns={"level_0": "development", "level_1": "origin"})
-                )
-
-                val_dict = dict(
-                    zip(
-                        list(zip(valuation["origin"], valuation["development"])),
-                        valuation["valuation"],
-                    )
-                )
-                if len(out) > 0:
-                    out["valuation"] = out.apply(
-                        lambda x: val_dict[(x["origin"], x["development"])], axis=1
-                    )
-                else:
-                    out["valuation"] = self.valuation_date
-                col_order = list(self.columns)
-                if implicit_axis:
-                    col_order = ["origin", "development", "valuation"] + col_order
-                else:
-                    if is_val_tri:
-                        col_order = ["origin", "valuation"] + col_order
-                    else:
-                        col_order = ["origin", "development"] + col_order
-                for col in set(missing_cols) - self.virtual_columns.columns.keys():
-                    out[col] = np.nan
-                for col in set(missing_cols).intersection(
-                    self.virtual_columns.columns.keys()
-                ):
-                    out[col] = out.fillna(0).apply(self.virtual_columns.columns[col], 1)
-                    out.loc[out[col] == 0, col] = np.nan
-
-                return out[col_order]
-
-            else:  # keepdims = False
-                if self.shape[:2] == (1, 1):
-                    return self._repr_format(origin_as_datetime)
-
-                elif len(axes) in [1, 2]:
-                    tri = np.squeeze(self.set_backend("numpy").values)
-                    axes_lookup = {
-                        0: self.kdims,
-                        1: self.vdims,
-                        2: self.origin,
-                        3: self.development,
-                    }
-
-                    if axes[0] == 0:
-                        idx = self.index.set_index(self.key_labels).index
-                    else:
-                        idx = axes_lookup[axes[0]]
-
-                    if len(axes) == 1:
-                        return pd.Series(tri, index=idx).fillna(0)
-
-                    elif len(axes) == 2:
-                        return pd.DataFrame(
-                            tri, index=idx, columns=axes_lookup[axes[1]]
-                        ).fillna(0)
-
-                else:
-                    return self.to_frame(
-                        origin_as_datetime=origin_as_datetime,
-                        keepdims=True,
-                        implicit_axis=implicit_axis,
-                    )
-
-        if origin_as_datetime == False:
-            return _to_frame_helper(
-                self,
-                origin_as_datetime=origin_as_datetime,
-                keepdims=keepdims,
-                implicit_axis=implicit_axis,
-                *args,
-                **kwargs
+        if keepdims:
+            is_val_tri = self.is_val_tri
+            obj = self.val_to_dev().set_backend("sparse")
+            out = pd.DataFrame(obj.index.iloc[obj.values.coords[0]])
+            out["columns"] = obj.columns[obj.values.coords[1]]
+            missing_cols = list(set(self.columns) - set(out['columns']))
+            if origin_as_datetime:
+                out["origin"] = obj.odims[obj.values.coords[2]]
+            else:
+                out["origin"] = obj.origin[obj.values.coords[2]]
+            out["development"] = obj.ddims[obj.values.coords[3]]
+            out["values"] = obj.values.data
+            out = pd.pivot_table(
+                out, index=obj.key_labels + ["origin", "development"], columns="columns"
             )
+            out = out.reset_index().set_index(obj.key_labels)
+            out.columns = ["origin", "development"] + list(
+                out.columns.get_level_values(1)[2:]
+            )
+
+            valuation = pd.DataFrame(
+                obj.valuation.values.reshape(obj.shape[-2:], order='F'),
+                index=obj.odims if origin_as_datetime else obj.origin, 
+                columns=obj.ddims
+            ).unstack().rename('valuation').reset_index().rename(
+                columns={'level_0': 'development', 'level_1': 'origin'})
+
+            val_dict = dict(zip(list(zip(
+                valuation['origin'], valuation['development'])),
+                valuation['valuation']))
+            if len(out) > 0:
+                out['valuation'] = out.apply(
+                    lambda x: val_dict[(x['origin'], x['development'])], axis=1)
+            else:
+                out['valuation'] = self.valuation_date
+            col_order = list(self.columns)
+            if implicit_axis:
+                col_order = ['origin', 'development', 'valuation'] + col_order
+            else:
+                if is_val_tri:
+                    col_order = ['origin', 'valuation'] + col_order
+                else:
+                    col_order = ['origin', 'development'] + col_order
+            for col in set(missing_cols) - self.virtual_columns.columns.keys():
+                out[col] = np.nan
+            for col in set(missing_cols).intersection(self.virtual_columns.columns.keys()):
+                out[col] = out.fillna(0).apply(self.virtual_columns.columns[col], 1)
+                out.loc[out[col] == 0, col] = np.nan
+
+            return out[col_order]
+
+        # keepdims = False
         else:
-            try:
-                return _to_frame_helper(
-                    self,
-                    origin_as_datetime=True,
-                    keepdims=keepdims,
-                    implicit_axis=implicit_axis,
-                    *args,
-                    **kwargs
-                )
-            except:
-                warning = "Unable to convert origin as datetime, the origin_as_datetime = True parameter is ignored."
-                warnings.warn(warning)
-                return _to_frame_helper(
-                    self,
-                    origin_as_datetime=False,
-                    keepdims=keepdims,
-                    implicit_axis=implicit_axis,
-                    *args,
-                    **kwargs
-                )
+            if self.shape[:2] == (1, 1):
+                return self._repr_format(origin_as_datetime)
+
+            elif len(axes) in [1, 2]:
+                tri = np.squeeze(self.set_backend("numpy").values)
+                axes_lookup = {
+                    0: self.kdims,
+                    1: self.vdims,
+                    2: self.origin,
+                    3: self.development,
+                }
+
+                if axes[0] == 0:
+                    idx = self.index.set_index(self.key_labels).index
+                else:
+                    idx = axes_lookup[axes[0]]
+
+                if len(axes) == 1:
+                    return pd.Series(tri, index=idx).fillna(0)
+
+                elif len(axes) == 2:
+                    return pd.DataFrame(
+                        tri, index=idx, columns=axes_lookup[axes[1]]
+                    ).fillna(0)
+
+            else:
+                return self.to_frame(
+                    origin_as_datetime=origin_as_datetime, keepdims=True,
+                    implicit_axis=implicit_axis)
 
     def plot(self, *args, **kwargs):
-        """Passthrough of pandas functionality"""
+        """ Passthrough of pandas functionality """
         return self.to_frame(origin_as_datetime=False).plot(*args, **kwargs)
 
     def hvplot(self, *args, **kwargs):
-        """Passthrough of pandas functionality"""
+        """ Passthrough of pandas functionality """
         df = self.to_frame(origin_as_datetime=True)
         if type(df.index) == pd.PeriodIndex and len(df.columns) > 1:
             df.index = df.index.to_timestamp(how="s")
@@ -228,7 +162,7 @@ class TrianglePandas:
         return ax.get(axis, 0)
 
     def dropna(self):
-        """Method that removes orgin/development vectors from edge of a
+        """  Method that removes orgin/development vectors from edge of a
         triangle that are all missing values. This may come in handy for a
         new line of business that doesn't have origins/developments of an
         existing line in the same triangle.
@@ -249,7 +183,7 @@ class TrianglePandas:
         return obj
 
     def fillna(self, value=None, inplace=False):
-        """Fill nan with 'value' by axis.
+        """  Fill nan with 'value' by axis.
         Parameters
         -----------
         value: single value or array-like values, default = None
@@ -264,17 +198,19 @@ class TrianglePandas:
         Triangle
         """
         if inplace:
-            frame = self + value * 0
+            frame = (self + value*0)
             xp = self.get_array_module()
-            fill = (xp.nan_to_num(frame.values) == 0) * (self * 0 + value)
+            fill = (xp.nan_to_num(frame.values)==0)*(self*0 + value)
             self.values = (frame + fill).values
             return self
         else:
             new_obj = self.copy()
             return new_obj.fillna(value=value, inplace=True)
 
+ 
+
     def drop(self, labels=None, axis=1):
-        """Drop specified labels from rows or columns.
+        """ Drop specified labels from rows or columns.
 
         Remove rows or columns by specifying label names and corresponding axis,
         or by specifying directly index or column names.
@@ -305,7 +241,7 @@ class TrianglePandas:
         return self.to_frame(origin_as_datetime=False).T
 
     def groupby(self, by, axis=0, *args, **kwargs):
-        """Group Triangle by index values.  If the triangle is convertable to a
+        """ Group Triangle by index values.  If the triangle is convertable to a
         DataFrame, then it defaults to pandas groupby functionality.
 
         Parameters
@@ -320,7 +256,7 @@ class TrianglePandas:
         return TriangleGroupBy(self, by, axis)
 
     def append(self, other):
-        """Append rows of other to the end of caller, returning a new object.
+        """ Append rows of other to the end of caller, returning a new object.
 
         Parameters
         ----------
@@ -336,7 +272,7 @@ class TrianglePandas:
         return concat((self, other), 0)
 
     def rename(self, axis, value):
-        """Alter axes labels.
+        """ Alter axes labels.
 
         Parameters
         ----------
@@ -364,7 +300,7 @@ class TrianglePandas:
         return self
 
     def astype(self, dtype, inplace=True):
-        """Copy of the array, cast to a specified type.
+        """ Copy of the array, cast to a specified type.
 
         Parameters
         ----------
@@ -410,7 +346,7 @@ class TrianglePandas:
 
 
 def add_triangle_agg_func(cls, k, v):
-    """Aggregate Overrides in Triangle"""
+    """ Aggregate Overrides in Triangle """
 
     def agg_func(self, axis=None, *args, **kwargs):
         keepdims = kwargs.get("keepdims", None)
@@ -450,7 +386,7 @@ def add_triangle_agg_func(cls, k, v):
 
 
 def add_groupby_agg_func(cls, k, v):
-    """Aggregate Overrides in GroupBy"""
+    """ Aggregate Overrides in GroupBy """
 
     def agg_func(self, *args, **kwargs):
         from chainladder.utils import concat
@@ -458,21 +394,19 @@ def add_groupby_agg_func(cls, k, v):
         xp = self.obj.get_array_module()
         obj = self.obj.copy()
         auto_sparse = kwargs.pop("auto_sparse", True)
-        if db and obj.array_backend == "sparse":
-
+        if db and obj.array_backend == 'sparse':
             def aggregate(i, obj, axis, v):
                 return getattr(
                     obj.iloc.__getitem__(tuple([slice(None)] * axis + [i])), v
                 )(axis, auto_sparse=False, keepdims=True)
-
             bag = db.from_sequence(self.groups.indices.values())
             bag = bag.map(aggregate, obj, self.axis, v)
-            values = bag.compute(scheduler="threads")
+            values = bag.compute(scheduler='threads')
         else:
             values = [
-                getattr(
-                    obj.iloc.__getitem__(tuple([slice(None)] * self.axis + [i])), v
-                )(self.axis, auto_sparse=False, keepdims=True)
+                getattr(obj.iloc.__getitem__(tuple([slice(None)] * self.axis + [i])), v)(
+                    self.axis, auto_sparse=False, keepdims=True
+                )
                 for i in self.groups.indices.values()
             ]
         obj = concat(values, axis=self.axis, ignore_index=True)
@@ -496,11 +430,10 @@ def add_groupby_agg_func(cls, k, v):
             obj.vdims = pd.DataFrame(self.groups.dtypes.index).values[:, 0]
         if self.axis == 2:
             odims = self.obj._to_datetime(
-                pd.Series(self.groups.indices.keys()).to_frame(), [0]
-            )
+                pd.Series(self.groups.indices.keys()).to_frame(), [0])
             obj.origin_grain = self.obj._get_grain(odims)
-            split = obj.origin_grain.split("-")
-            obj.origin_grain = {"A": "Y", "2Q": "S"}.get(split[0], split[0])
+            split = obj.origin_grain.split('-')
+            obj.origin_grain = {'A': 'Y', '2Q': 'S'}.get(split[0], split[0])
             obj.odims = odims.values
         obj._set_slicers()
         if auto_sparse:
@@ -511,7 +444,7 @@ def add_groupby_agg_func(cls, k, v):
 
 
 def add_df_passthru(cls, k):
-    """Pass Through of pandas functionality"""
+    """Pass Through of pandas functionality """
 
     def df_passthru(self, *args, **kwargs):
         return getattr(pd.DataFrame, k)(self.to_frame(), *args, **kwargs)
@@ -520,31 +453,16 @@ def add_df_passthru(cls, k):
 
 
 def set_method(cls, func, k):
-    """Assigns methods to a class"""
+    """ Assigns methods to a class """
     func.__doc__ = "Refer to pandas for ``{}`` functionality.".format(k)
     func.__name__ = k
     setattr(cls, func.__name__, func)
 
 
 df_passthru = (
-    [
-        "to_clipboard",
-        "to_csv",
-        "to_excel",
-        "to_json",
-        "to_html",
-    ]
-    + [
-        "to_dict",
-        "unstack",
-        "pivot",
-        "drop_duplicates",
-        "describe",
-        "melt",
-    ]
-    + [
-        "pct_chg",
-    ]
+    ["to_clipboard", "to_csv", "to_excel", "to_json", "to_html",]
+    + ["to_dict", "unstack", "pivot", "drop_duplicates", "describe", "melt",]
+    + ["pct_chg",]
 )
 for item in df_passthru:
     add_df_passthru(TrianglePandas, item)

--- a/chainladder/core/tests/test_display.py
+++ b/chainladder/core/tests/test_display.py
@@ -1,6 +1,20 @@
 import pytest
+import chainladder as cl
 
 
 def test_heatmap_render(raa):
     """ The heatmap method should render correctly given the sample."""
     return raa.heatmap()
+
+
+def test_to_frame(raa):
+    try:
+        cl.Chainladder().fit(raa).cdf_.to_frame()
+        cl.Chainladder().fit(raa).cdf_.to_frame(origin_as_datetime=False)
+        cl.Chainladder().fit(raa).cdf_.to_frame(origin_as_datetime=True)
+        cl.Chainladder().fit(raa).ultimate_.to_frame()
+        cl.Chainladder().fit(raa).ultimate_.to_frame(origin_as_datetime=False)
+        cl.Chainladder().fit(raa).ultimate_.to_frame(origin_as_datetime=True)
+        True == False
+    except:
+        assert False

--- a/chainladder/core/tests/test_display.py
+++ b/chainladder/core/tests/test_display.py
@@ -15,6 +15,6 @@ def test_to_frame(raa):
         cl.Chainladder().fit(raa).ultimate_.to_frame()
         cl.Chainladder().fit(raa).ultimate_.to_frame(origin_as_datetime=False)
         cl.Chainladder().fit(raa).ultimate_.to_frame(origin_as_datetime=True)
-        True == False
+
     except:
         assert False

--- a/chainladder/development/outstanding.py
+++ b/chainladder/development/outstanding.py
@@ -101,7 +101,7 @@ class CaseOutstanding(DevelopmentBase):
         return self
 
     def _set_ldf(self, X):
-        # print("=== in _set_ldf ===")
+        print("=== in _set_ldf ===")
         paid_tri = X[self.paid_to_incurred[0]]
         incurred_tri = X[self.paid_to_incurred[1]]
         case_tri = incurred_tri - paid_tri
@@ -177,9 +177,9 @@ class CaseOutstanding(DevelopmentBase):
 
         self.case = case_tri
         self.paid = paid
-        # print("=== self.case ===\n", self.case)
-        # print("=== self.paid ===\n", self.paid)
-        # print("=== set LDF return ===\n", dev.cum_to_incr())
+        print("=== self.case ===\n", self.case)
+        print("=== self.paid ===\n", self.paid)
+        print("=== set LDF return ===\n", dev.cum_to_incr())
         return dev.cum_to_incr()
 
     @property

--- a/chainladder/utils/tests/test_utilities.py
+++ b/chainladder/utils/tests/test_utilities.py
@@ -58,7 +58,7 @@ def test_json_subtri(raa):
         cl.Chainladder().fit_predict(raa).to_json()
     ).full_triangle_
     b = cl.Chainladder().fit_predict(raa).full_triangle_
-    abs(a - b).max().max() < 1e-4
+    assert abs(a - b).max().max() < 1e-4
 
 
 def test_json_df():

--- a/chainladder/utils/utility_functions.py
+++ b/chainladder/utils/utility_functions.py
@@ -15,16 +15,16 @@ from typing import Iterable, Union
 
 
 def load_sample(key: str, *args, **kwargs):
-    """Function to load datasets included in the chainladder package.
+    """ Function to load datasets included in the chainladder package.
 
-    Parameters
-    ----------
-    key: str
-        The name of the dataset, e.g. RAA, ABC, UKMotor, GenIns, etc.
+        Parameters
+        ----------
+        key: str
+            The name of the dataset, e.g. RAA, ABC, UKMotor, GenIns, etc.
 
-    Returns
-    --------
-        pandas.DataFrame of the loaded dataset.
+        Returns
+        --------
+            pandas.DataFrame of the loaded dataset.
 
     """
     from chainladder import Triangle
@@ -154,7 +154,8 @@ def read_json(json_str, array_backend=None):
 def parallelogram_olf(
     values, date, start_date=None, end_date=None, grain="M", vertical_line=False
 ):
-    """Parallelogram approach to on-leveling."""
+    """ Parallelogram approach to on-leveling.
+    """
     date = pd.to_datetime(date)
     if not start_date:
         start_date = "{}-01-01".format(date.min().year)
@@ -194,7 +195,7 @@ def concat(
     ignore_index: bool = False,
     sort: bool = False,
 ):
-    """Concatenate Triangle objects along a particular axis.
+    """ Concatenate Triangle objects along a particular axis.
 
     Parameters
     ----------
@@ -269,7 +270,7 @@ def concat(
 
 
 def num_to_value(arr, value):
-    """Function that turns all zeros to nan values in an array"""
+    """ Function that turns all zeros to nan values in an array """
     backend = arr.__class__.__module__.split(".")[0]
     if backend == "sparse":
         if arr.fill_value == 0 or sp.isnan(arr.fill_value):
@@ -286,7 +287,7 @@ def num_to_value(arr, value):
 
 
 def num_to_nan(arr):
-    """Function that turns all zeros to nan values in an array"""
+    """ Function that turns all zeros to nan values in an array """
     from chainladder import Triangle
 
     xp = Triangle.get_array_module(None, arr=arr)
@@ -302,7 +303,7 @@ def maximum(x1, x2):
 
 
 class PatsyFormula(BaseEstimator, TransformerMixin):
-    """A sklearn-style Transformer for patsy formulas.
+    """ A sklearn-style Transformer for patsy formulas.
 
     PatsyFormula allows for R-style formula preprocessing of the ``design_matrix``
     of a machine learning algorithm. It's particularly useful with the `DevelopmentML`
@@ -341,7 +342,7 @@ class PatsyFormula(BaseEstimator, TransformerMixin):
 
 
 def model_diagnostics(model, name=None, groupby=None):
-    """A helper function that summarizes various vectors of an
+    """ A helper function that summarizes various vectors of an
     IBNR model as columns of a Triangle
 
     Parameters
@@ -388,11 +389,8 @@ def model_diagnostics(model, name=None, groupby=None):
             out["Month Incremental"] = obj.X_[col][val == obj.X_.valuation_date].sum(
                 "development"
             )
-        if (
-            obj.X_.development_grain in ["M", "Q"]
-            and pd.Period(out.valuation_date, freq="Q").to_timestamp(how="s")
-            > val.min()
-        ):
+        if (obj.X_.development_grain in ["M", "Q"] and 
+            pd.Period(out.valuation_date, freq="Q").to_timestamp(how="s") > val.min()):
             out["Quarter Incremental"] = (
                 obj.X_
                 - obj.X_[
@@ -403,8 +401,8 @@ def model_diagnostics(model, name=None, groupby=None):
                 ]
             ).sum("development")[col]
         else:
-            out["Quarter Incremental"] = 0
-        if pd.Period(out.valuation_date, freq="Y").to_timestamp(how="s") > val.min():
+            out["Quarter Incremental"]  = 0
+        if (pd.Period(out.valuation_date, freq="Y").to_timestamp(how="s") > val.min()):
             out["Year Incremental"] = (
                 obj.X_ - obj.X_[val < str(obj.X_.valuation_date.year)]
             ).sum("development")[col]


### PR DESCRIPTION
Using try/except to check if origin_as_datetime can be converted

I am not sure if I am preserving the *args or **kargs correctly. Can you take a look?

The following test code works:
```python
import chainladder as cl
raa = cl.load_sample("raa")
cl.Chainladder().fit(raa).ultimate_.to_frame(origin_as_datetime=False)
cl.Chainladder().fit(raa).ultimate_.to_frame(origin_as_datetime=True) # no warning thrown
cl.Chainladder().fit(raa).cdf_.to_frame(origin_as_datetime=False)
cl.Chainladder().fit(raa).cdf_.to_frame(origin_as_datetime=True) # warning thrown
```