### PR TITLE
Fixing link_ratio

### DIFF
--- a/chainladder/core/triangle.py
+++ b/chainladder/core/triangle.py
@@ -396,7 +396,7 @@ class Triangle(TriangleBase):
             if not obj.is_full:
                 obj = obj[obj.valuation < obj.valuation_date]
             if hasattr(obj, "w_"):
-                w_ = obj.w_[..., 0:1, : len(obj.odims), :]
+                w_ = obj.w_[..., : len(obj.odims), :]
                 obj = obj * w_ if obj.shape == w_.shape else obj
             obj.is_pattern = True
             obj.is_cumulative = False


### PR DESCRIPTION
removing a redundant slicer in link_ratio that causes w_ to be ignored whenever there are more than 1 triangle columns