### PR TITLE
Store origin label as an attribute

### DIFF
--- a/chainladder/core/display.py
+++ b/chainladder/core/display.py
@@ -29,7 +29,7 @@ class TriangleDisplay:
                 self.olab,
                 list(self.vdims),
             ],
-            index=["Valuation:", "Grain:", "Shape:", "Index:", "Origin: ", "Columns:"],
+            index=["Valuation:", "Grain:", "Shape:", "Index:", "Origin:", "Columns:"],
             name="Triangle Summary",
         ).to_frame()
 

--- a/chainladder/core/display.py
+++ b/chainladder/core/display.py
@@ -26,9 +26,10 @@ class TriangleDisplay:
                 "O" + self.origin_grain + "D" + self.development_grain,
                 self.shape,
                 self.key_labels,
+                self.olab,
                 list(self.vdims),
             ],
-            index=["Valuation:", "Grain:", "Shape:", "Index:", "Columns:"],
+            index=["Valuation:", "Grain:", "Shape:", "Index:", "Origin: ", "Columns:"],
             name="Triangle Summary",
         ).to_frame()
 

--- a/chainladder/core/tests/test_triangle.py
+++ b/chainladder/core/tests/test_triangle.py
@@ -757,3 +757,9 @@ def test_halfyear_development():
             )
         )
     ) == cl.Triangle
+
+def test_olab(raa):
+    """
+    The string passed to the origin argument should be assigned to the .olab (origin label) attribute.
+    """
+    assert raa.olab == ['origin']

--- a/chainladder/core/triangle.py
+++ b/chainladder/core/triangle.py
@@ -176,6 +176,7 @@ class Triangle(TriangleBase):
         self.vdims = np.array(columns)
         self.odims, orig_idx = self._set_odims(data_agg, date_axes)
         self.ddims, dev_idx = self._set_ddims(data_agg, date_axes)
+        self.olab = origin
 
         # Set remaining triangle properties
         val_date = data_agg["__development__"].max()


### PR DESCRIPTION
Related to #416. I propose we keep the origin label metadata, this way the user can distinguish between different origin bases, such as accident year vs policy year, etc.

```
cl.load_sample('xyz')
                                       Triangle Summary
Valuation:                                      2008-12
Grain:                                             OYDY
Shape:                                   (1, 5, 11, 11)
Index:                                          [Total]
Origin:                                  [AccidentYear]
Columns:    [Incurred, Paid, Reported, Closed, Premium]
```