### PR TITLE
make less None in constructor

### DIFF
--- a/chainladder/core/triangle.py
+++ b/chainladder/core/triangle.py
@@ -798,7 +798,7 @@ class Triangle(TriangleBase):
         return self
 
     def copy(self):
-        X = Triangle()
+        X = object.__new__(self.__class__)
         X.__dict__.update(vars(self))
         X._set_slicers()
         X.values = X.values.copy()


### PR DESCRIPTION
This is to enable future work on type annotations, starting small to receive feedback. We need to change the `copy` method because it relied on a constructor with no args like `Triangle()`, I am unsure if this is intended to be a supported usage pattern and it makes the constructor less clear to users.

Found a similar implementation of copy using github code search - https://github.com/getsentry/sentry/blob/da74f6c805a5e7f3e94a0eaf5df7830c74f4a1c8/src/sentry/utils/canonical.py#L117

Overall curious if type annotations for user facing methods is seen as desirable or worthwhile

