### PR TITLE
#514

### DIFF
--- a/chainladder/core/triangle.py
+++ b/chainladder/core/triangle.py
@@ -690,7 +690,7 @@ class Triangle(TriangleBase):
         obj = self.dev_to_val()
 
         if ograin_new != ograin_old:
-            freq = {"Y": "Y", "S": "2Q"}.get(ograin_new, ograin_new)
+            freq = {"Y": "YE", "S": "2Q"}.get(ograin_new, ograin_new)
 
             if trailing or (obj.origin.freqstr[-3:] != "DEC" and ograin_old != "M"):
                 origin_period_end = self.origin[-1].strftime("%b").upper()

--- a/chainladder/core/triangle.py
+++ b/chainladder/core/triangle.py
@@ -690,7 +690,7 @@ class Triangle(TriangleBase):
         obj = self.dev_to_val()
 
         if ograin_new != ograin_old:
-            freq = {"Y": "YE", "S": "2Q"}.get(ograin_new, ograin_new)
+            freq = {"Y": "Y", "S": "2Q"}.get(ograin_new, ograin_new)
 
             if trailing or (obj.origin.freqstr[-3:] != "DEC" and ograin_old != "M"):
                 origin_period_end = self.origin[-1].strftime("%b").upper()
@@ -698,7 +698,7 @@ class Triangle(TriangleBase):
                 origin_period_end = "DEC"
 
             indices = (
-                pd.Series(range(len(self.origin)), index=self.origin.to_timestamp())
+                pd.Series(range(len(self.origin)), index=self.origin)
                 .resample("-".join([freq, origin_period_end]))
                 .indices
             )
@@ -708,6 +708,7 @@ class Triangle(TriangleBase):
             ).values
 
             obj = obj.groupby(groups, axis=2).sum()
+
             obj.origin_close = origin_period_end
             d_start = pd.Period(
                 obj.valuation[0],

--- a/chainladder/development/base.py
+++ b/chainladder/development/base.py
@@ -356,7 +356,7 @@ class DevelopmentBase(BaseEstimator, TransformerMixin, EstimatorIO, Common):
             param_array = param_array.astype(type(default_value))
         return param_array.to_numpy()
 
-    def _set_weight_func(self, factor):
+    def _set_weight_func(self, factor, secondary_rank=None):
         w = (~np.isnan(factor.values)).astype(float)
         w = w * self._assign_n_periods_weight_func(factor)
 

--- a/chainladder/development/base.py
+++ b/chainladder/development/base.py
@@ -356,9 +356,10 @@ class DevelopmentBase(BaseEstimator, TransformerMixin, EstimatorIO, Common):
             param_array = param_array.astype(type(default_value))
         return param_array.to_numpy()
 
-    def _set_weight_func(self, factor, secondary_rank=None):
+    def _set_weight_func(self, factor):
         w = (~np.isnan(factor.values)).astype(float)
         w = w * self._assign_n_periods_weight_func(factor)
+
         if self.drop is not None:
             w = w * self._drop_func(factor)
 
@@ -369,9 +370,11 @@ class DevelopmentBase(BaseEstimator, TransformerMixin, EstimatorIO, Common):
             w = w * self._drop_x_func(factor)
 
         if (self.drop_high is not None) | (self.drop_low is not None):
-            w = w * self._drop_n_func(factor * num_to_nan(w), secondary_rank)
+            w = w * self._drop_n_func(factor * num_to_nan(w))
+
         w_tri = factor.copy()
         w_tri.values = num_to_nan(w)
+
         return w_tri
 
     def _assign_n_periods_weight_func(self, factor):
@@ -517,18 +520,11 @@ class DevelopmentBase(BaseEstimator, TransformerMixin, EstimatorIO, Common):
         return w.transpose((0, 1, 3, 2)).astype(float)
 
     # for drop_high and drop_low
-    def _drop_n_func(self, factor, secondary_rank=None):
+    def _drop_n_func(self, factor):
         # getting dimensions of factor for various manipulation
         factor_val = factor.values.copy()
-        # secondary rank is the optional triangle that breaks ties in factor
-        # the original use case is for dropping the link ratio of 1 with the lowest loss value
-        # (pass in a reverse rank of loss to drop link of ratio of 1 with the highest loss value)
-        # leaving to user to ensure that secondary rank is the same dimensions as factor
-        # also leaving to user to pick whether to trim head or tail
-        if secondary_rank is None:
-            sec_rank_val = factor_val.copy()
-        else:
-            sec_rank_val = secondary_rank.values.copy()
+        sec_rank_val = factor_val.copy()
+
         factor_len = factor_val.shape[3]
         indices = factor_val.shape[0]
         columns = factor_val.shape[1]
@@ -538,16 +534,17 @@ class DevelopmentBase(BaseEstimator, TransformerMixin, EstimatorIO, Common):
         drop_high_array[:, :, :] = self._param_array_helper(
             factor_len, self.drop_high, 0
         )[None, None]
+
         drop_low_array = np.zeros((indices, columns, factor_len))
         drop_low_array[:, :, :] = self._param_array_helper(
             factor_len, self.drop_low, 0
         )[None, None]
+
         preserve_array = np.zeros((indices, columns, factor_len))
         preserve_array[:, :, :] = self._param_array_helper(
             factor_len, self.preserve, self.preserve
         )[None, None]
 
-        # ranking factors by itself and secondary rank
         factor_ranks = np.lexsort((sec_rank_val, factor_val), axis=2).argsort(axis=2)
 
         # setting up starting weights

--- a/chainladder/development/development.py
+++ b/chainladder/development/development.py
@@ -119,27 +119,36 @@ class Development(DevelopmentBase):
         from chainladder.utils.utility_functions import num_to_nan
 
         # Triangle must be cumulative and in "development" mode
+
         obj = self._set_fit_groups(X).incr_to_cum().val_to_dev().copy()
         xp = obj.get_array_module()
         if self.fillna:
             tri_array = num_to_nan((obj + self.fillna).values)
         else:
             tri_array = num_to_nan(obj.values.copy())
-        average_ = self._validate_assumption(X, self.average, axis=3)[... , :X.shape[3]-1]
+        average_ = self._validate_assumption(X, self.average, axis=3)[
+            ..., : X.shape[3] - 1
+        ]
         self.average_ = average_.flatten()
-        n_periods_ = self._validate_assumption(X, self.n_periods, axis=3)[... , :X.shape[3]-1]
+        n_periods_ = self._validate_assumption(X, self.n_periods, axis=3)[
+            ..., : X.shape[3] - 1
+        ]
         x, y = tri_array[..., :-1], tri_array[..., 1:]
         exponent = xp.array(
-            [{"regression": 0, "volume": 1, "simple": 2}[x] 
-             for x in average_[0, 0, 0]]
+            [{"regression": 0, "volume": 1, "simple": 2}[x] for x in average_[0, 0, 0]]
         )
         exponent = xp.nan_to_num(exponent * (y * 0 + 1))
         link_ratio = y / x
 
         if hasattr(X, "w_v2_"):
-            self.w_v2_ = self._set_weight_func(obj.age_to_age * X.w_v2_,obj.iloc[...,:-1,:-1])
+            self.w_v2_ = self._set_weight_func(
+                factor=obj.age_to_age * X.w_v2_,
+            )
         else:
-            self.w_v2_ = self._set_weight_func(obj.age_to_age,obj.iloc[...,:-1,:-1])
+            self.w_v2_ = self._set_weight_func(
+                factor=obj.age_to_age,
+            )
+
         self.w_ = self._assign_n_periods_weight(
             obj, n_periods_
         ) * self._drop_adjustment(obj, link_ratio)
@@ -164,7 +173,7 @@ class Development(DevelopmentBase):
         self.sigma_ = self._param_property(obj, params, 1)
         self.std_err_ = self._param_property(obj, params, 2)
         resid = -obj.iloc[..., :-1] * self.ldf_.values + obj.iloc[..., 1:].values
-        std = xp.sqrt((1 / num_to_nan(w)) * (self.sigma_ ** 2).values)
+        std = xp.sqrt((1 / num_to_nan(w)) * (self.sigma_**2).values)
         resid = resid / num_to_nan(std)
         self.std_residuals_ = resid[resid.valuation < obj.valuation_date]
         return self
@@ -184,7 +193,16 @@ class Development(DevelopmentBase):
         """
         X_new = X.copy()
         X_new.group_index = self._set_transform_groups(X_new)
-        triangles = ["std_err_", "ldf_", "sigma_","std_residuals_","average_", "w_", "sigma_interpolation","w_v2_"]
+        triangles = [
+            "std_err_",
+            "ldf_",
+            "sigma_",
+            "std_residuals_",
+            "average_",
+            "w_",
+            "sigma_interpolation",
+            "w_v2_",
+        ]
         for item in triangles:
             setattr(X_new, item, getattr(self, item))
         X_new._set_slicers()

--- a/chainladder/development/tests/test_development.py
+++ b/chainladder/development/tests/test_development.py
@@ -274,6 +274,10 @@ def test_new_drop_8():
     except:
         assert False
 
+
+def test_new_drop_9():
+    tri = cl.load_sample("prism")["Paid"].sum().grain("OYDQ")
+
     assert (
         cl.Development(drop_high=True).fit(tri).cdf_.to_frame().fillna(0).values
         == cl.Development(drop_high=1).fit(tri).cdf_.to_frame().fillna(0).values

--- a/chainladder/development/tests/test_development.py
+++ b/chainladder/development/tests/test_development.py
@@ -266,6 +266,24 @@ def test_new_drop_7(clrd):
     )
 
 
+def test_new_drop_8():
+    tri = cl.load_sample("prism")["Paid"].sum().grain("OYDQ")
+
+    try:
+        cl.Development(drop_high=False).fit_transform(tri)
+    except:
+        assert False
+
+    assert (
+        cl.Development(drop_high=True).fit(tri).cdf_.to_frame().fillna(0).values
+        == cl.Development(drop_high=1).fit(tri).cdf_.to_frame().fillna(0).values
+    ).all()
+    assert (
+        cl.Development(drop_high=True).fit(tri).cdf_.to_frame().fillna(0).values
+        >= cl.Development(drop_high=2).fit(tri).cdf_.to_frame().fillna(0).values
+    ).all()
+
+
 def compare_new_drop(dev, tri):
     assert np.array_equal(
         dev._set_weight_func(tri.age_to_age, tri.age_to_age).values,

--- a/chainladder/development/tests/test_development.py
+++ b/chainladder/development/tests/test_development.py
@@ -119,6 +119,13 @@ def test_drophighlow():
     )
     assert np.all(lhs == rhs)
 
+    tri = cl.load_sample("prism")["Paid"].sum().grain("OYDQ")
+    no_drop = cl.Development().fit_transform(tri).cdf_.to_frame().values
+    drop_high = cl.Development(drop_high=True).fit_transform(tri).cdf_.to_frame().values
+    drop_low = cl.Development(drop_low=True).fit_transform(tri).cdf_.to_frame().values
+    assert (drop_low >= no_drop).all()
+    assert (no_drop >= drop_high).all()
+
 
 def test_dropabovebelow():
     raa = cl.load_sample("raa")
@@ -173,91 +180,129 @@ def test_assymetric_development(atol):
     dev2 = cl.Development(n_periods=1, average="regression").fit(quarterly)
     assert xp.allclose(dev.ldf_.values, dev2.ldf_.values, atol=atol)
 
+
 def test_hilo_multiple_indices(clrd):
-    tri = clrd.groupby('LOB')['CumPaidLoss'].sum()
+    tri = clrd.groupby("LOB")["CumPaidLoss"].sum()
     assert (
-        cl.Development(n_periods=5).fit(tri).ldf_.loc['wkcomp'] == 
-        cl.Development(n_periods=5).fit(tri.loc['wkcomp']).ldf_)
+        cl.Development(n_periods=5).fit(tri).ldf_.loc["wkcomp"]
+        == cl.Development(n_periods=5).fit(tri.loc["wkcomp"]).ldf_
+    )
     assert (
-        cl.Development(drop_low=2).fit(tri).ldf_.loc['wkcomp'] == 
-        cl.Development(drop_low=2).fit(tri.loc['wkcomp']).ldf_)
+        cl.Development(drop_low=2).fit(tri).ldf_.loc["wkcomp"]
+        == cl.Development(drop_low=2).fit(tri.loc["wkcomp"]).ldf_
+    )
+
 
 def test_new_drop_1(clrd):
-    clrd = clrd.groupby('LOB')[["IncurLoss","CumPaidLoss"]].sum()
-    #n_periods
-    return compare_new_drop(cl.Development(n_periods = 4).fit(clrd),clrd)
+    clrd = clrd.groupby("LOB")[["IncurLoss", "CumPaidLoss"]].sum()
+    # n_periods
+    return compare_new_drop(cl.Development(n_periods=4).fit(clrd), clrd)
+
 
 def test_new_drop_2(clrd):
-    clrd = clrd.groupby('LOB')[["IncurLoss","CumPaidLoss"]].sum()
-    #single drop and drop_valuation
-    return compare_new_drop(cl.Development(drop = ("1992",12),drop_valuation = 1993).fit(clrd),clrd)
+    clrd = clrd.groupby("LOB")[["IncurLoss", "CumPaidLoss"]].sum()
+    # single drop and drop_valuation
+    return compare_new_drop(
+        cl.Development(drop=("1992", 12), drop_valuation=1993).fit(clrd), clrd
+    )
+
 
 def test_new_drop_3(clrd):
-    clrd = clrd.groupby('LOB')[["IncurLoss","CumPaidLoss"]].sum()
-    #multiple drop and drop_valuation
-    return compare_new_drop(cl.Development(drop = [("1992",12),("1996",24)],drop_valuation = [1993,1995]).fit(clrd),clrd)
+    clrd = clrd.groupby("LOB")[["IncurLoss", "CumPaidLoss"]].sum()
+    # multiple drop and drop_valuation
+    return compare_new_drop(
+        cl.Development(
+            drop=[("1992", 12), ("1996", 24)], drop_valuation=[1993, 1995]
+        ).fit(clrd),
+        clrd,
+    )
+
 
 def test_new_drop_4(clrd):
-    clrd = clrd.groupby('LOB')[["IncurLoss","CumPaidLoss"]].sum()
-    #drop_hi/low without preserve
-    return compare_new_drop(cl.Development(drop_high = 1, drop_low = 1).fit(clrd),clrd)
+    clrd = clrd.groupby("LOB")[["IncurLoss", "CumPaidLoss"]].sum()
+    # drop_hi/low without preserve
+    return compare_new_drop(cl.Development(drop_high=1, drop_low=1).fit(clrd), clrd)
+
 
 def test_new_drop_5(clrd):
-    clrd = clrd.groupby('LOB')[["IncurLoss","CumPaidLoss"]].sum()
-    #drop_hi/low without preserve
-    return compare_new_drop(cl.Development(drop_high = 1, drop_low = 1,preserve = 3).fit(clrd),clrd) 
+    clrd = clrd.groupby("LOB")[["IncurLoss", "CumPaidLoss"]].sum()
+    # drop_hi/low without preserve
+    return compare_new_drop(
+        cl.Development(drop_high=1, drop_low=1, preserve=3).fit(clrd), clrd
+    )
+
 
 def test_new_drop_5a(clrd):
-    clrd = clrd.groupby('LOB')[["IncurLoss","CumPaidLoss"]].sum()
-    #drop_hi/low without preserve
+    clrd = clrd.groupby("LOB")[["IncurLoss", "CumPaidLoss"]].sum()
+    # drop_hi/low without preserve
     assert np.array_equal(
-        cl.Development(drop_high = 1, drop_low = 1,preserve = 3)._set_weight_func(clrd.age_to_age, clrd.age_to_age).values,
-        cl.Development(drop_high = True, drop_low = [True, True, True, True, True, True, True, True, True] ,preserve = 3)._set_weight_func(clrd.age_to_age).values,
-        True
+        cl.Development(drop_high=1, drop_low=1, preserve=3)
+        ._set_weight_func(clrd.age_to_age, clrd.age_to_age)
+        .values,
+        cl.Development(
+            drop_high=True,
+            drop_low=[True, True, True, True, True, True, True, True, True],
+            preserve=3,
+        )
+        ._set_weight_func(clrd.age_to_age)
+        .values,
+        True,
     )
+
 
 def test_new_drop_6(clrd):
-    clrd = clrd.groupby('LOB')[["IncurLoss","CumPaidLoss"]].sum()
-    #drop_above/below without preserve
-    return compare_new_drop(cl.Development(drop_above = 1.01,drop_below = 0.95).fit(clrd),clrd) 
+    clrd = clrd.groupby("LOB")[["IncurLoss", "CumPaidLoss"]].sum()
+    # drop_above/below without preserve
+    return compare_new_drop(
+        cl.Development(drop_above=1.01, drop_below=0.95).fit(clrd), clrd
+    )
+
 
 def test_new_drop_7(clrd):
-    clrd = clrd.groupby('LOB')[["IncurLoss","CumPaidLoss"]].sum()
-    #drop_above/below with preserve
-    return compare_new_drop(cl.Development(drop_above = 1.01,drop_below = 0.95,preserve=3).fit(clrd),clrd)
-
-def compare_new_drop(dev,tri):
-    assert (
-        np.array_equal(
-            dev._set_weight_func(tri.age_to_age, tri.age_to_age).values, 
-            dev.transform(tri).age_to_age.values*0+1,
-            True
-        )
+    clrd = clrd.groupby("LOB")[["IncurLoss", "CumPaidLoss"]].sum()
+    # drop_above/below with preserve
+    return compare_new_drop(
+        cl.Development(drop_above=1.01, drop_below=0.95, preserve=3).fit(clrd), clrd
     )
+
+
+def compare_new_drop(dev, tri):
+    assert np.array_equal(
+        dev._set_weight_func(tri.age_to_age, tri.age_to_age).values,
+        dev.transform(tri).age_to_age.values * 0 + 1,
+        True,
+    )
+
 
 def test_4d_drop(clrd):
-    clrd = clrd.groupby("LOB").sum()[["CumPaidLoss","IncurLoss"]]
+    clrd = clrd.groupby("LOB").sum()[["CumPaidLoss", "IncurLoss"]]
     assert (
-        cl.Development(n_periods = 4).fit_transform(clrd.iloc[0,0]).link_ratio == 
-        cl.Development(n_periods = 4).fit_transform(clrd).link_ratio.iloc[0,0])
+        cl.Development(n_periods=4).fit_transform(clrd.iloc[0, 0]).link_ratio
+        == cl.Development(n_periods=4).fit_transform(clrd).link_ratio.iloc[0, 0]
+    )
+
 
 def test_pipeline(clrd):
-    clrd = clrd.groupby('LOB')[["IncurLoss","CumPaidLoss"]].sum()
+    clrd = clrd.groupby("LOB")[["IncurLoss", "CumPaidLoss"]].sum()
     dev1 = cl.Development(
-        n_periods = 7,
-        drop_valuation = 1995,
-        drop = ("1992",12),
-        drop_above = 1.05,
-        drop_below = .95,
-        drop_high = 1,
-        drop_low = 1
+        n_periods=7,
+        drop_valuation=1995,
+        drop=("1992", 12),
+        drop_above=1.05,
+        drop_below=0.95,
+        drop_high=1,
+        drop_low=1,
     ).fit(clrd)
-    pipe = cl.Pipeline(steps=[
-        ('n_periods', cl.Development(n_periods = 7)),
-        ('drop_valuation', cl.Development(drop_valuation = 1995)),
-        ('drop', cl.Development(drop = ("1992",12))),
-        ('drop_abovebelow', cl.Development(drop_above = 1.05, drop_below = .95)),
-        ('drop_hilo', cl.Development(drop_high = 1, drop_low = 1))]
+    pipe = cl.Pipeline(
+        steps=[
+            ("n_periods", cl.Development(n_periods=7)),
+            ("drop_valuation", cl.Development(drop_valuation=1995)),
+            ("drop", cl.Development(drop=("1992", 12))),
+            ("drop_abovebelow", cl.Development(drop_above=1.05, drop_below=0.95)),
+            ("drop_hilo", cl.Development(drop_high=1, drop_low=1)),
+        ]
     )
     dev2 = pipe.fit(X=clrd)
-    assert np.array_equal(dev1.w_v2_.values,dev2.named_steps.drop_hilo.w_v2_.values,True)
+    assert np.array_equal(
+        dev1.w_v2_.values, dev2.named_steps.drop_hilo.w_v2_.values, True
+    )


### PR DESCRIPTION
- Addressed #514.
This is done by removing [secondary_rank](https://github.com/casact/chainladder-python/compare/%23514?expand=1#diff-e4811ac35addcd44905fb8e503aeac1de4816ff160955cd40efe4c3a82c0cc7fL520-L531).
@henrydingliu, do you remember why you did this? None of the tests failed, and I couldn't figure out what its supposed to do.
- Added test in #517.
