### PR TITLE
#537

### DIFF
--- a/chainladder/adjustments/berqsherm.py
+++ b/chainladder/adjustments/berqsherm.py
@@ -140,6 +140,12 @@ class BerquistSherman(BaseEstimator, TransformerMixin, EstimatorIO):
                 )
                 - 1
             )
+
+        # Don't allow lookup values beyond the final value.
+        n = min(lookup.shape[-1], lookup.shape[-2])
+        for j in range(n - 1):
+            lookup[:, :, j, :] = np.clip(lookup[:, :, j, :], 0,  n - j - 2)
+
         a = (
             xp.concatenate(
                 [

--- a/chainladder/adjustments/tests/test_berqsherm.py
+++ b/chainladder/adjustments/tests/test_berqsherm.py
@@ -17,3 +17,27 @@ def test_preserve_diagonal():
         == 0
     )
     assert berq_triangle != triangle
+
+def test_adjusted_values():
+    triangle = cl.load_sample("berqsherm").loc["MedMal"]
+    xp = triangle.get_array_module()
+    berq = cl.BerquistSherman(
+        paid_amount="Paid",
+        incurred_amount="Incurred",
+        reported_count="Reported",
+        closed_count="Closed",
+        trend=0.15,
+    )
+    berq_triangle = berq.fit_transform(triangle)
+
+    assert np.allclose(
+        triangle["Reported"].values, berq_triangle["Reported"].values, equal_nan=True
+    )
+
+    # Ensure that the incurred, paid, and closed count columns are as expected
+    berq_triangle.values[np.isnan(berq_triangle.values)] = 0
+    assert np.isclose(
+        berq_triangle["Incurred"].values.sum(), 1126985253.661, atol=1e-2
+    )
+    assert np.isclose(berq_triangle["Paid"].values.sum(), 182046766.054, atol=1e-2)
+    assert np.isclose(berq_triangle["Closed"].values.sum(), 8798.982, atol=1e-2)


### PR DESCRIPTION
This PR accomplishes two things:
1. Ensures that the paid Berquist-Sherman adjustment continues to work when the lookup (based on the adjusted paid claim count) exceeds the maximum actual paid claim count in the row. It accomplishes this by capping the lookup value.
2. Adds an additional Berquist-Sherman unit tests to ensure adjusted values are as expected on the Berquist Sherman dataset. This test passes both before and after the change.

To replicate the error in question:

```
import chainladder as cl
triangle = cl.load_sample("berqsherm").loc['MedMal']
xp = triangle.get_array_module()
# Purposefully cause negative closed development towards the end for demonstration
triangle.loc["MedMal", "Closed", "1969" , 84] = triangle.loc["MedMal", "Closed", "1969" , 72] * 0.9
triangle.loc["MedMal", "Closed", "1969" , 96] = triangle.loc["MedMal", "Closed", "1969" , 84] * 0.9
triangle.loc["MedMal", "Closed", "1970" , 84] = triangle.loc["MedMal", "Closed", "1970" , 72] * 0.9

berq = cl.BerquistSherman(
    paid_amount='Paid', incurred_amount='Incurred',
    reported_count='Reported', closed_count='Closed',
    trend=0.15)
# Transform triangle
berq_triangle = berq.fit_transform(triangle)
```