### PR TITLE
Limit Numpy Version `<2`

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 pandas>=0.23
 scikit-learn>=0.23
 numba>0.54
+numpy<2.0
 sparse>=0.9
 matplotlib
 dill


### PR DESCRIPTION
As mentioned in issue #542 there is at least one compatibility issue with numpy 2.x.x. Until that's fixed let's just set a max numpy version?