### PR TITLE
553

### DIFF
--- a/chainladder/adjustments/berqsherm.py
+++ b/chainladder/adjustments/berqsherm.py
@@ -147,24 +147,24 @@ class BerquistSherman(BaseEstimator, TransformerMixin, EstimatorIO):
             lookup[:, :, j, :] = np.clip(lookup[:, :, j, :], 0,  n - j - 2)
 
         a = (
-            xp.concatenate(
-                [
-                    a[..., i, lookup[0, 0, i : i + 1, :]]
-                    for i in range(lookup.shape[-2])
-                ],
-                -2,
-            )
-            * adj_closed_clm.nan_triangle[None, None, ...]
+            xp.concatenate([
+                xp.concatenate(
+                    [a[j:j+1, ..., i, lookup[j, 0, i:i+1, :]] for i in range(lookup.shape[-2])],
+                    axis=-2
+                )
+                for j in range(a.shape[0]) # Process each batch independently
+            ], axis=0)
+        * adj_closed_clm.nan_triangle[None, None, ...]
         )
         b = (
-            xp.concatenate(
-                [
-                    b[..., i, lookup[0, 0, i : i + 1, :]]
-                    for i in range(lookup.shape[-2])
-                ],
-                -2,
-            )
-            * adj_closed_clm.nan_triangle[None, None, ...]
+            xp.concatenate([
+                xp.concatenate(
+                    [b[j:j+1, ..., i, lookup[j, 0, i:i+1, :]] for i in range(lookup.shape[-2])],
+                    axis=-2
+                )
+                for j in range(b.shape[0]) # Process each batch independently
+            ], axis=0)
+        * adj_closed_clm.nan_triangle[None, None, ...]
         )
         # Adjust paids
         adj_paid_claims = adj_closed_clm * 0 + xp.exp(adj_closed_clm.values * b) * a


### PR DESCRIPTION
This pull request resolves issue [553](https://github.com/casact/chainladder-python/issues/553), which notes that the Berquist Sherman settlement rate adjustment (in the `berqsherm.py` module) sometimes adjusts incorrectly for triangles with a kdims length >1

All tests pass after making the change, and the issue seems to be resolved. Let me know if there are any concerns.