### PR TITLE
Adding a native read_csv function to Chainladder-python

### DIFF
--- a/chainladder/utils/__init__.py
+++ b/chainladder/utils/__init__.py
@@ -7,6 +7,7 @@ from chainladder.utils.weighted_regression import (
 
 from chainladder.utils.utility_functions import (  # noqa (API import)
     parallelogram_olf,
+    read_csv,
     read_pickle,
     read_json,
     concat,

--- a/chainladder/utils/tests/test_utilities.py
+++ b/chainladder/utils/tests/test_utilities.py
@@ -156,6 +156,43 @@ def test_json_df():
     )
     assert abs(cl.read_json(x.to_json()).lambda_ - x.lambda_).sum() < 1e-5
 
+def test_read_csv_single(raa):
+    #test the read_csv funtion for a single dimensional input 
+    
+    #read in the csv file 
+    from pathlib import Path
+    raa_csv_path = Path(__file__).parent.parent / "data" / "raa.csv"
+
+    assert raa == cl.read_csv(
+        filepath_or_buffer=raa_csv_path,
+        origin = "origin",
+        development = "development",
+        columns = ["values"],
+        index = None,
+        cumulative = True)
+
+def test_read_csv_multi(clrd):
+    #test the read_csv funtion for multi dimensional input 
+
+    #read in the csv file 
+    from pathlib import Path
+    clrd_csv_path = Path(__file__).parent.parent / "data" / "clrd.csv"
+
+    assert clrd == cl.read_csv(
+        filepath_or_buffer=clrd_csv_path,
+        origin = "AccidentYear",
+        development = "DevelopmentYear",
+        columns = [
+            "IncurLoss",
+            "CumPaidLoss",
+            "BulkLoss",
+            "EarnedPremDIR",
+            "EarnedPremCeded",
+            "EarnedPremNet",
+        ],
+        index = ["GRNAME","LOB"],
+        cumulative = True
+    ) 
 
 def test_concat(clrd):
     tri = clrd.groupby("LOB").sum()

--- a/chainladder/utils/tests/test_utilities.py
+++ b/chainladder/utils/tests/test_utilities.py
@@ -157,9 +157,9 @@ def test_json_df():
     assert abs(cl.read_json(x.to_json()).lambda_ - x.lambda_).sum() < 1e-5
 
 def test_read_csv_single(raa):
-    #test the read_csv funtion for a single dimensional input 
+    # Test the read_csv function for a single dimensional input.
     
-    #read in the csv file 
+    # Read in the csv file.
     from pathlib import Path
     raa_csv_path = Path(__file__).parent.parent / "data" / "raa.csv"
 
@@ -172,9 +172,9 @@ def test_read_csv_single(raa):
         cumulative = True)
 
 def test_read_csv_multi(clrd):
-    #test the read_csv funtion for multi dimensional input 
+    # Test the read_csv function for multidimensional input.
 
-    #read in the csv file 
+    # Read in the csv file.
     from pathlib import Path
     clrd_csv_path = Path(__file__).parent.parent / "data" / "clrd.csv"
 

--- a/chainladder/utils/utility_functions.py
+++ b/chainladder/utils/utility_functions.py
@@ -196,6 +196,97 @@ def read_csv(
         *args, 
         **kwargs
         ) -> Triangle:
+    """
+    Funtion that creates Triangle directly from input. Wrapper for pandas dataframe:
+    https://pandas.pydata.org/docs/reference/api/pandas.read_csv.html
+
+    Parameters
+    ----------
+    filepath_or_buffer: str, path object or file-like object
+        Any valid string path is acceptable. The string could be a URL. Valid URL schemes 
+        include http, ftp, s3, gs, and file. For file URLs, a host is expected. A local 
+        file could be: file://localhost/path/to/table.csv.
+        If you want to pass in a path object, pandas accepts any os.PathLike.
+        By file-like object, we refer to objects with a read() method, such as a 
+        file handle (e.g. via builtin open function) or StringIO.
+    origin: str or list
+         A representation of the accident, reporting or more generally the
+         origin period of the triangle that will map to the Origin dimension
+    development: str or list
+        A representation of the development/valuation periods of the triangle
+        that will map to the Development dimension
+    columns: str or list
+        A representation of the numeric data of the triangle that will map to
+        the columns dimension.  If None, then a single 'Total' key will be
+        generated.
+    index: str or list or None
+        A representation of the index of the triangle that will map to the
+        index dimension.  If None, then a single 'Total' key will be generated.
+    origin_format: optional str
+        A string representation of the date format of the origin arg. If
+        omitted then date format will be inferred by pandas.
+    development_format: optional str
+        A string representation of the date format of the development arg. If
+        omitted then date format will be inferred by pandas.
+    cumulative: bool
+        Whether the triangle is cumulative or incremental.  This attribute is
+        required to use the ``grain`` and ``dev_to_val`` methods and will be
+        automatically set when invoking ``cum_to_incr`` or ``incr_to_cum`` methods.
+    trailing: bool
+        When partial origin periods are present, setting trailing to True will
+        ensure the most recent origin period is a full period and the oldest
+        origin is partial. If full origin periods are present in the data, then
+        trailing has no effect.
+
+    Attributes
+    ----------
+    index: Series
+        Represents all available levels of the index dimension.
+    columns: Series
+        Represents all available levels of the value dimension.
+    origin: DatetimeIndex
+        Represents all available levels of the origin dimension.
+    development: Series
+        Represents all available levels of the development dimension.
+    key_labels: list
+        Represents the ``index`` axis labels
+    virtual_columns: Series
+        Represents the subset of columns of the triangle that are virtual.
+    valuation: DatetimeIndex
+        Represents all valuation dates of each cell in the Triangle.
+    origin_grain: str
+        The grain of the origin vector ('Y', 'S', 'Q', 'M')
+    development_grain: str
+        The grain of the development vector ('Y', 'S', 'Q', 'M')
+    shape: tuple
+        The 4D shape of the triangle instance with axes corresponding to (index, columns, origin, development)
+    link_ratio, age_to_age
+        Displays age-to-age ratios for the triangle.
+    valuation_date : date
+        The latest valuation date of the data
+    loc: Triangle
+        pandas-style ``loc`` accessor
+    iloc: Triangle
+        pandas-style ``iloc`` accessor
+    latest_diagonal: Triangle
+        The latest diagonal of the triangle
+    is_cumulative: bool
+        Whether the triangle is cumulative or not
+    is_ultimate: bool
+        Whether the triangle has an ultimate valuation
+    is_full: bool
+        Whether lower half of Triangle has been filled in
+    is_val_tri:
+        Whether the triangle development period is expressed as valuation
+        periods.
+    values: array
+        4D numpy array underlying the Triangle instance
+    T: Triangle
+        Transpose index and columns of object.  Only available when Triangle is
+        convertible to DataFrame.
+    """
+
+
     from chainladder import Triangle
 
     #Chainladder implementation of: https://pandas.pydata.org/docs/reference/api/pandas.read_csv.html

--- a/chainladder/utils/utility_functions.py
+++ b/chainladder/utils/utility_functions.py
@@ -174,6 +174,10 @@ def read_pickle(path):
     with open(path, "rb") as pkl:
         return dill.load(pkl)
 
+def read_csv(*args, **kwargs):
+    #Chainladder implementation of: https://pandas.pydata.org/docs/reference/api/pandas.read_csv.html
+    local_dataframe = pd.read_csv(*args, **kwargs)
+    return local_dataframe
 
 def read_json(json_str, array_backend=None):
     from chainladder import Triangle

--- a/chainladder/utils/utility_functions.py
+++ b/chainladder/utils/utility_functions.py
@@ -21,15 +21,22 @@ from sklearn.base import (
 from typing import (
     Iterable,
     Union,
+    Optional,
     TYPE_CHECKING
 )
 
 if TYPE_CHECKING:
     from chainladder import Triangle
     from numpy.typing import ArrayLike
+    from pandas import DataFrame
+    from pandas.core.interchange.dataframe_protocol import DataFrame as DataFrameXchg
     from sparse import COO
     from types import ModuleType
     from typing import AnyStr
+    from pandas._typing import (
+        FilePath,
+        ReadCsvBuffer
+    )
 
 
 def load_sample(
@@ -174,10 +181,45 @@ def read_pickle(path):
     with open(path, "rb") as pkl:
         return dill.load(pkl)
 
-def read_csv(*args, **kwargs):
+def read_csv(
+        filepath_or_buffer: FilePath | ReadCsvBuffer[bytes] | ReadCsvBuffer[str],
+        origin: Optional[str | list] = None,
+        development: Optional[str | list] = None,
+        columns: Optional[str | list] = None,
+        index: Optional[str | list] = None,
+        origin_format: Optional[str] = None,
+        development_format: Optional[str] = None,
+        cumulative: Optional[bool] = None,
+        array_backend: str = None,
+        pattern=False,
+        trailing: bool = True,
+        *args, 
+        **kwargs
+        ) -> Triangle:
+    from chainladder import Triangle
+
     #Chainladder implementation of: https://pandas.pydata.org/docs/reference/api/pandas.read_csv.html
-    local_dataframe = pd.read_csv(*args, **kwargs)
-    return local_dataframe
+    #This will allow the user to create a trignel directly from csv instead in csv -> dataframe -> triangle
+
+    #create a data frame using the *args and **kwargs that the user specified
+    local_dataframe = pd.read_csv(filepath_or_buffer,*args, **kwargs)
+
+    #pass the created local_dataframe in the Triangle constructor 
+    local_triangle = Triangle(
+        data = local_dataframe, 
+        origin=origin,
+        development=development,
+        columns=columns,
+        index=index,
+        origin_format=origin_format,
+        development_format=development_format,
+        cumulative=cumulative,
+        array_backend=array_backend,
+        pattern=pattern,
+        trailing = trailing
+    )
+
+    return local_triangle
 
 def read_json(json_str, array_backend=None):
     from chainladder import Triangle


### PR DESCRIPTION
This PR is in response to: Issue #569. 

I created a wrapper for the pandas read_csv function. Now you will be able to use `chainladder.read_csv` instead of having to first import the csv via pandas. 

Pandas read_csv implementation: https://pandas.pydata.org/docs/reference/api/pandas.read_csv.html

**Testing and reading example file listed:** 
<img width="1103" height="802" alt="Screenshot from 2025-07-18 19-26-07" src="https://github.com/user-attachments/assets/205f881f-82c3-4899-86f8-f7a3ee7b5349" />