### PR TITLE
Fix KeyError for semi-annual origins 

### DIFF
--- a/chainladder/development/base.py
+++ b/chainladder/development/base.py
@@ -386,8 +386,8 @@ class DevelopmentBase(BaseEstimator, TransformerMixin, EstimatorIO, Common):
             val_offset = {
                 "Y": {"Y": 1},
                 "S": {"Y": 2, "S": 1},
-                "Q": {"Y": 4, "Q": 1},
-                "M": {"Y": 12, "Q": 3, "M": 1},
+                "Q": {"Y": 4, "S": 2, "Q": 1},
+                "M": {"Y": 12, "S": 6, "Q": 3, "M": 1},
             }
             if n_periods < 1 or n_periods >= X.shape[-2]:
                 return X.values * 0 + 1


### PR DESCRIPTION
This PR fixes a KeyError: 'S' that occurs when fitting a development pattern to triangles with semi-annual origin periods and quarterly or monthly development periods.

The error arises from the _assign_n_periods_weight_func method in base.py, where the val_offset dictionary was missing "S" lookups for quarterly and monthly development grains. 

**Changes**
- Updated val_offset mapping in _assign_n_periods_weight_func to include "S" entries (to match the mapping in _assign_n_periods_weight)

**Notes**

- Fixes #596 