### PR TITLE
Fix for #608

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,6 +66,7 @@ docs = [
     "parso>=0.8",
     "polars",  # For docs examples
     "statsmodels",  # For docs examples
+    "jupyter_black",
 ]
 test = [
     "lxml",


### PR DESCRIPTION
fixing jupyter_black dependency. 

Tested on [separate RTD instance](https://hdlclp.readthedocs.io/en/latest/getting_started/tutorials/triangle-tutorial.html) based on my repo. 