### PR TITLE
fixes grain error in learning.py

### DIFF
--- a/chainladder/development/learning.py
+++ b/chainladder/development/learning.py
@@ -93,8 +93,8 @@ class DevelopmentML(DevelopmentBase):
             preds = self.estimator_ml.predict(df)
         X_r = [df]
         y_r = [preds]
-        dgrain = {'Y':12, 'Q':3, 'M': 1, 'S': 6}[self.development_grain_]
-        ograin = {'Y':1, 'Q':4, 'M': 12, 'S': 6}[self.origin_grain_]
+        dgrain = {'Y':12, 'S': 6, 'Q':3, 'M': 1}[self.development_grain_]
+        ograin = {'Y':1, 'S': 2, 'Q':4, 'M': 12}[self.origin_grain_]
         latest_filter = (df['origin']+1)*ograin+(df['development']-dgrain)/dgrain
         latest_filter = latest_filter == latest_filter.max()
         preds=pd.DataFrame(preds.copy())[latest_filter].values
@@ -171,11 +171,11 @@ class DevelopmentML(DevelopmentBase):
         self.development_grain_ = X.development_grain
         self.origin_encoder_ = dict(zip(
             X.origin.to_timestamp(how='s'),
-            (pd.Series(X.origin).rank()-1)/{'Y':1, 'Q':4, 'M': 12, 'S': 6}[X.origin_grain]))
+            (pd.Series(X.origin).rank()-1)/{'Y':1, 'S': 2, 'Q':4, 'M': 12}[X.origin_grain]))
         val = X.valuation.sort_values().unique()
         self.valuation_encoder_ = dict(zip(
             val,
-            (pd.Series(val).rank()-1)/{'Y':1, 'Q':4, 'M': 12, 'S': 6}[X.development_grain]))
+            (pd.Series(val).rank()-1)/{'Y':1, 'S': 2, 'Q':4, 'M': 12}[X.development_grain]))
         df = self._prep_X_ml(X)
         self.df_ = df
         # Fit model


### PR DESCRIPTION
There is a small grain error in learning.py that affects semiannual grain triangles. As it stands, passing a semiannual triangle to learning.py (via some estimator) causes a size mismatch error during triangle arithmetic.
<details>
<summary>here's an example largely ripped from an earlier grain issue (#609)</summary>

```
import chainladder as cl, pandas as pd
# Create semi-annual triangle data
data = {
    'origin': ["2007-01-01", "2007-01-01", "2007-01-01", "2007-01-01", "2007-01-01", "2007-01-01", "2007-01-01",
               "2007-07-01", "2007-07-01", "2007-07-01", "2007-07-01", "2007-07-01", "2007-07-01",
               "2008-01-01", "2008-01-01", "2008-01-01", "2008-01-01", "2008-01-01",
               "2008-07-01", "2008-07-01", "2008-07-01", "2008-07-01",
               "2009-01-01", "2009-01-01", "2009-01-01",
               "2009-07-01", "2009-07-01",
               "2010-01-01"],
    'development': ["2007-01-01", "2007-07-01", "2008-01-01", "2008-07-01", "2009-01-01", "2009-07-01", "2010-01-01",
                    "2007-07-01", "2008-01-01", "2008-07-01", "2009-01-01", "2009-07-01", "2010-01-01",
                    "2008-01-01", "2008-07-01", "2009-01-01", "2009-07-01", "2010-01-01",
                    "2008-07-01", "2009-01-01", "2009-07-01", "2010-01-01",
                    "2009-01-01", "2009-07-01", "2010-01-01",
                    "2009-07-01", "2010-01-01",
                    "2010-01-01"],
    'loss': [100, 200, 300, 400, 500, 600, 700, 
             150, 300, 450, 500, 550, 600, 
             200, 250, 350, 400, 450, 
             50, 100, 150, 200,
             100, 200, 300,
             50, 150, 
             100]
}

df = pd.DataFrame(data)

tri = cl.Triangle(
    df, 
    origin='origin',
    development='development',
    columns='loss',
    cumulative=True
)
# ODP fit for example
BZsemi = cl.BarnettZehnwirth(formula = 'C(development)+C(origin)').fit(tri)
```
```
ValueError                                Traceback (most recent call last)
Cell In[1], line 36
     27 df = pd.DataFrame(data)
     29 tri = cl.Triangle(
     30     df,
     31     origin='origin',
   (...)     34     cumulative=True
     35 )
---> 36 BZsemi = cl.BarnettZehnwirth(formula = 'C(development)+C(origin)').fit(tri)

File ~\chainladder-python\chainladder\development\barnzehn.py:54, in BarnettZehnwirth.fit(self, X, y, sample_weight)
     49     warnings.warn("Using more than one linear predictor with BarnettZehnwirth may lead to issues with multicollinearity.")
     50 self.model_ = DevelopmentML(Pipeline(steps=[
     51     ('design_matrix', PatsyFormula(self.formula)),
     52     ('model', LinearRegression(fit_intercept=False))]),
     53             y_ml=response, fit_incrementals=False).fit(tri)
---> 54 resid = tri - self.model_.triangle_ml_[
     55     self.model_.triangle_ml_.valuation <= tri.valuation_date]
     56 self.mse_resid_ = (resid**2).sum(0).sum(1).sum(2).sum() / (
     57     np.nansum(tri.nan_triangle) -
     58     len(self.model_.estimator_ml.named_steps.model.coef_))
     59 self.std_residuals_ = (resid / np.sqrt(self.mse_resid_))

File ~\chainladder-python\chainladder\core\dunders.py:270, in TriangleDunders.__sub__(self, other)
    269 def __sub__(self, other):
--> 270     obj, other = self._validate_arithmetic(other)
    271     if isinstance(obj, TriangleGroupBy):
    272         def f(k, self, obj, other):

File ~\chainladder-python\chainladder\core\dunders.py:35, in TriangleDunders._validate_arithmetic(self, other)
     33 """ Common functionality BEFORE arithmetic operations """
     34 if isinstance(other, TriangleDunders):
---> 35     obj, other = self._compatibility_check(self, other)
     36     if obj.is_pattern != other.is_pattern:
     37         obj.is_pattern = other.is_pattern = False

File ~\chainladder-python\chainladder\core\dunders.py:69, in TriangleDunders._compatibility_check(self, x, y)
     63 x, y = set_common_backend([x, y])
     64 if (
     65     x.origin_grain != y.origin_grain
     66     or (x.development_grain != y.development_grain and
     68 ):
---> 69     raise ValueError(
     70         "Triangle arithmetic requires both triangles to be the same grain."
     71     )
     72 return x, y

ValueError: Triangle arithmetic requires both triangles to be the same grain.

```
</details>

This is caused by the wrong number of periods per year being given for semiannual triangles: there are 2 semis in an annual, not 6. This leads to `self.model_.triangle_ml_` being constructed with a finer granularity than it ought to have. I fixed the incorrect values and reordered the grain dictionaries to make things more obvious. The above code runs as expected with this change.