### PR TITLE
bump actions, simplify uv python setup

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -18,17 +18,16 @@ jobs:
         os: ['ubuntu-latest']
         python-version: ['3.9', '3.10', '3.11', '3.12']
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Install uv
-        uses: astral-sh/setup-uv@v3
+        uses: astral-sh/setup-uv@v7
         with:
           version: "latest"
-      - name: Set up Python ${{ matrix.python-version }}
-        run: uv python install ${{ matrix.python-version }}
-      - name: Install dependencies and run tests
-        run: |
-          uv sync --extra test
-          uv run pytest --cov=chainladder --cov-report=xml
+          python-version: ${{ matrix.python-version }}
+      - name: Install dependencies
+        run: uv sync --extra test
+      - name: Run tests
+        run: uv run pytest --cov=chainladder --cov-report=xml
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v4
         with:

--- a/.github/workflows/pytest_upstream_nightly.yml
+++ b/.github/workflows/pytest_upstream_nightly.yml
@@ -20,14 +20,13 @@ jobs:
         os: ['ubuntu-latest']
         python-version: ['3.9', '3.10', '3.11', '3.12', '3.13']
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Install uv
-        uses: astral-sh/setup-uv@v3
+        uses: astral-sh/setup-uv@v7
         with:
           version: "latest"
-      - name: Set up Python ${{ matrix.python-version }}
-        run: uv python install ${{ matrix.python-version }}
-      - name: Install dependencies and run tests
-        run: |
-          uv sync --extra test
-          uv run pytest chainladder -m "not r"
+          python-version: ${{ matrix.python-version }}
+      - name: Install dependencies
+        run: uv sync --extra test
+      - name: Run tests
+        run: uv run pytest chainladder -m "not r"

--- a/.github/workflows/pythonpublish.yml
+++ b/.github/workflows/pythonpublish.yml
@@ -13,9 +13,9 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - name: Set up Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v6
       with:
         python-version: '3.x'
     - name: Install build dependencies


### PR DESCRIPTION
- bumped all Github Actions except for Codecov, which I'm not familiar with and it seemed there were breaking changes I didn't want to mess with.
- `uv` bump has improved dependency caching for faster CI
- split dependency installation and tests into two processes for easier timing and error tracking

Area for future improvement:
- use `uv build` and `uv publish` instead of `build` and `twine`. Left those as-is for now.