### PR TITLE
Update CI Upstream workflow to remove branch triggers

### DIFF
--- a/.github/workflows/pytest_upstream_nightly.yml
+++ b/.github/workflows/pytest_upstream_nightly.yml
@@ -1,11 +1,5 @@
 name: CI Upstream
 on:
-  push:
-    branches:
-      - master
-  pull_request:
-    branches:
-      - master
   schedule:
     - cron: "0 0 * * *" # Daily “At 00:00” UTC
   workflow_dispatch: # allows you to trigger the workflow run manually


### PR DESCRIPTION
Removed redundant push and pull_request triggers from CI workflow. The same `uv run pytest` is triggered on PRs with master and post-merge as in the Unit Tests CI. Removing those triggers so that they only execute on chron trigger and manual trigger. 