### PR TITLE
Improve docstring for approximation_grain in ParallelogramOLF

### DIFF
--- a/chainladder/adjustments/parallelogram.py
+++ b/chainladder/adjustments/parallelogram.py
@@ -21,6 +21,10 @@ class ParallelogramOLF(BaseEstimator, TransformerMixin, EstimatorIO):
         5% decrease should be stated as -0.05
     date_col: str
         A list-like set of effective dates corresponding to each of the changes
+    approximation_grain: str
+        The resolution of the internal calendar used for calculating the on-level factors: 
+        monthly ('M') or daily ('D'). Daily is finer and adjusts for leap years when assigning
+        factors to origin periods.
     vertical_line:
         Rates are typically stated on an effective date basis and premiums on
         and earned basis.  By default, this argument is False and produces


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Docstring-only change; no functional or behavioral impact.
> 
> **Overview**
> Improves the `ParallelogramOLF` docstring by documenting the `approximation_grain` parameter, including supported values (`'M'` monthly, `'D'` daily) and the effect of daily granularity (leap-year handling when assigning factors to origin periods).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b984f80422adcec4500c7401862df646d309c663. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->