### PR TITLE
#689

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -92,6 +92,8 @@ celerybeat-schedule
 .venv
 venv/
 ENV/
+.ipynb_checkpoints
+.virtual_documents
 
 # Spyder project settings
 .spyderproject

--- a/chainladder/adjustments/parallelogram.py
+++ b/chainladder/adjustments/parallelogram.py
@@ -21,6 +21,10 @@ class ParallelogramOLF(BaseEstimator, TransformerMixin, EstimatorIO):
         5% decrease should be stated as -0.05
     date_col: str
         A list-like set of effective dates corresponding to each of the changes
+    approximation_grain: str
+        The resolution of the internal calendar used for calculating the on-level factors: 
+        monthly ('M') or daily ('D'). Daily is finer and adjusts for leap years when assigning
+        factors to origin periods.
     vertical_line:
         Rates are typically stated on an effective date basis and premiums on
         and earned basis.  By default, this argument is False and produces

--- a/docs/library/contributing.md
+++ b/docs/library/contributing.md
@@ -65,8 +65,12 @@ cd chainladder-python
 # Create virtual environment and install all dependencies
 uv sync --extra all
 
+```
+
+Once the environment is set up, we may go into development mode with `uv`:
+```bash
 # Activate the environment
-uv run python # or uv run jupyter-lab
+uv run jupyter-lab # or uv run python
 ```
 
 This will install the package in editable mode with all development dependencies. After finishing work, deactivate:

--- a/docs/user_guide/adjustments.ipynb
+++ b/docs/user_guide/adjustments.ipynb
@@ -657,7 +657,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 7,
    "id": "252ed464-a589-4a09-9bc7-937c4b0a8529",
    "metadata": {},
    "outputs": [
@@ -704,7 +704,7 @@
        "2020  1.034456"
       ]
      },
-     "execution_count": 6,
+     "execution_count": 7,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -713,7 +713,7 @@
     "data = pd.DataFrame({\n",
     "    'Year': [2016, 2017, 2018, 2019, 2020],\n",
     "    'EarnedPremium': [10_000]*5})\n",
-    "prem_tri = cl.Triangle(data, origin='Year', columns='EarnedPremium')\n",
+    "prem_tri = cl.Triangle(data, origin='Year', columns='EarnedPremium', cumulative = True)\n",
     "prem_tri = cl.ParallelogramOLF(rate_history, change_col='RateChange', date_col='EffDate').fit_transform(prem_tri)\n",
     "prem_tri.olf_"
    ]
@@ -757,7 +757,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 8,
    "id": "af652141-0a29-4dcf-9807-18f252c6cd3c",
    "metadata": {},
    "outputs": [
@@ -767,7 +767,7 @@
        "True"
       ]
      },
-     "execution_count": 7,
+     "execution_count": 8,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -801,7 +801,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 9,
    "id": "dae2933e-864f-4d42-a866-e3fda52d1f2a",
    "metadata": {},
    "outputs": [
@@ -972,7 +972,7 @@
        "1997  1.00   NaN   NaN   NaN   NaN   NaN   NaN   NaN   NaN   NaN"
       ]
      },
-     "execution_count": 8,
+     "execution_count": 9,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -981,22 +981,14 @@
     "ppauto_loss = cl.load_sample('clrd').groupby('LOB').sum().loc['ppauto', 'CumPaidLoss']\n",
     "cl.Trend(\n",
     "    trends=[.05, .03],\n",
-    "    dates=[('1997-12-31', '1995'),('1995', '1992-07')]\n",
+    "    dates=[('1997-12-31', '1995-01-01'),('1995-01-01', '1992-07-01')]\n",
     ").fit(ppauto_loss).trend_.round(2)"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "eaaf2ea2-cf4e-4549-ae83-4f1b6476e30e",
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3.7.11 ('cl_dev')",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -1010,7 +1002,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.11"
+   "version": "3.9.12"
   },
   "vscode": {
    "interpreter": {


### PR DESCRIPTION
- Addressed and added clarity on the dates example in the multi trend user guide
- Added some notes on uv and virtual environment
- Added some files to gitignore (docs generated)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation and housekeeping changes; the only code change is a docstring clarification for `ParallelogramOLF`, with no runtime logic modified.
> 
> **Overview**
> **Documentation updates:** clarifies `uv`-based dev setup in `docs/library/contributing.md`, fixes the `uv run` example, and updates the user guide notebook to use clearer, fully-specified multipart trend date ranges and a correct `Triangle(..., cumulative=True)` on-leveling example.
> 
> **Minor housekeeping:** expands `.gitignore` to exclude Jupyter/VSCode generated artifacts (e.g., `.virtual_documents`, checkpoints).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c861aff9ab364ea6a6db0bc4e5a35eec08729c80. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->