### PR TITLE
DOCS: Begin work on examples.

### DIFF
--- a/chainladder/core/triangle.py
+++ b/chainladder/core/triangle.py
@@ -144,6 +144,33 @@ class Triangle(TriangleBase):
         1982   106.0  4285.0   5396.0      NaN
         1983  3410.0  8992.0      NaN      NaN
         1984  5655.0     NaN      NaN      NaN
+
+    When another dimension is added, such an additional column, the Triangle becomes multidimensional. In this case,
+    printing displays the Triangle's metadata, rather than its contents.
+
+    >>> df = pd.DataFrame(
+            data={
+                'origin': [1981, 1981, 1981, 1981, 1982, 1982, 1982, 1983, 1983, 1984],
+                'development': [1981, 1982, 1983, 1984, 1982, 1983, 1984, 1983, 1984, 1984],
+                'reported': [5012, 8269, 10907, 11805, 106, 4285, 5396, 3410, 8992, 5655],
+                'paid': [2506, 4135, 5454, 5903, 53, 2143, 2698, 1705, 4496, 2828]
+            }
+        )
+
+    >>> tr = cl.Triangle(
+            data=df,
+            origin='origin',
+            development='development',
+            columns=['reported', 'paid'],
+            cumulative=True
+        )
+    >>> tr
+                    Triangle Summary
+        Valuation:           1984-12
+        Grain:                  OYDY
+        Shape:          (1, 2, 4, 4)
+        Index:               [Total]
+        Columns:    [reported, paid]
     """
 
     def __init__(

--- a/chainladder/core/triangle.py
+++ b/chainladder/core/triangle.py
@@ -116,6 +116,34 @@ class Triangle(TriangleBase):
     T: Triangle
         Transpose index and columns of object.  Only available when Triangle is
         convertible to DataFrame.
+
+    Examples
+    --------
+
+    Constructing a Triangle from a Pandas DataFrame.
+
+    >>> import chainladder as cl
+    >>> import pandas as pd
+    >>> df = pd.DataFrame(
+            data={
+                'origin': [1981, 1981, 1981, 1981, 1982, 1982, 1982, 1983, 1983, 1984],
+                'development': [1981, 1982, 1983, 1984, 1982, 1983, 1984, 1983, 1984, 1984],
+                'reported': [5012, 8269, 10907, 11805, 106, 4285, 5396, 3410, 8992, 5655]
+            }
+        )
+    >>> tr = cl.Triangle(
+            data=df,
+            origin='origin',
+            development='development',
+            columns=['reported'],
+            cumulative=True
+        )
+    >>> tr
+                  12      24       36       48
+        1981  5012.0  8269.0  10907.0  11805.0
+        1982   106.0  4285.0   5396.0      NaN
+        1983  3410.0  8992.0      NaN      NaN
+        1984  5655.0     NaN      NaN      NaN
     """
 
     def __init__(

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -23,6 +23,7 @@ extensions = [
     "sphinx_thebe",
     "sphinx_comments",
     "sphinx_external_toc",
+    "sphinx.ext.doctest",
     "sphinx.ext.intersphinx",
     "sphinx_book_theme",
     "sphinx.ext.autodoc",


### PR DESCRIPTION
I'd like to get the ball rolling on creating examples for the significant classes and methods in the documentation. This is mostly inspired by Pandas, where the documentation on the [DataFrame](https://pandas.pydata.org/docs/reference/api/pandas.DataFrame.html) class and methods is richly populated with examples. I think examples will be key to increasing users.

So far, in order to find examples of certain chainladder classes, methods, etc., you'll have to search through the documentation and hope that it takes you to a place in the tutorial where it's used. Instead, having examples in the API reference section will make things easier to look up, and will also improve chainladder-python's ranking in Google search.

Examples are written in the Python docstrings. These will automatically update the API reference via the Sphinx extension, 
`sphinx.ext.doctest`. For this simple pull request, I've initialized a Triangle from a Pandas DataFrame.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Low runtime risk (docs-only), but enabling `sphinx.ext.doctest` can cause documentation builds/CI to start executing and failing on example outputs or environment differences.
> 
> **Overview**
> Adds **doctest-style examples** to the `Triangle` class docstring showing how to construct a triangle from a Pandas DataFrame (single-column and multi-column cases) and what `print(tr)` returns.
> 
> Enables Sphinx’s `sphinx.ext.doctest` extension in `docs/conf.py` so these docstring examples can be validated during documentation builds.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 84fd6e0d5141455be2371f4a2381e3919cffea8b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->