### PR TITLE
nan_triangle 1D logic overhaul

### DIFF
--- a/chainladder/core/base.py
+++ b/chainladder/core/base.py
@@ -9,6 +9,8 @@ from packaging import version
 import numpy as np
 import warnings
 
+from abc import ABC, abstractmethod
+
 from chainladder import options
 
 from chainladder.core.common import Common
@@ -44,7 +46,8 @@ class TriangleBase(
     TriangleSlicer,
     TriangleDunders,
     TrianglePandas,
-    Common
+    Common,
+    ABC
 ):
     """This class handles the initialization of a triangle"""
 
@@ -309,6 +312,16 @@ class TriangleBase(
         )
         
         return c[c["__development__"] > c["__origin__"]]
+    
+    @property
+    @abstractmethod
+    def is_pattern(self):
+        raise NotImplementedError
+        
+    @property
+    @abstractmethod
+    def is_ultimate(self):
+        raise NotImplementedError
 
     @property
     def nan_triangle(self):
@@ -317,7 +330,8 @@ class TriangleBase(
         This becomes useful when managing array arithmetic.
         """
         xp = self.get_array_module()
-        if min(self.values.shape[2:]) == 1:
+#        if min(self.values.shape[2:]) == 1:
+        if self.is_pattern or self.is_ultimate:
             return xp.ones(self.values.shape[2:], dtype="float16")
         val_array = np.array(self.valuation).reshape(self.shape[-2:], order="f")
         nan_triangle = np.array(pd.DataFrame(val_array) > self.valuation_date)

--- a/chainladder/core/base.py
+++ b/chainladder/core/base.py
@@ -330,7 +330,6 @@ class TriangleBase(
         This becomes useful when managing array arithmetic.
         """
         xp = self.get_array_module()
-#        if min(self.values.shape[2:]) == 1:
         if self.is_pattern or self.is_ultimate:
             return xp.ones(self.values.shape[2:], dtype="float16")
         val_array = np.array(self.valuation).reshape(self.shape[-2:], order="f")

--- a/chainladder/core/base.py
+++ b/chainladder/core/base.py
@@ -315,12 +315,12 @@ class TriangleBase(
     
     @property
     @abstractmethod
-    def is_pattern(self):
+    def is_pattern(self) -> bool:
         raise NotImplementedError
         
     @property
     @abstractmethod
-    def is_ultimate(self):
+    def is_ultimate(self) -> bool:
         raise NotImplementedError
 
     @property

--- a/chainladder/core/tests/test_triangle.py
+++ b/chainladder/core/tests/test_triangle.py
@@ -950,3 +950,21 @@ def test_fillzero():
     zero = raa - raa[raa.origin=='1982']
     filled = zero.fillzero()
     assert (filled[filled.origin == '1982'][filled.development == 24].values.flatten()[0]) == 0
+    
+def test_2x2_triangle():
+        
+    df = pd.DataFrame(data={
+        'origin': [2022, 2022, 2023],
+        'development': [2022, 2023, 2023],
+        'reported': [78000, 222000, 78000]}
+    )
+    tri_from_df = cl.Triangle(
+        data=df,
+        origin='origin',
+        development='development',
+        columns=['reported'],
+        cumulative=True
+    )
+    tri_from_df
+    assert np.array_equal(tri_from_df.cum_to_incr().values,np.array([[[[ 78000., 144000.],
+    [ 78000., np.float64(np.nan)]]]]), equal_nan=True)

--- a/chainladder/core/triangle.py
+++ b/chainladder/core/triangle.py
@@ -251,7 +251,7 @@ class Triangle(TriangleBase):
 
         self.is_cumulative: bool = cumulative
         self.virtual_columns = VirtualColumns(self)
-        self.is_pattern: bool = pattern
+        self._pattern: bool = pattern
         
         split: list[str] = self.origin_grain.split("-")
         self.origin_grain: str = {"A": "Y", "2Q": "S"}.get(split[0], split[0])
@@ -483,6 +483,14 @@ class Triangle(TriangleBase):
         """
 
         return self.nan_triangle.sum().sum() == np.prod(self.shape[-2:])
+
+        
+    @property
+    def is_pattern(self):
+        return self._pattern
+    @is_pattern.setter
+    def is_pattern(self,pattern):
+        self._pattern = pattern
 
     @property
     def is_ultimate(self):

--- a/chainladder/core/triangle.py
+++ b/chainladder/core/triangle.py
@@ -486,14 +486,15 @@ class Triangle(TriangleBase):
 
         
     @property
-    def is_pattern(self):
+    def is_pattern(self) -> bool:
         return self._pattern
+        
     @is_pattern.setter
-    def is_pattern(self,pattern):
+    def is_pattern(self, pattern: bool):
         self._pattern = pattern
 
     @property
-    def is_ultimate(self):
+    def is_ultimate(self) ->  np.bool:
         return sum(self.valuation >= options.ULT_VAL[:4]) > 0
 
     @property


### PR DESCRIPTION
Fixes #692
1. Reimplemented `is_pattern` as a property in `Triangle`. Adds `_pattern` as an internal attribute.
2. Added the abstract properties `is_pattern` and `is_ultimate` to `TriangleBase`. `TriangleBase` is now an abstract class.
3. Changed `nan_triangle` to check explicitly for pattern/ultimate vectors, instead of checking for any 1D Triangles.

[see this post](https://github.com/casact/chainladder-python/issues/692#issuecomment-4260881040). `cum_to_incr()` mishandles 2x2 triangles because it passes `nan_triangle` a one dimensional triangle (corresponding to the latter development period), and receives back a full 1D triangle of ones. This causes `cum_to_incr()` to ignore valuation information and populate the lower right corner of the triangle with a negative incremental value. 

In addition to the test suite, I tested this PR with this snippet of code pulled from the issue discussion: 
```
import chainladder as cl
import pandas as pd

df = pd.DataFrame(data={
    'origin': [2022, 2022, 2023],
    'development': [2022, 2023, 2023],
    'reported': [78000, 222000, 78000]}
)

tri_from_df = cl.Triangle(
    data=df,
    origin='origin',
    development='development',
    columns=['reported'],
    cumulative=True
)

tri_from_df

tri_from_df.cum_to_incr()
```
I also ensured that development estimators that set is_pattern (e.g. ClarkLDF) continue to function properly. 

This PR will restrict `nan_triangle` to only return 1D triangles of ones for pattern and ultimate triangles. If I'm missing a case, please let me know.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core triangle masking used across arithmetic and conversions, so it may subtly change results for pattern/ultimate workflows even though coverage includes a targeted regression test.
> 
> **Overview**
> Fixes a `cum_to_incr()` regression on 2x2 triangles by changing `nan_triangle` to return an all-ones mask **only** for pattern vectors and ultimate vectors, rather than for any 1D triangle.
> 
> Promotes `TriangleBase` to an abstract base class by requiring `is_pattern`/`is_ultimate` properties, and reworks `Triangle.is_pattern` to use an internal `_pattern` attribute with a property/setter. Adds a regression test covering the 2x2 conversion case.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a25ea4c88a4fa5ca4b66d5abdbb5f506898adf34. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->