### PR TITLE
FEAT: Initialize triangle from dict.

### DIFF
--- a/chainladder/core/tests/test_triangle.py
+++ b/chainladder/core/tests/test_triangle.py
@@ -968,3 +968,40 @@ def test_2x2_triangle():
     tri_from_df
     assert np.array_equal(tri_from_df.cum_to_incr().values,np.array([[[[ 78000., 144000.],
     [ 78000., np.float64(np.nan)]]]]), equal_nan=True)
+
+
+def test_triangle_init_from_dict() -> None:
+    """
+    Tests the initialization of a triangle by supplying a dict to the data parameter. The triangle
+    created should be equal to that of one created with a pandas DataFrame containing the same data.
+    """
+
+    # Common data.
+    data_dict = {
+            'origin': [1981, 1981, 1981, 1981, 1982, 1982, 1982, 1983, 1983, 1984],
+            'development': [1981, 1982, 1983, 1984, 1982, 1983, 1984, 1983, 1984, 1984],
+            'reported': [5012, 8269, 10907, 11805, 106, 4285, 5396, 3410, 8992, 5655]
+    }
+
+    # Initialze via DataFrame.
+    df = pd.DataFrame(
+        data=data_dict
+    )
+    tri_from_df = cl.Triangle(
+        data=df,
+        origin='origin',
+        development='development',
+        columns=['reported'],
+        cumulative=True
+    )
+
+    # Initialize via dict.
+    tri_from_dict = cl.Triangle(
+        data=data_dict,
+        origin='origin',
+        development='development',
+        columns=['reported'],
+        cumulative=True
+    )
+
+    assert tri_from_df == tri_from_dict

--- a/chainladder/core/triangle.py
+++ b/chainladder/core/triangle.py
@@ -35,12 +35,13 @@ class Triangle(TriangleBase):
 
     Parameters
     ----------
-    data: DataFrame or DataFrameXchg
+    data: DataFrame or DataFrameXchg, or dict
         A single dataframe that contains columns representing all other
         arguments to the Triangle constructor. If using pandas version > 1.5.2,
         one may supply a DataFrame-like object (referred to as DataFrameXchg)
         supporting the __dataframe__ protocol, which will then be converted to
-        a pandas DataFrame.
+        a pandas DataFrame. If supplying a dict, it must be structured such that
+        a pandas DataFrame created from it will be accepted by the constructor.
     origin: str or list
          A representation of the accident, reporting or more generally the
          origin period of the triangle that will map to the Origin dimension
@@ -175,7 +176,7 @@ class Triangle(TriangleBase):
 
     def __init__(
         self,
-        data: Optional[DataFrame | DataFrameXchg] = None,
+        data: Optional[DataFrame | DataFrameXchg | dict] = None,
         origin: Optional[str | list] = None,
         development: Optional[str | list] = None,
         columns: Optional[str | list] = None,
@@ -193,6 +194,8 @@ class Triangle(TriangleBase):
         # If data are present, validate the dimensions.
         if data is None:
             return
+        elif type(data) == dict:
+            data = pd.DataFrame(data)
         elif not isinstance(data, pd.DataFrame) and hasattr(data, "__dataframe__"):
             data = self._interchange_dataframe(data)
         index, columns, origin, development = self._input_validation(


### PR DESCRIPTION
Enables the initialization of a triangle via data supplied in a dictionary. Closes #701.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: change is limited to accepting `dict` input by converting it to a pandas `DataFrame`, plus a unit test to confirm parity with existing DataFrame initialization.
> 
> **Overview**
> `Triangle` now accepts a Python `dict` for the `data` argument by converting it to a pandas `DataFrame` during initialization.
> 
> Adds a regression test (`test_triangle_init_from_dict`) asserting a dict-backed triangle is equal to one built from an equivalent DataFrame, and updates the constructor docstring/type hints accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1b0a7a80c452b073df39bbf6356440c12580f4d6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->