### PR TITLE
CHORE: Update workflows to test docs examples.

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -36,3 +36,17 @@ jobs:
           flags: unittests
           name: codecov-umbrella
           fail_ci_if_error: false
+  doctest:
+    name: Doctest (ubuntu-latest, 3.12)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          version: "latest"
+          python-version: "3.12"
+      - name: Install dependencies
+        run: uv sync --extra docs
+      - name: Run doctests
+        run: cd docs && uv run jb build . --builder=custom --custom-builder=doctest

--- a/chainladder/core/slice.py
+++ b/chainladder/core/slice.py
@@ -21,7 +21,7 @@ class _LocBase:
     def __init__(self, obj):
         self.obj = obj
 
-    def get_idx(self, idx):
+    def get_idx(self, idx: tuple):
         """ Returns a slice of the original Triangle """
         obj = self.obj.copy()
         i_idx = _LocBase._contig_slice(idx[0])
@@ -74,8 +74,8 @@ class _LocBase:
         )
         self.obj.values.__setitem__(self._normalize_index(key), values)
 
-    def _normalize_index(self, key):
-        key = _slicing.normalize_index(key, self.obj.shape)
+    def _normalize_index(self, key: tuple) -> tuple:
+        key: tuple = _slicing.normalize_index(key, self.obj.shape)
         l = []
         for n, i in enumerate(key):
             if type(i) is slice:
@@ -183,7 +183,7 @@ class Ilocation(_LocBase):
     Class to generate .iloc[] functionality.
     """
 
-    def __getitem__(self, key):
+    def __getitem__(self, key: tuple):
         return self.get_idx(self._normalize_index(key))
 
     def __setitem__(self, key, values):
@@ -208,7 +208,8 @@ class TriangleSlicer:
                 out = self.virtual_columns[key].copy()
                 out.virtual_columns.columns = {}
                 return out
-            key = [key] if not hasattr(key, '__iter__') or type(key) is str else key
+            key: list = [key] if not hasattr(key, '__iter__') or type(key) is str else key
+            # Identify the position of each requested element within the valuation dimension.
             idx = [list(self.vdims).index(item) for item in key]
             return self.iloc[:, idx]
 

--- a/chainladder/core/triangle.py
+++ b/chainladder/core/triangle.py
@@ -124,10 +124,12 @@ class Triangle(TriangleBase):
 
     Constructing a Triangle from a Pandas DataFrame.
 
-    .. testsetup:
+    .. testsetup::
+
         import chainladder as cl
 
-    .. testcode:
+    .. testcode::
+
         import pandas as pd
         df = pd.DataFrame(
             data={
@@ -145,7 +147,8 @@ class Triangle(TriangleBase):
         )
         print(tr)
 
-    .. testoutput:
+    .. testoutput::
+
                   12      24       36       48
         1981  5012.0  8269.0  10907.0  11805.0
         1982   106.0  4285.0   5396.0      NaN
@@ -156,7 +159,7 @@ class Triangle(TriangleBase):
     becomes multidimensional. In this case, printing displays the Triangle's
     metadata rather than its contents.
 
-    .. testcode:
+    .. testcode::
 
         df = pd.DataFrame(
             data={
@@ -175,7 +178,7 @@ class Triangle(TriangleBase):
         )
         print(tr)
 
-    .. testoutput:
+    .. testoutput::
 
                     Triangle Summary
         Valuation:           1984-12
@@ -187,7 +190,7 @@ class Triangle(TriangleBase):
     Using the ``index`` parameter creates a multi-dimensional Triangle split by a
     categorical grouping, for example Line of Business.
 
-.. testcode:
+.. testcode::
 
         df = pd.DataFrame(
             data={
@@ -207,7 +210,7 @@ class Triangle(TriangleBase):
         )
         print(tr)
 
-    .. testoutput:
+    .. testoutput::
 
                    Triangle Summary
         Valuation:          2021-12
@@ -219,7 +222,7 @@ class Triangle(TriangleBase):
     Non-standard date strings can be parsed by specifying ``origin_format`` and
     ``development_format`` using Python ``strftime`` codes.
 
-    .. testcode:
+    .. testcode::
 
         df = pd.DataFrame(
             data={
@@ -239,7 +242,7 @@ class Triangle(TriangleBase):
         )
         print(tr)
 
-    .. testoutput:
+    .. testoutput::
 
                      1      2   3
         2020-01  100.0  150.0 NaN
@@ -250,7 +253,7 @@ class Triangle(TriangleBase):
     is the amount accrued within that development period rather than the
     cumulative total to date.
 
-    .. testcode:
+    .. testcode::
 
         df = pd.DataFrame(
             data={
@@ -278,7 +281,7 @@ class Triangle(TriangleBase):
     ``trailing=True`` instead infers the period end from the data itself,
     producing quarters aligned to the origin dates.
 
-    .. testcode:
+    .. testcode::
 
         df = pd.DataFrame(
             data={
@@ -299,7 +302,7 @@ class Triangle(TriangleBase):
         )
         print(tr)
 
-    .. testoutput:
+    .. testoutput::
 
                 2024-04
         2023Q2    100.0
@@ -308,7 +311,7 @@ class Triangle(TriangleBase):
         2024Q1    140.0
         2024Q2      NaN
 
-    .. testcode:
+    .. testcode::
 
         tr = cl.Triangle(
             data=df,
@@ -322,7 +325,7 @@ class Triangle(TriangleBase):
         )
         print(tr)
 
-    .. testouput:
+    .. testouput::
 
                 2024Q2
         2024Q1   100.0

--- a/chainladder/core/triangle.py
+++ b/chainladder/core/triangle.py
@@ -270,6 +270,9 @@ class Triangle(TriangleBase):
             cumulative=False,
         )
         print(tr)
+
+    .. testoutput::
+    
                   12      24      36     48
         1981  5012.0  3257.0  2638.0  898.0
         1982   106.0  4179.0  1111.0    NaN

--- a/chainladder/core/triangle.py
+++ b/chainladder/core/triangle.py
@@ -190,7 +190,7 @@ class Triangle(TriangleBase):
     Using the ``index`` parameter creates a multi-dimensional Triangle split by a
     categorical grouping, for example Line of Business.
 
-.. testcode::
+    .. testcode::
 
         df = pd.DataFrame(
             data={

--- a/chainladder/core/triangle.py
+++ b/chainladder/core/triangle.py
@@ -272,7 +272,7 @@ class Triangle(TriangleBase):
         print(tr)
 
     .. testoutput::
-    
+
                   12      24      36     48
         1981  5012.0  3257.0  2638.0  898.0
         1982   106.0  4179.0  1111.0    NaN
@@ -328,7 +328,7 @@ class Triangle(TriangleBase):
         )
         print(tr)
 
-    .. testouput::
+    .. testoutput::
 
                 2024Q2
         2024Q1   100.0

--- a/chainladder/core/triangle.py
+++ b/chainladder/core/triangle.py
@@ -122,23 +122,31 @@ class Triangle(TriangleBase):
 
     Constructing a Triangle from a Pandas DataFrame.
 
-    >>> import chainladder as cl
-    >>> import pandas as pd
-    >>> df = pd.DataFrame(
+    .. testsetup::
+
+        import chainladder as cl
+        import pandas as pd
+
+    .. testcode::
+
+        df = pd.DataFrame(
             data={
                 'origin': [1981, 1981, 1981, 1981, 1982, 1982, 1982, 1983, 1983, 1984],
                 'development': [1981, 1982, 1983, 1984, 1982, 1983, 1984, 1983, 1984, 1984],
                 'reported': [5012, 8269, 10907, 11805, 106, 4285, 5396, 3410, 8992, 5655]
             }
         )
-    >>> tr = cl.Triangle(
+        tr = cl.Triangle(
             data=df,
             origin='origin',
             development='development',
             columns=['reported'],
             cumulative=True
         )
-    >>> tr
+        print(tr)
+
+    .. testoutput::
+
                   12      24       36       48
         1981  5012.0  8269.0  10907.0  11805.0
         1982   106.0  4285.0   5396.0      NaN
@@ -148,7 +156,9 @@ class Triangle(TriangleBase):
     When another dimension is added, such an additional column, the Triangle becomes multidimensional. In this case,
     printing displays the Triangle's metadata, rather than its contents.
 
-    >>> df = pd.DataFrame(
+    .. testcode::
+
+        df = pd.DataFrame(
             data={
                 'origin': [1981, 1981, 1981, 1981, 1982, 1982, 1982, 1983, 1983, 1984],
                 'development': [1981, 1982, 1983, 1984, 1982, 1983, 1984, 1983, 1984, 1984],
@@ -157,14 +167,17 @@ class Triangle(TriangleBase):
             }
         )
 
-    >>> tr = cl.Triangle(
+        tr = cl.Triangle(
             data=df,
             origin='origin',
             development='development',
             columns=['reported', 'paid'],
             cumulative=True
         )
-    >>> tr
+        print(tr)
+
+    .. testoutput::
+
                     Triangle Summary
         Valuation:           1984-12
         Grain:                  OYDY

--- a/chainladder/core/triangle.py
+++ b/chainladder/core/triangle.py
@@ -124,177 +124,211 @@ class Triangle(TriangleBase):
 
     Constructing a Triangle from a Pandas DataFrame.
 
-    >>> df = pd.DataFrame(
-    ...     data={
-    ...         'origin': [1981, 1981, 1981, 1981, 1982, 1982, 1982, 1983, 1983, 1984],
-    ...         'development': [1981, 1982, 1983, 1984, 1982, 1983, 1984, 1983, 1984, 1984],
-    ...         'reported': [5012, 8269, 10907, 11805, 106, 4285, 5396, 3410, 8992, 5655],
-    ...     }
-    ... )
-    >>> tr = cl.Triangle(
-    ...     data=df,
-    ...     origin='origin',
-    ...     development='development',
-    ...     columns=['reported'],
-    ...     cumulative=True,
-    ... )
-    >>> tr
-              12      24       36       48
-    1981  5012.0  8269.0  10907.0  11805.0
-    1982   106.0  4285.0   5396.0      NaN
-    1983  3410.0  8992.0      NaN      NaN
-    1984  5655.0     NaN      NaN      NaN
+    .. testsetup:
+        import chainladder as cl
+
+    .. testcode:
+        import pandas as pd
+        df = pd.DataFrame(
+            data={
+                'origin': [1981, 1981, 1981, 1981, 1982, 1982, 1982, 1983, 1983, 1984],
+                'development': [1981, 1982, 1983, 1984, 1982, 1983, 1984, 1983, 1984, 1984],
+                'reported': [5012, 8269, 10907, 11805, 106, 4285, 5396, 3410, 8992, 5655],
+            }
+        )
+        tr = cl.Triangle(
+            data=df,
+            origin='origin',
+            development='development',
+            columns=['reported'],
+            cumulative=True,
+        )
+        print(tr)
+
+    .. testoutput:
+                  12      24       36       48
+        1981  5012.0  8269.0  10907.0  11805.0
+        1982   106.0  4285.0   5396.0      NaN
+        1983  3410.0  8992.0      NaN      NaN
+        1984  5655.0     NaN      NaN      NaN
 
     When another dimension is added, such as an additional column, the Triangle
     becomes multidimensional. In this case, printing displays the Triangle's
     metadata rather than its contents.
 
-    >>> df = pd.DataFrame(
-    ...     data={
-    ...         'origin': [1981, 1981, 1981, 1981, 1982, 1982, 1982, 1983, 1983, 1984],
-    ...         'development': [1981, 1982, 1983, 1984, 1982, 1983, 1984, 1983, 1984, 1984],
-    ...         'reported': [5012, 8269, 10907, 11805, 106, 4285, 5396, 3410, 8992, 5655],
-    ...         'paid': [2506, 4135, 5454, 5903, 53, 2143, 2698, 1705, 4496, 2828],
-    ...     }
-    ... )
-    >>> tr = cl.Triangle(
-    ...     data=df,
-    ...     origin='origin',
-    ...     development='development',
-    ...     columns=['reported', 'paid'],
-    ...     cumulative=True,
-    ... )
-    >>> tr
-                Triangle Summary
-    Valuation:           1984-12
-    Grain:                  OYDY
-    Shape:          (1, 2, 4, 4)
-    Index:               [Total]
-    Columns:    [reported, paid]
+    .. testcode:
+
+        df = pd.DataFrame(
+            data={
+                'origin': [1981, 1981, 1981, 1981, 1982, 1982, 1982, 1983, 1983, 1984],
+                'development': [1981, 1982, 1983, 1984, 1982, 1983, 1984, 1983, 1984, 1984],
+                'reported': [5012, 8269, 10907, 11805, 106, 4285, 5396, 3410, 8992, 5655],
+                'paid': [2506, 4135, 5454, 5903, 53, 2143, 2698, 1705, 4496, 2828],
+            }
+        )
+        tr = cl.Triangle(
+            data=df,
+            origin='origin',
+            development='development',
+            columns=['reported', 'paid'],
+            cumulative=True,
+        )
+        print(tr)
+
+    .. testoutput:
+
+                    Triangle Summary
+        Valuation:           1984-12
+        Grain:                  OYDY
+        Shape:          (1, 2, 4, 4)
+        Index:               [Total]
+        Columns:    [reported, paid]
 
     Using the ``index`` parameter creates a multi-dimensional Triangle split by a
     categorical grouping, for example Line of Business.
 
-    >>> df = pd.DataFrame(
-    ...     data={
-    ...         'lob': ['auto', 'auto', 'auto', 'home', 'home', 'home'],
-    ...         'origin': [2020, 2020, 2021, 2020, 2020, 2021],
-    ...         'development': [2020, 2021, 2021, 2020, 2021, 2021],
-    ...         'reported': [100, 150, 80, 200, 280, 160],
-    ...     }
-    ... )
-    >>> tr = cl.Triangle(
-    ...     data=df,
-    ...     origin='origin',
-    ...     development='development',
-    ...     columns=['reported'],
-    ...     index=['lob'],
-    ...     cumulative=True,
-    ... )
-    >>> tr
-               Triangle Summary
-    Valuation:          2021-12
-    Grain:                 OYDY
-    Shape:         (2, 1, 2, 2)
-    Index:                [lob]
-    Columns:         [reported]
+.. testcode:
+
+        df = pd.DataFrame(
+            data={
+                 'lob': ['auto', 'auto', 'auto', 'home', 'home', 'home'],
+                'origin': [2020, 2020, 2021, 2020, 2020, 2021],
+                'development': [2020, 2021, 2021, 2020, 2021, 2021],
+                'reported': [100, 150, 80, 200, 280, 160],
+            }
+        )
+        tr = cl.Triangle(
+            data=df,
+            origin='origin',
+            development='development',
+            columns=['reported'],
+            index=['lob'],
+            cumulative=True,
+        )
+        print(tr)
+
+    .. testoutput:
+
+                   Triangle Summary
+        Valuation:          2021-12
+        Grain:                 OYDY
+        Shape:         (2, 1, 2, 2)
+        Index:                [lob]
+        Columns:         [reported]
 
     Non-standard date strings can be parsed by specifying ``origin_format`` and
     ``development_format`` using Python ``strftime`` codes.
 
-    >>> df = pd.DataFrame(
-    ...     data={
-    ...         'origin': ['2020-01', '2020-01', '2020-02', '2020-02'],
-    ...         'development': ['2020-01', '2020-02', '2020-02', '2020-03'],
-    ...         'reported': [100, 150, 200, 280],
-    ...     }
-    ... )
-    >>> tr = cl.Triangle(
-    ...     data=df,
-    ...     origin='origin',
-    ...     origin_format='%Y-%m',
-    ...     development='development',
-    ...     development_format='%Y-%m',
-    ...     columns=['reported'],
-    ...     cumulative=True,
-    ... )
-    >>> tr
-                 1      2   3
-    2020-01  100.0  150.0 NaN
-    2020-02  200.0  280.0 NaN
-    2020-03    NaN    NaN NaN
+    .. testcode:
+
+        df = pd.DataFrame(
+            data={
+                'origin': ['2020-01', '2020-01', '2020-02', '2020-02'],
+                'development': ['2020-01', '2020-02', '2020-02', '2020-03'],
+                'reported': [100, 150, 200, 280],
+            }
+        )
+        tr = cl.Triangle(
+            data=df,
+            origin='origin',
+            origin_format='%Y-%m',
+            development='development',
+            development_format='%Y-%m',
+            columns=['reported'],
+            cumulative=True,
+        )
+        print(tr)
+
+    .. testoutput:
+
+                     1      2   3
+        2020-01  100.0  150.0 NaN
+        2020-02  200.0  280.0 NaN
+        2020-03    NaN    NaN NaN
 
     Setting ``cumulative=False`` builds an incremental Triangle, where each cell
     is the amount accrued within that development period rather than the
     cumulative total to date.
 
-    >>> df = pd.DataFrame(
-    ...     data={
-    ...         'origin': [1981, 1981, 1981, 1981, 1982, 1982, 1982, 1983, 1983, 1984],
-    ...         'development': [1981, 1982, 1983, 1984, 1982, 1983, 1984, 1983, 1984, 1984],
-    ...         'reported': [5012, 3257, 2638, 898, 106, 4179, 1111, 3410, 5582, 5655],
-    ...     }
-    ... )
-    >>> tr = cl.Triangle(
-    ...     data=df,
-    ...     origin='origin',
-    ...     development='development',
-    ...     columns=['reported'],
-    ...     cumulative=False,
-    ... )
-    >>> tr
-              12      24      36     48
-    1981  5012.0  3257.0  2638.0  898.0
-    1982   106.0  4179.0  1111.0    NaN
-    1983  3410.0  5582.0     NaN    NaN
-    1984  5655.0     NaN     NaN    NaN
+    .. testcode:
+
+        df = pd.DataFrame(
+            data={
+                'origin': [1981, 1981, 1981, 1981, 1982, 1982, 1982, 1983, 1983, 1984],
+                'development': [1981, 1982, 1983, 1984, 1982, 1983, 1984, 1983, 1984, 1984],
+                'reported': [5012, 3257, 2638, 898, 106, 4179, 1111, 3410, 5582, 5655],
+            }
+        )
+        tr = cl.Triangle(
+            data=df,
+            origin='origin',
+            development='development',
+            columns=['reported'],
+            cumulative=False,
+        )
+        print(tr)
+                  12      24      36     48
+        1981  5012.0  3257.0  2638.0  898.0
+        1982   106.0  4179.0  1111.0    NaN
+        1983  3410.0  5582.0     NaN    NaN
+        1984  5655.0     NaN     NaN    NaN
 
     By default (``trailing=False``), chainladder uses December as the fiscal
     period end, so origin dates are assigned to calendar quarters. Setting
     ``trailing=True`` instead infers the period end from the data itself,
     producing quarters aligned to the origin dates.
 
-    >>> df = pd.DataFrame(
-    ...     data={
-    ...         'origin': ['2023-05', '2023-08', '2023-11', '2024-02'],
-    ...         'development': ['2024-04', '2024-04', '2024-04', '2024-04'],
-    ...         'premium': [100, 130, 160, 140],
-    ...     }
-    ... )
-    >>> tr = cl.Triangle(
-    ...     data=df,
-    ...     origin='origin',
-    ...     origin_format='%Y-%m',
-    ...     development='development',
-    ...     development_format='%Y-%m',
-    ...     columns=['premium'],
-    ...     cumulative=True,
-    ...     trailing=False,
-    ... )
-    >>> tr
-            2024-04
-    2023Q2    100.0
-    2023Q3    130.0
-    2023Q4    160.0
-    2024Q1    140.0
-    2024Q2      NaN
+    .. testcode:
 
-    >>> tr = cl.Triangle(
-    ...     data=df,
-    ...     origin='origin',
-    ...     origin_format='%Y-%m',
-    ...     development='development',
-    ...     development_format='%Y-%m',
-    ...     columns=['premium'],
-    ...     cumulative=True,
-    ...     trailing=True,
-    ... )
-    >>> tr
-            2024Q2
-    2024Q1   100.0
-    2024Q2   130.0
-    2024Q3   160.0
-    2024Q4   140.0
+        df = pd.DataFrame(
+            data={
+                'origin': ['2023-05', '2023-08', '2023-11', '2024-02'],
+                'development': ['2024-04', '2024-04', '2024-04', '2024-04'],
+                'premium': [100, 130, 160, 140],
+            }
+        )
+        tr = cl.Triangle(
+            data=df,
+            origin='origin',
+            origin_format='%Y-%m',
+            development='development',
+            development_format='%Y-%m',
+            columns=['premium'],
+            cumulative=True,
+            trailing=False,
+        )
+        print(tr)
+
+    .. testoutput:
+
+                2024-04
+        2023Q2    100.0
+        2023Q3    130.0
+        2023Q4    160.0
+        2024Q1    140.0
+        2024Q2      NaN
+
+    .. testcode:
+
+        tr = cl.Triangle(
+            data=df,
+            origin='origin',
+            origin_format='%Y-%m',
+            development='development',
+            development_format='%Y-%m',
+            columns=['premium'],
+            cumulative=True,
+            trailing=True,
+        )
+        print(tr)
+
+    .. testouput:
+
+                2024Q2
+        2024Q1   100.0
+        2024Q2   130.0
+        2024Q3   160.0
+        2024Q4   140.0
     """
 
     def __init__(

--- a/chainladder/development/clark.py
+++ b/chainladder/development/clark.py
@@ -1,20 +1,27 @@
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
+from __future__ import annotations
 from chainladder.development.base import DevelopmentBase
 import numpy as np
 import pandas as pd
 from scipy.optimize import minimize
 
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:  # pragma: no cover
+    from numpy import ndarray
+    from types import ModuleType
+
 
 class ClarkLDF(DevelopmentBase):
-    """ A Estimator that allows for curve fitting development pattterns according
+    """An Estimator that allows for curve fitting development patterns according
     to Clark 2003.
 
     The method fits incremental triangle amounts to one of
-    ``loglogistic`` or ``weibull`` growth curves.  Both Clarks methods, LDF and Cape
+    "loglogistic" or "weibull" growth curves.  Both of Clark's methods, LDF and Cape
     Cod, can be estimated.  To invoke the Cape Cod method, include
-    ``sample_weight`` in when fitting the estimator.
+    "sample_weight" in when fitting the estimator.
 
 
     Parameters
@@ -49,13 +56,32 @@ class ClarkLDF(DevelopmentBase):
 
     """
 
-    def __init__(self, growth="loglogistic", groupby=None):
-        self.growth = growth
+    def __init__(
+            self,
+            growth: str = "loglogistic",
+            groupby=None
+    ):
+        self.growth: str = growth
         self.groupby = groupby
 
-    def _G(self, age, theta=None, omega=None):
-        """ Growth function """
-        xp = self.incremental_act_.get_array_module()
+    def _G(
+            self,
+            age,
+            theta: float = None,
+            omega: float = None
+    ):
+        """Growth function.
+
+        Parameters
+        ----------
+
+        theta: float
+            The scale parameter of the growth function.
+        omega: float
+            The shape, or "warp" parameter of the growth function.
+
+        """
+        xp: ModuleType = self.incremental_act_.get_array_module()
         if theta is None:
             theta = self.theta_.values[..., None, None]
         if omega is None:
@@ -67,7 +93,7 @@ class ClarkLDF(DevelopmentBase):
             out = 1 / (1 - xp.exp(-((age / theta) ** omega)))
         else:
             ValueError(str(self.growth) + "is an invalid growth curve.")
-        out[xp.isnan(out)] = xp.inf
+        out[xp.isnan(out)] = xp.inf # noqa
         return out
 
     def G_(self, age):
@@ -155,7 +181,7 @@ class ClarkLDF(DevelopmentBase):
             idx_params = []
             for col in range(len(X.columns)):
 
-                def solver(x):
+                def solver(x: ndarray):
                     """ Solve Loglogistic MLE"""
                     ldf = lambda age: self._G(age, theta=x[..., 1], omega=x[..., 0])
                     if sample_weight:

--- a/chainladder/development/clark.py
+++ b/chainladder/development/clark.py
@@ -1,20 +1,27 @@
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
+from __future__ import annotations
 from chainladder.development.base import DevelopmentBase
 import numpy as np
 import pandas as pd
 from scipy.optimize import minimize
 
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from numpy import ndarray
+    from types import ModuleType
+
 
 class ClarkLDF(DevelopmentBase):
-    """ A Estimator that allows for curve fitting development pattterns according
+    """An Estimator that allows for curve fitting development patterns according
     to Clark 2003.
 
     The method fits incremental triangle amounts to one of
-    ``loglogistic`` or ``weibull`` growth curves.  Both Clarks methods, LDF and Cape
+    "loglogistic" or "weibull" growth curves.  Both of Clark's methods, LDF and Cape
     Cod, can be estimated.  To invoke the Cape Cod method, include
-    ``sample_weight`` in when fitting the estimator.
+    "sample_weight" in when fitting the estimator.
 
 
     Parameters
@@ -49,13 +56,32 @@ class ClarkLDF(DevelopmentBase):
 
     """
 
-    def __init__(self, growth="loglogistic", groupby=None):
-        self.growth = growth
+    def __init__(
+            self,
+            growth: str = "loglogistic",
+            groupby=None
+    ):
+        self.growth: str = growth
         self.groupby = groupby
 
-    def _G(self, age, theta=None, omega=None):
-        """ Growth function """
-        xp = self.incremental_act_.get_array_module()
+    def _G(
+            self,
+            age,
+            theta: float = None,
+            omega: float = None
+    ):
+        """Growth function.
+
+        Parameters
+        ----------
+
+        theta: float
+            The scale parameter of the growth function.
+        omega: float
+            The shape, or "warp" parameter of the growth function.
+
+        """
+        xp: ModuleType = self.incremental_act_.get_array_module()
         if theta is None:
             theta = self.theta_.values[..., None, None]
         if omega is None:
@@ -67,7 +93,7 @@ class ClarkLDF(DevelopmentBase):
             out = 1 / (1 - xp.exp(-((age / theta) ** omega)))
         else:
             ValueError(str(self.growth) + "is an invalid growth curve.")
-        out[xp.isnan(out)] = xp.inf
+        out[xp.isnan(out)] = xp.inf # noqa
         return out
 
     def G_(self, age):
@@ -155,7 +181,7 @@ class ClarkLDF(DevelopmentBase):
             idx_params = []
             for col in range(len(X.columns)):
 
-                def solver(x):
+                def solver(x: ndarray):
                     """ Solve Loglogistic MLE"""
                     ldf = lambda age: self._G(age, theta=x[..., 1], omega=x[..., 0])
                     if sample_weight:

--- a/chainladder/development/clark.py
+++ b/chainladder/development/clark.py
@@ -9,7 +9,7 @@ from scipy.optimize import minimize
 
 from typing import TYPE_CHECKING
 
-if TYPE_CHECKING:
+if TYPE_CHECKING:  # pragma: no cover
     from numpy import ndarray
     from types import ModuleType
 

--- a/chainladder/methods/benktander.py
+++ b/chainladder/methods/benktander.py
@@ -126,10 +126,19 @@ class Benktander(MethodBase):
         Fit returns the estimator itself, with ``ultimate_`` populated. The
         repr shows non-default parameters.
 
-        >>> tr = cl.load_sample('ukmotor')
-        >>> apriori = cl.Chainladder().fit(tr).ultimate_ * 0 + 14000
-        >>> cl.Benktander(apriori=1.0, n_iters=2).fit(tr, sample_weight=apriori)
-        Benktander(n_iters=2)
+        .. testsetup::
+
+            import chainladder as cl
+
+        .. testcode::
+
+            tr = cl.load_sample('ukmotor')
+            apriori = cl.Chainladder().fit(tr).ultimate_ * 0 + 14000
+            print(cl.Benktander(apriori=1.0, n_iters=2).fit(tr, sample_weight=apriori))
+
+        .. testoutput::
+
+            Benktander(n_iters=2)
         """
         if sample_weight is None:
             raise ValueError("sample_weight is required.")
@@ -159,22 +168,31 @@ class Benktander(MethodBase):
         Fit on a prior-period view of the data, then apply the model to the
         current Triangle and a refreshed apriori.
 
-        >>> tr = cl.load_sample('ukmotor')
-        >>> tr_prior = tr[tr.valuation < tr.valuation_date]
-        >>> apriori_prior = cl.Chainladder().fit(tr_prior).ultimate_ * 0 + 14000
-        >>> apriori = cl.Chainladder().fit(tr).ultimate_ * 0 + 14000
-        >>> model = cl.Benktander(apriori=1.0, n_iters=2).fit(
-        ...     tr_prior, sample_weight=apriori_prior
-        ... )
-        >>> model.predict(tr, sample_weight=apriori).ultimate_
-                      2261
-        2007  12690.000000
-        2008  12746.000000
-        2009  13642.189922
-        2010  12740.812082
-        2011  13516.188545
-        2012  15914.716737
-        2013  17193.715555
+        .. testsetup::
+            import chainladder as cl
+
+        .. testcode::
+
+            tr = cl.load_sample('ukmotor')
+            tr_prior = tr[tr.valuation < tr.valuation_date]
+            apriori_prior = cl.Chainladder().fit(tr_prior).ultimate_ * 0 + 14000
+            apriori = cl.Chainladder().fit(tr).ultimate_ * 0 + 14000
+            model = cl.Benktander(apriori=1.0, n_iters=2).fit(
+                tr_prior, sample_weight=apriori_prior
+            )
+
+            print(model.predict(tr, sample_weight=apriori).ultimate_)
+
+        .. testoutput::
+
+                          2261
+            2007  12690.000000
+            2008  12746.000000
+            2009  13642.189922
+            2010  12740.812082
+            2011  13516.188545
+            2012  15914.716737
+            2013  17193.715555
         """
         X_new = super().predict(X, sample_weight)
         X_new.expectation_ = self._get_benktander_aprioris(X, sample_weight)

--- a/chainladder/methods/benktander.py
+++ b/chainladder/methods/benktander.py
@@ -43,17 +43,18 @@ class Benktander(MethodBase):
     (``n_iters=1``) and chainladder (``n_iters`` large): each additional
     iteration shifts the ultimate further toward the chainladder estimate.
 
-    .. testsetup:
+    .. testsetup::
+
         import chainladder as cl
 
-    .. testcode:
+    .. testcode::
 
         tr = cl.load_sample('ukmotor')
         apriori = cl.Chainladder().fit(tr).ultimate_ * 0 + 14000
 
     With ``n_iters=1`` Benktander reproduces Bornhuetter-Ferguson exactly.
 
-    .. testcode:
+    .. testcode::
 
         print(
             cl.Benktander(apriori=1.0, n_iters=1).fit(
@@ -61,7 +62,7 @@ class Benktander(MethodBase):
             ).ultimate_
         )
 
-    .. testoutput:
+    .. testoutput::
 
                       2261
         2007  12690.000000
@@ -77,7 +78,7 @@ class Benktander(MethodBase):
     rising to ``19110`` at ``n_iters=4`` and approaching the chainladder
     ultimate of ``20680``.
 
-    .. testcode:
+    .. testcode::
 
         print(
             cl.Benktander(apriori=1.0, n_iters=4).fit(
@@ -85,7 +86,7 @@ class Benktander(MethodBase):
             ).ultimate_
         )
 
-    .. testoutput:
+    .. testoutput::
 
                       2261
         2007  12690.000000

--- a/chainladder/methods/benktander.py
+++ b/chainladder/methods/benktander.py
@@ -43,39 +43,58 @@ class Benktander(MethodBase):
     (``n_iters=1``) and chainladder (``n_iters`` large): each additional
     iteration shifts the ultimate further toward the chainladder estimate.
 
-    >>> tr = cl.load_sample('ukmotor')
-    >>> apriori = cl.Chainladder().fit(tr).ultimate_ * 0 + 14000
+    .. testsetup:
+        import chainladder as cl
+
+    .. testcode:
+
+        tr = cl.load_sample('ukmotor')
+        apriori = cl.Chainladder().fit(tr).ultimate_ * 0 + 14000
 
     With ``n_iters=1`` Benktander reproduces Bornhuetter-Ferguson exactly.
 
-    >>> cl.Benktander(apriori=1.0, n_iters=1).fit(
-    ...     tr, sample_weight=apriori
-    ... ).ultimate_
-                  2261
-    2007  12690.000000
-    2008  13121.098503
-    2009  14028.278620
-    2010  13272.048822
-    2011  13911.968891
-    2012  15614.145287
-    2013  16029.501746
+    .. testcode:
+
+        print(
+            cl.Benktander(apriori=1.0, n_iters=1).fit(
+                tr, sample_weight=apriori
+            ).ultimate_
+        )
+
+    .. testoutput:
+
+                      2261
+        2007  12690.000000
+        2008  13121.098503
+        2009  14028.278620
+        2010  13272.048822
+        2011  13911.968891
+        2012  15614.145287
+        2013  16029.501746
 
     Increasing ``n_iters`` pulls the immature origins toward the chainladder
     estimate. The 2013 origin shows this most: ``16029`` at ``n_iters=1``,
     rising to ``19110`` at ``n_iters=4`` and approaching the chainladder
     ultimate of ``20680``.
 
-    >>> cl.Benktander(apriori=1.0, n_iters=4).fit(
-    ...     tr, sample_weight=apriori
-    ... ).ultimate_
-                  2261
-    2007  12690.000000
-    2008  13096.902490
-    2009  14030.535854
-    2010  13138.365841
-    2011  13880.984774
-    2012  16719.527550
-    2013  19110.806503
+    .. testcode:
+
+        print(
+            cl.Benktander(apriori=1.0, n_iters=4).fit(
+                tr, sample_weight=apriori
+            ).ultimate_
+        )
+
+    .. testoutput:
+
+                      2261
+        2007  12690.000000
+        2008  13096.902490
+        2009  14030.535854
+        2010  13138.365841
+        2011  13880.984774
+        2012  16719.527550
+        2013  19110.806503
     """
 
     def __init__(self, apriori=1.0, n_iters=1, apriori_sigma=0, random_state=None):

--- a/chainladder/methods/bornferg.py
+++ b/chainladder/methods/bornferg.py
@@ -112,10 +112,18 @@ class BornhuetterFerguson(Benktander):
         --------
         Fit returns the estimator itself, with ``ultimate_`` populated.
 
-        >>> tr = cl.load_sample('ukmotor')
-        >>> apriori = cl.Chainladder().fit(tr).ultimate_ * 0 + 14000
-        >>> cl.BornhuetterFerguson(apriori=1.0).fit(tr, sample_weight=apriori)
-        BornhuetterFerguson()
+        .. testsetup::
+            import chainladder as cl
+
+        .. testcode::
+
+            tr = cl.load_sample('ukmotor')
+            apriori = cl.Chainladder().fit(tr).ultimate_ * 0 + 14000
+            print(cl.BornhuetterFerguson(apriori=1.0).fit(tr, sample_weight=apriori))
+
+        .. testoutput::
+
+            BornhuetterFerguson()
         """
         self.n_iters = 1
         super().fit(X, y, sample_weight)
@@ -141,21 +149,30 @@ class BornhuetterFerguson(Benktander):
         Fit on a prior-period view of the data, then apply the model to the
         current Triangle and a refreshed apriori.
 
-        >>> tr = cl.load_sample('ukmotor')
-        >>> tr_prior = tr[tr.valuation < tr.valuation_date]
-        >>> apriori_prior = cl.Chainladder().fit(tr_prior).ultimate_ * 0 + 14000
-        >>> apriori = cl.Chainladder().fit(tr).ultimate_ * 0 + 14000
-        >>> model = cl.BornhuetterFerguson(apriori=1.0).fit(
-        ...     tr_prior, sample_weight=apriori_prior
-        ... )
-        >>> model.predict(tr, sample_weight=apriori).ultimate_
-                      2261
-        2007  12690.000000
-        2008  12746.000000
-        2009  13658.425101
-        2010  12883.599658
-        2011  13610.582796
-        2012  15360.020613
-        2013  15893.717063
+        .. testsetup::
+            import chainladder as cl
+
+        .. testcode::
+
+            tr = cl.load_sample('ukmotor')
+            tr_prior = tr[tr.valuation < tr.valuation_date]
+            apriori_prior = cl.Chainladder().fit(tr_prior).ultimate_ * 0 + 14000
+            apriori = cl.Chainladder().fit(tr).ultimate_ * 0 + 14000
+            model = cl.BornhuetterFerguson(apriori=1.0).fit(
+                tr_prior, sample_weight=apriori_prior
+            )
+
+            print(model.predict(tr, sample_weight=apriori).ultimate_)
+
+        .. testoutput
+
+                          2261
+            2007  12690.000000
+            2008  12746.000000
+            2009  13658.425101
+            2010  12883.599658
+            2011  13610.582796
+            2012  15360.020613
+            2013  15893.717063
         """
         return super().predict(X, sample_weight)

--- a/chainladder/methods/bornferg.py
+++ b/chainladder/methods/bornferg.py
@@ -44,32 +44,46 @@ class BornhuetterFerguson(Benktander):
     same-shape Triangle, zero it out, and add the desired value. Below uses
     the chainladder ultimate as the shape donor.
 
-    >>> tr = cl.load_sample('ukmotor')
-    >>> cl_ult = cl.Chainladder().fit(tr).ultimate_
-    >>> apriori = cl_ult * 0 + float(cl_ult.sum()) / 7
-    >>> apriori
-                  2261
-    2007  14903.967562
-    2008  14903.967562
-    2009  14903.967562
-    2010  14903.967562
-    2011  14903.967562
-    2012  14903.967562
-    2013  14903.967562
+    .. testsetup:
+
+        import chainladder as cl
+
+    .. testcode:
+
+        tr = cl.load_sample('ukmotor')
+        cl_ult = cl.Chainladder().fit(tr).ultimate_
+        apriori = cl_ult * 0 + float(cl_ult.sum()) / 7
+        print(apriori)
+
+    .. testoutput:
+
+                      2261
+        2007  14903.967562
+        2008  14903.967562
+        2009  14903.967562
+        2010  14903.967562
+        2011  14903.967562
+        2012  14903.967562
+        2013  14903.967562
 
     Fit with that apriori. The BF ultimates pull the immature origins toward
     the apriori while leaving mature origins close to chainladder.
 
-    >>> model = cl.BornhuetterFerguson(apriori=1.0).fit(tr, sample_weight=apriori)
-    >>> model.ultimate_
-                  2261
-    2007  12690.000000
-    2008  13145.318280
-    2009  14095.125641
-    2010  13412.748068
-    2011  14150.549749
-    2012  15999.244850
-    2013  16658.824705
+    .. testcode:
+
+        model = cl.BornhuetterFerguson(apriori=1.0).fit(tr, sample_weight=apriori)
+        print(model.ultimate_)
+
+    .. testoutput:
+
+                      2261
+        2007  12690.000000
+        2008  13145.318280
+        2009  14095.125641
+        2010  13412.748068
+        2011  14150.549749
+        2012  15999.244850
+        2013  16658.824705
     """
 
     def __init__(self, apriori=1.0, apriori_sigma=0.0, random_state=None):

--- a/chainladder/methods/bornferg.py
+++ b/chainladder/methods/bornferg.py
@@ -44,18 +44,18 @@ class BornhuetterFerguson(Benktander):
     same-shape Triangle, zero it out, and add the desired value. Below uses
     the chainladder ultimate as the shape donor.
 
-    .. testsetup:
+    .. testsetup::
 
         import chainladder as cl
 
-    .. testcode:
+    .. testcode::
 
         tr = cl.load_sample('ukmotor')
         cl_ult = cl.Chainladder().fit(tr).ultimate_
         apriori = cl_ult * 0 + float(cl_ult.sum()) / 7
         print(apriori)
 
-    .. testoutput:
+    .. testoutput::
 
                       2261
         2007  14903.967562
@@ -69,12 +69,12 @@ class BornhuetterFerguson(Benktander):
     Fit with that apriori. The BF ultimates pull the immature origins toward
     the apriori while leaving mature origins close to chainladder.
 
-    .. testcode:
+    .. testcode::
 
         model = cl.BornhuetterFerguson(apriori=1.0).fit(tr, sample_weight=apriori)
         print(model.ultimate_)
 
-    .. testoutput:
+    .. testoutput::
 
                       2261
         2007  12690.000000

--- a/chainladder/methods/capecod.py
+++ b/chainladder/methods/capecod.py
@@ -55,11 +55,11 @@ class CapeCod(Benktander):
     loss ratio from the data itself. ``sample_weight`` represents exposure
     (e.g. earned premium) rather than an apriori expected ultimate.
 
-    .. testsetup:
+    .. testsetup::
 
         import chainladder as cl
 
-    .. testcode:
+    .. testcode::
 
         tr = cl.load_sample('ukmotor')
         exposure = cl.Chainladder().fit(tr).ultimate_ * 0 + 20000
@@ -68,12 +68,12 @@ class CapeCod(Benktander):
     apriori loss ratio: the exposure-weighted mean loss ratio across all
     origins.
 
-    .. testcode:
+    .. testcode::
 
         model = cl.CapeCod().fit(tr, sample_weight=exposure)
         print(model.apriori_)
 
-    .. testoutput:
+    .. testoutput::
 
                   2261
         2007  0.706225
@@ -88,11 +88,11 @@ class CapeCod(Benktander):
     each origin's apriori, so each origin receives its own loss-ratio
     estimate that drifts toward more recent experience.
 
-    .. testcode:
+    .. testcode::
 
         print(cl.CapeCod(decay=0.5).fit(tr, sample_weight=exposure).apriori_)
 
-    .. testoutput:
+    .. testoutput::
 
                   2261
         2007  0.653584
@@ -106,11 +106,11 @@ class CapeCod(Benktander):
     Setting ``trend`` projects the loss ratio forward over the experience
     period. With ``decay=1``, all origins share the trended apriori.
 
-    .. testcode:
+    .. testcode::
 
         print(cl.CapeCod(trend=0.05).fit(tr, sample_weight=exposure).apriori_)
 
-    .. testoutput:
+    .. testoutput::
 
                   2261
         2007  0.836096

--- a/chainladder/methods/capecod.py
+++ b/chainladder/methods/capecod.py
@@ -55,50 +55,71 @@ class CapeCod(Benktander):
     loss ratio from the data itself. ``sample_weight`` represents exposure
     (e.g. earned premium) rather than an apriori expected ultimate.
 
-    >>> tr = cl.load_sample('ukmotor')
-    >>> exposure = cl.Chainladder().fit(tr).ultimate_ * 0 + 20000
+    .. testsetup:
+
+        import chainladder as cl
+
+    .. testcode:
+
+        tr = cl.load_sample('ukmotor')
+        exposure = cl.Chainladder().fit(tr).ultimate_ * 0 + 20000
 
     With default ``decay=1`` and ``trend=0``, every origin receives the same
     apriori loss ratio: the exposure-weighted mean loss ratio across all
     origins.
 
-    >>> model = cl.CapeCod().fit(tr, sample_weight=exposure)
-    >>> model.apriori_
-              2261
-    2007  0.706225
-    2008  0.706225
-    2009  0.706225
-    2010  0.706225
-    2011  0.706225
-    2012  0.706225
-    2013  0.706225
+    .. testcode:
+
+        model = cl.CapeCod().fit(tr, sample_weight=exposure)
+        print(model.apriori_)
+
+    .. testoutput:
+
+                  2261
+        2007  0.706225
+        2008  0.706225
+        2009  0.706225
+        2010  0.706225
+        2011  0.706225
+        2012  0.706225
+        2013  0.706225
 
     Setting ``decay`` below 1 down-weights distant origins when computing
     each origin's apriori, so each origin receives its own loss-ratio
     estimate that drifts toward more recent experience.
 
-    >>> cl.CapeCod(decay=0.5).fit(tr, sample_weight=exposure).apriori_
-              2261
-    2007  0.653584
-    2008  0.666113
-    2009  0.683132
-    2010  0.689123
-    2011  0.717497
-    2012  0.776364
-    2013  0.836006
+    .. testcode:
+
+        print(cl.CapeCod(decay=0.5).fit(tr, sample_weight=exposure).apriori_)
+
+    .. testoutput:
+
+                  2261
+        2007  0.653584
+        2008  0.666113
+        2009  0.683132
+        2010  0.689123
+        2011  0.717497
+        2012  0.776364
+        2013  0.836006
 
     Setting ``trend`` projects the loss ratio forward over the experience
     period. With ``decay=1``, all origins share the trended apriori.
 
-    >>> cl.CapeCod(trend=0.05).fit(tr, sample_weight=exposure).apriori_
-              2261
-    2007  0.836096
-    2008  0.836096
-    2009  0.836096
-    2010  0.836096
-    2011  0.836096
-    2012  0.836096
-    2013  0.836096
+    .. testcode:
+
+        print(cl.CapeCod(trend=0.05).fit(tr, sample_weight=exposure).apriori_)
+
+    .. testoutput:
+
+                  2261
+        2007  0.836096
+        2008  0.836096
+        2009  0.836096
+        2010  0.836096
+        2011  0.836096
+        2012  0.836096
+        2013  0.836096
     """
 
     def __init__(

--- a/chainladder/methods/capecod.py
+++ b/chainladder/methods/capecod.py
@@ -159,10 +159,19 @@ class CapeCod(Benktander):
         Fit returns the estimator itself, with ``ultimate_`` and
         ``apriori_`` populated. The repr shows non-default parameters.
 
-        >>> tr = cl.load_sample('ukmotor')
-        >>> exposure = cl.Chainladder().fit(tr).ultimate_ * 0 + 20000
-        >>> cl.CapeCod(trend=0.05).fit(tr, sample_weight=exposure)
-        CapeCod(trend=0.05)
+        .. testsetup::
+
+            import chainladder as cl
+
+        .. testcode::
+
+            tr = cl.load_sample('ukmotor')
+            exposure = cl.Chainladder().fit(tr).ultimate_ * 0 + 20000
+            print(cl.CapeCod(trend=0.05).fit(tr, sample_weight=exposure))
+
+        .. testoutput:
+
+            CapeCod(trend=0.05)
         """
 
         if sample_weight is None:
@@ -226,22 +235,31 @@ class CapeCod(Benktander):
         Fit on a prior-period view of the data, then apply the model to the
         current Triangle and a refreshed exposure.
 
-        >>> tr = cl.load_sample('ukmotor')
-        >>> tr_prior = tr[tr.valuation < tr.valuation_date]
-        >>> exposure_prior = cl.Chainladder().fit(tr_prior).ultimate_ * 0 + 20000
-        >>> exposure = cl.Chainladder().fit(tr).ultimate_ * 0 + 20000
-        >>> model = cl.CapeCod(trend=0.05).fit(
-        ...     tr_prior, sample_weight=exposure_prior
-        ... )
-        >>> model.predict(tr, sample_weight=exposure).ultimate_
-                      2261
-        2007  12690.000000
-        2008  12746.000000
-        2009  13631.353487
-        2010  12896.639975
-        2011  13806.211939
-        2012  15991.144199
-        2013  17489.630279
+        .. testsetup:
+
+            import chainladder as cl
+
+        .. testcode::
+
+            tr = cl.load_sample('ukmotor')
+            tr_prior = tr[tr.valuation < tr.valuation_date]
+            exposure_prior = cl.Chainladder().fit(tr_prior).ultimate_ * 0 + 20000
+            exposure = cl.Chainladder().fit(tr).ultimate_ * 0 + 20000
+            model = cl.CapeCod(trend=0.05).fit(
+                tr_prior, sample_weight=exposure_prior
+            )
+            print(model.predict(tr, sample_weight=exposure).ultimate_)
+
+        .. testoutput::
+
+                          2261
+            2007  12690.000000
+            2008  12746.000000
+            2009  13631.353487
+            2010  12896.639975
+            2011  13806.211939
+            2012  15991.144199
+            2013  17489.630279
         """
         if sample_weight is None:
             raise ValueError("sample_weight is required.")

--- a/chainladder/methods/chainladder.py
+++ b/chainladder/methods/chainladder.py
@@ -60,6 +60,8 @@ class Chainladder(MethodBase):
 
         print(model.ibnr_)
 
+    .. testoutput::
+
                       2261
         2007           NaN
         2008    350.902024
@@ -92,6 +94,8 @@ class Chainladder(MethodBase):
     .. testcode::
 
         print(model.full_expectation_.iloc[..., -3:, :5])
+
+    .. testoutput::
 
                        12            24            36            48            60
         2011  4217.162588   7967.208127  10217.000000  11719.970266  12853.969769

--- a/chainladder/methods/chainladder.py
+++ b/chainladder/methods/chainladder.py
@@ -80,7 +80,7 @@ class Chainladder(MethodBase):
 
         print(model.full_triangle_.iloc[..., -3:, :5])
 
-    .. testoutput:
+    .. testoutput::
 
                   12            24            36            48            60
         2011  4150.0   7897.000000  10217.000000  11719.970266  12853.969769
@@ -123,9 +123,14 @@ class Chainladder(MethodBase):
         Fitting returns the estimator itself, so it can be chained with
         attribute access.
 
-        >>> tr = cl.load_sample('ukmotor')
-        >>> cl.Chainladder().fit(tr)
-        Chainladder()
+        .. testsetup::
+            import chainladder as cl
+
+        .. testcode::
+
+            tr = cl.load_sample('ukmotor')
+            cl.Chainladder().fit(tr)
+            Chainladder()
         """
         super().fit(X, y, sample_weight)
         self.ultimate_ = self._get_ultimate(self.X_)
@@ -155,18 +160,27 @@ class Chainladder(MethodBase):
         Triangle. The ultimates differ from a freshly-fit model because the
         patterns reflect the older view.
 
-        >>> tr = cl.load_sample('ukmotor')
-        >>> tr_prior = tr[tr.valuation < tr.valuation_date]
-        >>> model = cl.Chainladder().fit(tr_prior)
-        >>> model.predict(tr).ultimate_
-                      2261
-        2007  12690.000000
-        2008  12746.000000
-        2009  13641.379750
-        2010  12719.871218
-        2011  13485.986574
-        2012  16296.783586
-        2013  20040.175415
+        .. testsetup::
+
+            import chainladder as cl
+
+        .. testcode::
+
+            tr = cl.load_sample('ukmotor')
+            tr_prior = tr[tr.valuation < tr.valuation_date]
+            model = cl.Chainladder().fit(tr_prior)
+            print(model.predict(tr).ultimate_)
+
+        .. testoutput::
+
+                          2261
+            2007  12690.000000
+            2008  12746.000000
+            2009  13641.379750
+            2010  12719.871218
+            2011  13485.986574
+            2012  16296.783586
+            2013  20040.175415
         """
         X_new = super().predict(X, sample_weight)
         X_new.ultimate_ = self._get_ultimate(X_new, sample_weight)

--- a/chainladder/methods/chainladder.py
+++ b/chainladder/methods/chainladder.py
@@ -32,17 +32,17 @@ class Chainladder(MethodBase):
     Fit the chainladder method to a loss triangle and inspect the projected
     ultimates.
 
-    .. testsetup:
+    .. testsetup::
 
         import chainladder as cl
 
-    .. testcode:
+    .. testcode::
 
         tr = cl.load_sample('ukmotor')
         model = cl.Chainladder().fit(tr)
         print(model.ultimate_)
 
-    .. testoutput:
+    .. testoutput::
 
                       2261
         2007  12690.000000
@@ -56,7 +56,7 @@ class Chainladder(MethodBase):
     The ``ibnr_`` attribute is ``ultimate_ - latest_diagonal``. The 2007 origin
     is fully developed in the data, so its IBNR is ``NaN``.
 
-    .. testcode:
+    .. testcode::
 
         print(model.ibnr_)
 
@@ -74,7 +74,7 @@ class Chainladder(MethodBase):
     periods makes the data-to-projection boundary visible: whole-number cells
     are observed, decimal cells are projected.
 
-    .. testcode:
+    .. testcode::
 
         print(model.full_triangle_.iloc[..., -3:, :5])
 
@@ -89,7 +89,7 @@ class Chainladder(MethodBase):
     known ones, with the model's expectation. Compare the ``12`` column above
     against the same slice below: the observed values have been overwritten.
 
-    .. testcode:
+    .. testcode::
 
         print(model.full_expectation_.iloc[..., -3:, :5])
 

--- a/chainladder/methods/chainladder.py
+++ b/chainladder/methods/chainladder.py
@@ -32,51 +32,71 @@ class Chainladder(MethodBase):
     Fit the chainladder method to a loss triangle and inspect the projected
     ultimates.
 
-    >>> tr = cl.load_sample('ukmotor')
-    >>> model = cl.Chainladder().fit(tr)
-    >>> model.ultimate_
-                  2261
-    2007  12690.000000
-    2008  13096.902024
-    2009  14030.536767
-    2010  13137.859861
-    2011  13880.404483
-    2012  16812.150646
-    2013  20679.919151
+    .. testsetup:
+
+        import chainladder as cl
+
+    .. testcode:
+
+        tr = cl.load_sample('ukmotor')
+        model = cl.Chainladder().fit(tr)
+        print(model.ultimate_)
+
+    .. testoutput:
+
+                      2261
+        2007  12690.000000
+        2008  13096.902024
+        2009  14030.536767
+        2010  13137.859861
+        2011  13880.404483
+        2012  16812.150646
+        2013  20679.919151
 
     The ``ibnr_`` attribute is ``ultimate_ - latest_diagonal``. The 2007 origin
     is fully developed in the data, so its IBNR is ``NaN``.
 
-    >>> model.ibnr_
-                  2261
-    2007           NaN
-    2008    350.902024
-    2009   1037.536767
-    2010   2044.859861
-    2011   3663.404483
-    2012   7162.150646
-    2013  14396.919151
+    .. testcode:
+
+        print(model.ibnr_)
+
+                      2261
+        2007           NaN
+        2008    350.902024
+        2009   1037.536767
+        2010   2044.859861
+        2011   3663.404483
+        2012   7162.150646
+        2013  14396.919151
 
     ``full_triangle_`` projects each origin to ultimate while preserving the
     known cells. Showing the last three origins and the first five development
     periods makes the data-to-projection boundary visible: whole-number cells
     are observed, decimal cells are projected.
 
-    >>> model.full_triangle_.iloc[..., -3:, :5]
-              12            24            36            48            60
-    2011  4150.0   7897.000000  10217.000000  11719.970266  12853.969769
-    2012  5102.0   9650.000000  12374.981102  14195.400857  15568.917781
-    2013  6283.0  11870.058983  15221.943585  17461.165333  19150.670711
+    .. testcode:
+
+        print(model.full_triangle_.iloc[..., -3:, :5])
+
+    .. testoutput:
+
+                  12            24            36            48            60
+        2011  4150.0   7897.000000  10217.000000  11719.970266  12853.969769
+        2012  5102.0   9650.000000  12374.981102  14195.400857  15568.917781
+        2013  6283.0  11870.058983  15221.943585  17461.165333  19150.670711
 
     ``full_expectation_`` is similar but replaces every cell, including the
     known ones, with the model's expectation. Compare the ``12`` column above
     against the same slice below: the observed values have been overwritten.
 
-    >>> model.full_expectation_.iloc[..., -3:, :5]
-                   12            24            36            48            60
-    2011  4217.162588   7967.208127  10217.000000  11719.970266  12853.969769
-    2012  5107.889530   9650.000000  12374.981102  14195.400857  15568.917781
-    2013  6283.000000  11870.058983  15221.943585  17461.165333  19150.670711
+    .. testcode:
+
+        print(model.full_expectation_.iloc[..., -3:, :5])
+
+                       12            24            36            48            60
+        2011  4217.162588   7967.208127  10217.000000  11719.970266  12853.969769
+        2012  5107.889530   9650.000000  12374.981102  14195.400857  15568.917781
+        2013  6283.000000  11870.058983  15221.943585  17461.165333  19150.670711
     """
 
     def fit(self, X, y=None, sample_weight=None):

--- a/chainladder/methods/mack.py
+++ b/chainladder/methods/mack.py
@@ -46,25 +46,38 @@ class MackChainladder(Chainladder):
     which combines the deterministic chainladder estimate with Mack's
     stochastic standard error.
 
-    >>> tr = cl.load_sample('ukmotor')
-    >>> model = cl.MackChainladder().fit(tr)
-    >>> model.summary_
-           Latest          IBNR      Ultimate  Mack Std Err
-    2007  12690.0           NaN  12690.000000           NaN
-    2008  12746.0    350.902024  13096.902024     27.246756
-    2009  12993.0   1037.536767  14030.536767     36.524408
-    2010  11093.0   2044.859861  13137.859861    144.534287
-    2011  10217.0   3663.404483  13880.404483    427.634355
-    2012   9650.0   7162.150646  16812.150646    693.166178
-    2013   6283.0  14396.919151  20679.919151    901.408385
+    .. testsetup:
+
+        import chainladder as cl
+
+    .. testcode:
+
+        tr = cl.load_sample('ukmotor')
+        model = cl.MackChainladder().fit(tr)
+        print(model.summary_)
+
+    .. testoutput:
+
+               Latest          IBNR      Ultimate  Mack Std Err
+        2007  12690.0           NaN  12690.000000           NaN
+        2008  12746.0    350.902024  13096.902024     27.246756
+        2009  12993.0   1037.536767  14030.536767     36.524408
+        2010  11093.0   2044.859861  13137.859861    144.534287
+        2011  10217.0   3663.404483  13880.404483    427.634355
+        2012   9650.0   7162.150646  16812.150646    693.166178
+        2013   6283.0  14396.919151  20679.919151    901.408385
 
     The deterministic chainladder ultimates match those of
     :class:`Chainladder`. Mack's contribution is the stochastic standard error
     in the rightmost column, which can be aggregated across origins.
 
-    >>> model.total_mack_std_err_
-    columns        values
-    (Total,)  1424.531543
+    .. testcode:
+        print(model.total_mack_std_err_)
+
+    .. testoutput:
+
+        columns        values
+        (Total,)  1424.531543
     """
 
     def fit(self, X, y=None, sample_weight=None):

--- a/chainladder/methods/mack.py
+++ b/chainladder/methods/mack.py
@@ -101,9 +101,18 @@ class MackChainladder(Chainladder):
         Fitting attaches the ``ultimate_`` and Mack std error attributes to
         the estimator and returns the estimator itself.
 
-        >>> tr = cl.load_sample('ukmotor')
-        >>> cl.MackChainladder().fit(tr)
-        MackChainladder()
+        .. testsetup::
+
+            import chainladder as cl
+
+        .. testcode::
+
+            tr = cl.load_sample('ukmotor')
+            cl.MackChainladder().fit(tr)
+
+        .. testoutput::
+
+            MackChainladder()
         """
         super().fit(X, y, sample_weight)
         if "sigma_" not in self.X_:
@@ -146,12 +155,21 @@ class MackChainladder(Chainladder):
         Fit the model and apply it to a Triangle with the same shape, then
         read the Mack standard error off the resulting Triangle.
 
-        >>> tr = cl.load_sample('ukmotor')
-        >>> model = cl.MackChainladder().fit(tr)
-        >>> predicted = model.predict(tr)
-        >>> predicted.total_mack_std_err_
-        columns        values
-        (Total,)  1424.531543
+        .. testsetup::
+
+            import chainladder as cl
+
+        .. testcode::
+
+            tr = cl.load_sample('ukmotor')
+            model = cl.MackChainladder().fit(tr)
+            predicted = model.predict(tr)
+            print(predicted.total_mack_std_err_)
+
+        .. testoutput::
+
+            columns        values
+            (Total,)  1424.531543
         """
         X_new = super().predict(X, sample_weight)
         X_new.sigma_ = getattr(X_new, "sigma_", self.X_.sigma_)
@@ -188,17 +206,27 @@ class MackChainladder(Chainladder):
 
         Examples
         --------
-        >>> tr = cl.load_sample('ukmotor')
-        >>> model = cl.MackChainladder().fit(tr)
-        >>> model.full_std_err_
-                    12        24        36        48        60        72   84
-        2007  0.047826  0.040745  0.031412  0.010337  0.001431  0.001523  0.0
-        2008  0.044802  0.038074  0.029815  0.010123  0.001410  0.001500  0.0
-        2009  0.042943  0.036708  0.029445  0.009864  0.001361  0.001449  0.0
-        2010  0.043241  0.037958  0.030130  0.010154  0.001407  0.001497  0.0
-        2011  0.043990  0.037603  0.029468  0.009879  0.001369  0.001457  0.0
-        2012  0.039675  0.034017  0.026776  0.008976  0.001243  0.001324  0.0
-        2013  0.035752  0.030671  0.024143  0.008094  0.001121  0.001193  0.0
+
+        .. testsetup::
+
+            import chainladder as cl
+
+        .. testcode::
+
+            tr = cl.load_sample('ukmotor')
+            model = cl.MackChainladder().fit(tr)
+            print(model.full_std_err_)
+
+        .. testoutput
+
+                        12        24        36        48        60        72   84
+            2007  0.047826  0.040745  0.031412  0.010337  0.001431  0.001523  0.0
+            2008  0.044802  0.038074  0.029815  0.010123  0.001410  0.001500  0.0
+            2009  0.042943  0.036708  0.029445  0.009864  0.001361  0.001449  0.0
+            2010  0.043241  0.037958  0.030130  0.010154  0.001407  0.001497  0.0
+            2011  0.043990  0.037603  0.029468  0.009879  0.001369  0.001457  0.0
+            2012  0.039675  0.034017  0.026776  0.008976  0.001243  0.001324  0.0
+            2013  0.035752  0.030671  0.024143  0.008094  0.001121  0.001193  0.0
         """
         return self._get_full_std_err_(self.X_)
 
@@ -238,11 +266,20 @@ class MackChainladder(Chainladder):
 
         Examples
         --------
-        >>> tr = cl.load_sample('ukmotor')
-        >>> model = cl.MackChainladder().fit(tr)
-        >>> model.total_process_risk_.iloc[..., -3:]
-                     72           84           9999
-        2007  1039.901929  1069.726277  1069.726277
+
+        .. testsetup::
+            import chainladder as cl
+
+        .. testcode::
+
+            tr = cl.load_sample('ukmotor')
+            model = cl.MackChainladder().fit(tr)
+            print(model.total_process_risk_.iloc[..., -3:])
+
+        .. testoutput::
+
+                         72           84           9999
+            2007  1039.901929  1069.726277  1069.726277
         """
         return (self.process_risk_ ** 2).sum(axis="origin").sqrt()
 
@@ -302,13 +339,20 @@ class MackChainladder(Chainladder):
         keep the slice readable. The final column is the ultimate prediction
         error per origin.
 
-        >>> tr = cl.load_sample('ukmotor')
-        >>> model = cl.MackChainladder().fit(tr)
-        >>> model.mack_std_err_.iloc[..., -3:, -3:]
-                    72          84          9999
-        2011  415.253333  427.634355  427.634355
-        2012  673.828536  693.166178  693.166178
-        2013  876.437914  901.408385  901.408385
+        .. testsetup::
+            import chainladder as cl
+
+        .. testcode::
+            tr = cl.load_sample('ukmotor')
+            model = cl.MackChainladder().fit(tr)
+            print(model.mack_std_err_.iloc[..., -3:, -3:])
+
+        .. testoutput::
+
+                        72          84          9999
+            2011  415.253333  427.634355  427.634355
+            2012  673.828536  693.166178  693.166178
+            2013  876.437914  901.408385  901.408385
         """
         return (self.parameter_risk_ ** 2 + self.process_risk_ ** 2).sqrt()
 
@@ -330,11 +374,21 @@ class MackChainladder(Chainladder):
 
         Examples
         --------
-        >>> tr = cl.load_sample('ukmotor')
-        >>> model = cl.MackChainladder().fit(tr)
-        >>> model.total_mack_std_err_
-        columns        values
-        (Total,)  1424.531543
+
+        .. testsetup::
+
+            import chainladder as cl
+
+        .. testcode::
+
+            tr = cl.load_sample('ukmotor')
+            model = cl.MackChainladder().fit(tr)
+            print(model.total_mack_std_err_)
+
+        .. testoutput::
+
+            columns        values
+            (Total,)  1424.531543
         """
         return self._get_total_mack_std_err_(self)
 
@@ -360,17 +414,27 @@ class MackChainladder(Chainladder):
 
         Examples
         --------
-        >>> tr = cl.load_sample('ukmotor')
-        >>> model = cl.MackChainladder().fit(tr)
-        >>> model.summary_
-               Latest          IBNR      Ultimate  Mack Std Err
-        2007  12690.0           NaN  12690.000000           NaN
-        2008  12746.0    350.902024  13096.902024     27.246756
-        2009  12993.0   1037.536767  14030.536767     36.524408
-        2010  11093.0   2044.859861  13137.859861    144.534287
-        2011  10217.0   3663.404483  13880.404483    427.634355
-        2012   9650.0   7162.150646  16812.150646    693.166178
-        2013   6283.0  14396.919151  20679.919151    901.408385
+
+        .. testsetup::
+
+            import chainladder as cl
+
+        .. testcode::
+
+            tr = cl.load_sample('ukmotor')
+            model = cl.MackChainladder().fit(tr)
+            print(model.summary_)
+
+        .. testoutput::
+
+                   Latest          IBNR      Ultimate  Mack Std Err
+            2007  12690.0           NaN  12690.000000           NaN
+            2008  12746.0    350.902024  13096.902024     27.246756
+            2009  12993.0   1037.536767  14030.536767     36.524408
+            2010  11093.0   2044.859861  13137.859861    144.534287
+            2011  10217.0   3663.404483  13880.404483    427.634355
+            2012   9650.0   7162.150646  16812.150646    693.166178
+            2013   6283.0  14396.919151  20679.919151    901.408385
         """
         # This might be better as a dataframe
         obj = self.ultimate_.copy()

--- a/chainladder/methods/mack.py
+++ b/chainladder/methods/mack.py
@@ -72,6 +72,7 @@ class MackChainladder(Chainladder):
     in the rightmost column, which can be aggregated across origins.
 
     .. testcode:
+
         print(model.total_mack_std_err_)
 
     .. testoutput:

--- a/chainladder/workflow/voting.py
+++ b/chainladder/workflow/voting.py
@@ -205,44 +205,40 @@ class VotingChainladder(_BaseChainladderVoting, MethodBase):
 
     Examples
     --------
-    >>> import numpy as np
-    >>> import chainladder as cl
-    >>> raa = cl.load_sample('RAA')
-    >>> cl_ult = cl.Chainladder().fit(raa).ultimate_  # Chainladder Ultimate
-    >>> apriori = cl_ult * 0 + (float(cl_ult.sum()) / 10)  # Mean Chainladder Ultimate
-    >>> bcl = cl.Chainladder()
-    >>> bf = cl.BornhuetterFerguson()
-    >>> cc = cl.CapeCod()
-    >>> estimators = [('bcl', bcl), ('bf', bf), ('cc', cc)]
-    >>> weights = np.array([[0.6, 0.2, 0.2]] * 4 + [[0, 0.5, 0.5]] * 3 + [[0, 0, 1]] * 3)
-    >>> vot = cl.VotingChainladder(estimators=estimators, weights=weights)
-    >>> vot.fit(raa, sample_weight=apriori)
-    VotingChainladder(default_weighting=(1, 1, 1),
-                      estimators=[('bcl', Chainladder()),
-                                  ('bf', BornhuetterFerguson()),
-                                  ('cc', CapeCod())],
-                      weights=array([[0.6, 0.2, 0.2],
-           [0.6, 0.2, 0.2],
-           [0.6, 0.2, 0.2],
-           [0.6, 0.2, 0.2],
-           [0. , 0.5, 0.5],
-           [0. , 0.5, 0.5],
-           [0. , 0.5, 0.5],
-           [0. , 0. , 1. ],
-           [0. , 0. , 1. ],
-           [0. , 0. , 1. ]]))
-    >>> print(vot.ultimate_)
-                  2261
-    1981  18834.000000
-    1982  16875.500226
-    1983  24058.534810
-    1984  28542.580970
-    1985  28236.843134
-    1986  19905.317262
-    1987  18947.245455
-    1988  23106.943030
-    1989  20004.502125
-    1990  21605.832631
+
+    .. testsetup::
+
+        import chainladder as cl
+
+    .. testcode::
+
+        import numpy as np
+
+        raa = cl.load_sample('RAA')
+        cl_ult = cl.Chainladder().fit(raa).ultimate_  # Chainladder Ultimate
+        apriori = cl_ult * 0 + (float(cl_ult.sum()) / 10)  # Mean Chainladder Ultimate
+        bcl = cl.Chainladder()
+        bf = cl.BornhuetterFerguson()
+        cc = cl.CapeCod()
+        estimators = [('bcl', bcl), ('bf', bf), ('cc', cc)]
+        weights = np.array([[0.6, 0.2, 0.2]] * 4 + [[0, 0.5, 0.5]] * 3 + [[0, 0, 1]] * 3)
+        vot = cl.VotingChainladder(estimators=estimators, weights=weights)
+        vot.fit(raa, sample_weight=apriori)
+        print(vot.ultimate_)
+
+    .. testoutput::
+
+                      2261
+        1981  18834.000000
+        1982  16875.500226
+        1983  24058.534810
+        1984  28542.580970
+        1985  28236.843134
+        1986  19905.317262
+        1987  18947.245455
+        1988  23106.943030
+        1989  20004.502125
+        1990  21605.832631
     """
 
     @_deprecate_positional_args

--- a/chainladder/workflow/voting.py
+++ b/chainladder/workflow/voting.py
@@ -217,18 +217,32 @@ class VotingChainladder(_BaseChainladderVoting, MethodBase):
     >>> weights = np.array([[0.6, 0.2, 0.2]] * 4 + [[0, 0.5, 0.5]] * 3 + [[0, 0, 1]] * 3)
     >>> vot = cl.VotingChainladder(estimators=estimators, weights=weights)
     >>> vot.fit(raa, sample_weight=apriori)
+    VotingChainladder(default_weighting=(1, 1, 1),
+                      estimators=[('bcl', Chainladder()),
+                                  ('bf', BornhuetterFerguson()),
+                                  ('cc', CapeCod())],
+                      weights=array([[0.6, 0.2, 0.2],
+           [0.6, 0.2, 0.2],
+           [0.6, 0.2, 0.2],
+           [0.6, 0.2, 0.2],
+           [0. , 0.5, 0.5],
+           [0. , 0.5, 0.5],
+           [0. , 0.5, 0.5],
+           [0. , 0. , 1. ],
+           [0. , 0. , 1. ],
+           [0. , 0. , 1. ]]))
     >>> print(vot.ultimate_)
-                      2262
-        1981  18834.000000
-        1982  16875.500226
-        1983  24058.534810
-        1984  28542.580970
-        1985  28236.843134
-        1986  19905.317262
-        1987  18947.245455
-        1988  23106.943030
-        1989  20004.502125
-        1990  21605.832631
+                  2261
+    1981  18834.000000
+    1982  16875.500226
+    1983  24058.534810
+    1984  28542.580970
+    1985  28236.843134
+    1986  19905.317262
+    1987  18947.245455
+    1988  23106.943030
+    1989  20004.502125
+    1990  21605.832631
     """
 
     @_deprecate_positional_args

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -35,6 +35,7 @@ sphinx:
   extra_extensions:
     - sphinx.ext.autodoc
     - sphinx.ext.autosummary
+    - sphinx.ext.doctest
     - sphinx.ext.linkcode
     - numpydoc
     - sphinx.ext.mathjax


### PR DESCRIPTION
This PR adds a workflow to run `cd docs && uv run jb build . --builder=custom --custom-builder=doctest`, which runs unit tests found within docstrings.

If successful, we should see a failure in the checks regarding Voting Chainladder. When running locally, doctest found an error in an example there, so I'd expect to see it here.

@kennethshsu, do you know what Python version the readthedocs is running? I can update the workflow to reflect the correct version.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mostly documentation/CI changes that add a new doctest check; code changes are limited to type annotations and doc/formatting tweaks with no intended runtime behavior changes.
> 
> **Overview**
> Adds a new GitHub Actions `doctest` job that installs the docs extras and runs JupyterBook/Sphinx doctests (`jb build ... --custom-builder=doctest`) alongside the existing pytest matrix.
> 
> Enables Sphinx’s doctest extension in `docs/_config.yml` and rewrites multiple docstring examples across core/methods/workflow modules into explicit `.. testcode::`/`.. testoutput::` blocks so the documentation examples are executed and output-verified in CI.
> 
> Includes minor non-functional cleanups in core code (additional type hints/annotations in `slice.py` and `clark.py`, small docstring/formatting adjustments).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8c8ae0c83ff85ceb99a55e8bfbb7bd58e54c5746. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->