### PR TITLE
Missing testoutput

### DIFF
--- a/chainladder/methods/chainladder.py
+++ b/chainladder/methods/chainladder.py
@@ -130,7 +130,11 @@ class Chainladder(MethodBase):
 
             tr = cl.load_sample('ukmotor')
             cl.Chainladder().fit(tr)
+
+        .. testoutput::
+
             Chainladder()
+            
         """
         super().fit(X, y, sample_weight)
         self.ultimate_ = self._get_ultimate(self.X_)


### PR DESCRIPTION
## What does this pull request do?
Addressed #713's missing test output

## Relevent Github ticket(s)?
#713 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change that adds expected doctest output for an existing example; no runtime logic is modified.
> 
> **Overview**
> Adds the missing `.. testoutput::` block to the `Chainladder.fit` docstring example so doctests/docs validation can assert the expected `Chainladder()` repr output.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 044e3a6c1ef9653c756e9328f0fbd2b461993cfb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->