### PR TITLE
Wrap raw HTML in StringIO for pd.read_html (#726)

### DIFF
--- a/chainladder/core/tests/test_triangle.py
+++ b/chainladder/core/tests/test_triangle.py
@@ -19,7 +19,7 @@ except ImportError:
 
 def test_repr(raa):
     np.testing.assert_array_equal(
-        pd.read_html(raa._repr_html_())[0].set_index("Unnamed: 0").values,
+        pd.read_html(io.StringIO(raa._repr_html_()))[0].set_index("Unnamed: 0").values,
         raa.to_frame(origin_as_datetime=False).values,
     )
 


### PR DESCRIPTION
Closes #726.

## Summary

`pd.read_html()` on pandas 3.0 no longer accepts literal HTML strings; they must be wrapped in `io.StringIO`. On pandas 2.x this currently emits:

```
FutureWarning: Passing literal html to 'read_html' is deprecated and will be
removed in a future version. To read from a literal string, wrap it in a
'StringIO' object.
```

A repo-wide search confirmed `chainladder/core/tests/test_triangle.py::test_repr` is the only call site passing raw HTML, so the fix is a single-line change. `io` was already imported in the file.

## Verification

```
$ uv run pytest chainladder/core/tests/test_triangle.py::test_repr -W error::FutureWarning
2 passed
$ uv run pytest chainladder/core/tests/test_triangle.py
141 passed, 8 xfailed
```

## Reference

- pandas 3.0 whatsnew (Other removals): https://pandas.pydata.org/docs/dev/whatsnew/v3.0.0.html#other-removals