### PR TITLE
fix(tests): use assert in test_n_periods so failures actually fail

### DIFF
--- a/chainladder/development/tests/test_development.py
+++ b/chainladder/development/tests/test_development.py
@@ -40,7 +40,7 @@ def test_drop2(raa):
 def test_n_periods():
     d = cl.load_sample("usauto")["incurred"]
     xp = np if d.array_backend == "sparse" else d.get_array_module()
-    return xp.all(
+    assert xp.all(
         xp.around(
             xp.unique(
                 cl.Development(n_periods=3, average="volume").fit(d).ldf_.values,


### PR DESCRIPTION
## Summary of Changes

`chainladder/development/tests/test_development.py::test_n_periods` ended with `return xp.all(...)` instead of `assert xp.all(...)`. Two consequences:

1. The boolean result was silently discarded, so the test did **not** actually fail when the equality broke — regressions in `Development(n_periods=3, average='volume')` were masked.
2. Pytest 9 emits `PytestReturnNotNoneWarning` for any test function that returns a non-`None` value.

This PR replaces the single `return` with `assert`. One-line change.

### Verification

- Before fix, with `-W error::pytest.PytestReturnNotNoneWarning`: the test errors out on the warning.
- After fix: `pytest chainladder/development/tests/test_development.py -W error::pytest.PytestReturnNotNoneWarning` → `35 passed, 1 xfailed, 0 PytestReturnNotNoneWarnings`.
- Mutation check: temporarily replaced one expected LDF (`1.164` → `9.999`) and confirmed the test now fails with `AssertionError` (it previously would have passed silently).

This is purely a pytest hygiene fix and is independent of the pandas 3.0 work in #664 / #729.

## Related GitHub Issue(s)

Closes #743

## Additional Context for Reviewers

I grepped `^    return ` across `test_*.py` to confirm this is the only test in the package with this bug; the other 5 matches are all legitimate fixture returns.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes a single test to use `assert`, making failures visible and eliminating pytest warnings; no production code changes.
> 
> **Overview**
> Fixes `test_n_periods` in `chainladder/development/tests/test_development.py` to `assert xp.all(...)` instead of returning the boolean result.
> 
> This ensures regressions in `Development(n_periods=3, average="volume")` cause an actual test failure and avoids pytest warnings about non-`None` test returns.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f1fd5070ff2a7a3c7bd1d0717369b0ebfcfba7dd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->