### PR TITLE
Update pyproject.toml - Add numpy #738

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,7 @@ dependencies = [
     "scikit-learn>1.4.2",
     "numba>0.54",
     "sparse>=0.9",
+    "numpy",
     "matplotlib",
     "dill",
     "patsy",


### PR DESCRIPTION
## Summary of Changes  
Add numpy as a direct dependency

## Related GitHub Issue(s)  
Fixes casact/chainladder-python #738


## Additional Context for Reviewers  
This PR adds numpy without specifying a version constraint. Pip’s resolver seems to be able to select a compatible version. Alternative option: e.g. `numpy >=1.22.4, <2.0` for more control?




<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk dependency-metadata change only; main impact is installer resolution/compatibility if an unsuitable `numpy` version is selected due to the lack of a version pin.
> 
> **Overview**
> Adds `numpy` to `pyproject.toml` as a direct runtime dependency so environments install it explicitly rather than relying on transitive installs.
> 
> Also normalizes the `[tool.uv]` `config-settings` line (no functional behavior change expected).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8c6e285430be5900b20de4c2948dfdad18e934f7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->