### PR TITLE
Update prep_sphinx_conf.py

### DIFF
--- a/docs/prep_sphinx_conf.py
+++ b/docs/prep_sphinx_conf.py
@@ -10,28 +10,11 @@ CONF = Path(__file__).resolve().parent / "conf.py"
 MARKER = "_DOCS_EXT_DIR = Path(__file__).resolve().parent / '_ext'"
 
 BLOCK = """import sys
-import os
-import subprocess
 from pathlib import Path
-
 _DOCS_EXT_DIR = Path(__file__).resolve().parent / '_ext'
 _p = str(_DOCS_EXT_DIR)
 if _p not in sys.path:
     sys.path.insert(0, _p)
-
-def run_doctests(app):
-    from sphinx.application import Sphinx
-
-    # Only run during RTD build
-    if os.environ.get("READTHEDOCS") == "True":
-        import subprocess
-        subprocess.run(
-            ["sphinx-build", "-b", "doctest", ".", "_build/doctest"],
-            check=True
-        )
-
-def setup(app):
-    app.connect("builder-inited", run_doctests)
 
 """
 


### PR DESCRIPTION
## Summary of Changes  


## Related GitHub Issue(s)  


## Additional Context for Reviewers  


- [ ] I passed tests locally for both code (`pytest`) and documentation changes (`uv run jb build docs --builder=custom --custom-builder=doctest`)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: documentation helper script change only, removing Read the Docs-specific doctest execution logic and unused imports.
> 
> **Overview**
> `docs/prep_sphinx_conf.py` now injects only the minimal `sys.path` prepend for `docs/_ext` into `conf.py`, removing the previously embedded RTD-only doctest build hook and related `os/subprocess` imports.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d9c99f13c60114d10789ba5a52d6244e3f72cc5b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->