### PR TITLE
Update chapter_7.rst

### DIFF
--- a/docs/friedland/chapter_7.rst
+++ b/docs/friedland/chapter_7.rst
@@ -11,32 +11,56 @@ Development Technique
 
 This chapter covers the foundational development/chainladder method. In the chainladder package, this is implemented in the Development class. 
 
+Diving straight into Exhibit 1. We will begin by importing packages and loading the triangle at the top of p106.
+
 .. doctest::
 
     >>> import numpy as np
     >>> import pandas as pd
     >>> import chainladder as cl
-
-Diving straight into Exhibit 1. We will begin by loading the triangle at the top of p106.
+    >>> tri = cl.load_sample('friedland_us_industry_auto')
+    
+# PART 1 - Data Triangle
 
 .. doctest::
 
-    >>> tri = cl.load_sample('friedland_us_industry_auto')
-    # PART 1 - Data Triangle
     >>> tri['Reported Claims'].round(decimals = 0)
+                 12          24          36          48          60          72          84          96          108         120
+    1998  37017487.0  43169009.0  45568919.0  46784558.0  47337318.0  47533264.0  47634419.0  47689655.0  47724678.0  47742304.0
+    1999  38954484.0  46045718.0  48882924.0  50219672.0  50729292.0  50926779.0  51069285.0  51163540.0  51185767.0         NaN
+    2000  41155776.0  49371478.0  52358476.0  53780322.0  54303086.0  54582950.0  54742188.0  54837929.0         NaN         NaN
+    2001  42394069.0  50584112.0  53704296.0  55150118.0  55895583.0  56156727.0  56299562.0         NaN         NaN         NaN
+    2002  44755243.0  52971643.0  56102312.0  57703851.0  58363564.0  58592712.0         NaN         NaN         NaN         NaN
+    2003  45163102.0  52497731.0  55468551.0  57015411.0  57565344.0         NaN         NaN         NaN         NaN         NaN
+    2004  45417309.0  52640322.0  55553673.0  56976657.0         NaN         NaN         NaN         NaN         NaN         NaN
+    2005  46360869.0  53790061.0  56786410.0         NaN         NaN         NaN         NaN         NaN         NaN         NaN
+    2006  46582684.0  54641339.0         NaN         NaN         NaN         NaN         NaN         NaN         NaN         NaN
+    2007  48853563.0         NaN         NaN         NaN         NaN         NaN         NaN         NaN         NaN         NaN
 
 To calculate the triangle of age-to-age factors, use the age-to-age property of the triangle. 
 
-.. doctest::
+# PART 2 - Age-to-Age Factors
 
-    # PART 2 - Age-to-Age Factors
+.. doctest::
+    
     >>> tri['Reported Claims'].age_to_age.round(decimals = 3) 
+          12-24  24-36  36-48  48-60  60-72  72-84  84-96  96-108  108-120
+    1998  1.166  1.056  1.027  1.012  1.004  1.002  1.001   1.001      1.0
+    1999  1.182  1.062  1.027  1.010  1.004  1.003  1.002   1.000      NaN
+    2000  1.200  1.061  1.027  1.010  1.005  1.003  1.002     NaN      NaN
+    2001  1.193  1.062  1.027  1.014  1.005  1.003    NaN     NaN      NaN
+    2002  1.184  1.059  1.029  1.011  1.004    NaN    NaN     NaN      NaN
+    2003  1.162  1.057  1.028  1.010    NaN    NaN    NaN     NaN      NaN
+    2004  1.159  1.055  1.026    NaN    NaN    NaN    NaN     NaN      NaN
+    2005  1.160  1.056    NaN    NaN    NaN    NaN    NaN     NaN      NaN
+    2006  1.173    NaN    NaN    NaN    NaN    NaN    NaN     NaN      NaN
 
 To calculate the average age-to-age factors, we will use the Development class to fit_transform the original triangle. The specific choice of average paramters (n_period, etc.) are provided to the Development class. 
 
+    # PART 3 - Average Age-to-Age Factors
+
 .. doctest::
 
-    # PART 3 - Average Age-to-Age Factors
     # Simple Average
     # Latest 5
     >>> cl.Development(n_periods=5, average='simple').fit_transform(tri['Reported Claims']).ldf_.round(decimals = 3) 


### PR DESCRIPTION
## Summary of Changes  


## Related GitHub Issue(s)  


## Additional Context for Reviewers  


- [ ] I passed tests locally for both code (`pytest`) and documentation changes (`uv run jb build docs --builder=custom --custom-builder=doctest`)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes that reorder and expand `doctest` snippets; risk is limited to potential doctest brittleness if sample output changes.
> 
> **Overview**
> Updates `docs/friedland/chapter_7.rst` to better mirror Friedland Exhibit 1 by **moving the narrative intro above the first `doctest`**, adding explicit imports, and restructuring the chapter into clearly labeled parts (data triangle, age-to-age factors, and average factors).
> 
> Expands the doctest examples to include the expected printed triangle and `age_to_age` outputs, improving reproducibility and readability of the documentation walkthrough.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b45d3156d2d731c7d65f6600583c2bafdac596a4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->