### PR TITLE
adding xs

### DIFF
--- a/chainladder/core/pandas.py
+++ b/chainladder/core/pandas.py
@@ -445,7 +445,7 @@ class TrianglePandas:
     def round(self, decimals=0, *args, **kwargs):
         return round(self, decimals)
     
-    def xs(self,index_key,level=None,drop_level=True):
+    def xs(self,index_key,level=None,drop_level=False):
         '''
         mimics xs from pandas. key difference is that axis is always 0 and therefore not an argument in the function 
         main use case for this function is when slicing the 2nd field in the index
@@ -461,13 +461,11 @@ class TrianglePandas:
         indexer = tuple(_indexer)
         result = self.iloc[indexer]
         if new_ax is not None:
-            new_ax_df = new_ax.to_frame().reset_index(allow_duplicates = True)[new_ax.names]
-            new_ax_df = new_ax_df.loc[:,new_ax_df.columns.duplicated()]
+            new_ax_df = new_ax.to_frame(index=None)[new_ax.names]
             result.index = new_ax_df
         else:
             result.index = pd.DataFrame(data=['Total'],columns=['Total'])
         return result
-
 
 def add_triangle_agg_func(
         cls: Type[TrianglePandas],

--- a/chainladder/core/pandas.py
+++ b/chainladder/core/pandas.py
@@ -444,6 +444,28 @@ class TrianglePandas:
 
     def round(self, decimals=0, *args, **kwargs):
         return round(self, decimals)
+    
+    def xs(self,index_key,level=None,drop_level=True):
+        '''
+        mimics xs from pandas. key difference is that axis is always 0 and therefore not an argument in the function 
+        main use case for this function is when slicing the 2nd field in the index
+        '''
+        mi = pd.MultiIndex.from_frame(self.index)
+        df = pd.DataFrame(data=list(range(len(self.index))),index = mi)
+
+        lvl = 0 if level is None else level
+        loc, new_ax = mi.get_loc_level(index_key, level=lvl, drop_level=drop_level)
+
+        # create the tuple of the indexer
+        _indexer = [slice(None)] * df.ndim
+        _indexer[0] = loc
+        indexer = tuple(_indexer)
+        result = self.iloc[indexer]
+        if new_ax is not None:
+            result.index = new_ax.to_frame().reset_index(names='__discard__')[new_ax.names]
+        else:
+            result.index = pd.DataFrame(data=['Total'],columns=['Total'])
+        return result
 
 
 def add_triangle_agg_func(

--- a/chainladder/core/pandas.py
+++ b/chainladder/core/pandas.py
@@ -447,8 +447,10 @@ class TrianglePandas:
     
     def xs(self,index_key,level=None,drop_level=False):
         '''
-        mimics xs from pandas. key difference is that axis is always 0 and therefore not an argument in the function 
-        main use case for this function is when slicing the 2nd field in the index
+        mimics xs from pandas. key differences 
+            - is always 0 and therefore not an argument in the function 
+            - drop-level is set to be False be default, to retain Triangle.loc behavior
+        main use case for this function is when slicing beyond the first field in the index (such as LOB in the clrd dataset)
         '''
         mi = pd.MultiIndex.from_frame(self.index)
 

--- a/chainladder/core/pandas.py
+++ b/chainladder/core/pandas.py
@@ -451,18 +451,19 @@ class TrianglePandas:
         main use case for this function is when slicing the 2nd field in the index
         '''
         mi = pd.MultiIndex.from_frame(self.index)
-        df = pd.DataFrame(data=list(range(len(self.index))),index = mi)
 
         lvl = 0 if level is None else level
         loc, new_ax = mi.get_loc_level(index_key, level=lvl, drop_level=drop_level)
 
         # create the tuple of the indexer
-        _indexer = [slice(None)] * df.ndim
+        _indexer = [slice(None)] * 2
         _indexer[0] = loc
         indexer = tuple(_indexer)
         result = self.iloc[indexer]
         if new_ax is not None:
-            result.index = new_ax.to_frame().reset_index(names='__discard__')[new_ax.names]
+            new_ax_df = new_ax.to_frame().reset_index(allow_duplicates = True)[new_ax.names]
+            new_ax_df = new_ax_df.loc[:,new_ax_df.columns.duplicated()]
+            result.index = new_ax_df
         else:
             result.index = pd.DataFrame(data=['Total'],columns=['Total'])
         return result

--- a/chainladder/core/tests/test_triangle.py
+++ b/chainladder/core/tests/test_triangle.py
@@ -1014,8 +1014,11 @@ def test_triangle_init_from_dict() -> None:
 
 def test_xs(clrd):
     assert clrd.xs('Adriatic Ins Co') == clrd.loc['Adriatic Ins Co']
+    assert clrd.xs('Adriatic Ins Co',drop_leve = True).index == clrd.loc['Adriatic Ins Co'].index
     assert clrd.xs(('Agway Ins Co','comauto')) == clrd.loc['Agway Ins Co','comauto']
+    assert clrd.xs(('Agway Ins Co','comauto')).index == clrd.loc['Agway Ins Co','comauto'].index
     assert clrd.xs('comauto',level=1) == clrd.loc[clrd['LOB'] == 'comauto']
+    assert clrd.xs('comauto',level=1).index == clrd.loc[clrd['LOB'] == 'comauto'].index
 
 def test_validate_assumption(raa: Triangle) -> None:
     """

--- a/chainladder/core/tests/test_triangle.py
+++ b/chainladder/core/tests/test_triangle.py
@@ -1014,11 +1014,14 @@ def test_triangle_init_from_dict() -> None:
 
 def test_xs(clrd):
     assert clrd.xs('Adriatic Ins Co') == clrd.loc['Adriatic Ins Co']
-    assert clrd.xs('Adriatic Ins Co',drop_leve = True).index == clrd.loc['Adriatic Ins Co'].index
+    # when slicing with .loc on the first term in the index, Triangle will drop the term 
+    assert clrd.xs('Adriatic Ins Co',drop_level = True).index.equals(clrd.loc['Adriatic Ins Co'].index)
     assert clrd.xs(('Agway Ins Co','comauto')) == clrd.loc['Agway Ins Co','comauto']
-    assert clrd.xs(('Agway Ins Co','comauto')).index == clrd.loc['Agway Ins Co','comauto'].index
+    assert clrd.xs(('Agway Ins Co','comauto')).index.equals(clrd.loc['Agway Ins Co','comauto'].index)
+    # when all index terms are included in xs and drop_level is True, the default 'Total' index value is provided
+    assert clrd.xs(('Agway Ins Co','comauto'), drop_level=True).index.equals(cl.load_sample('genins').index)
     assert clrd.xs('comauto',level=1) == clrd.loc[clrd['LOB'] == 'comauto']
-    assert clrd.xs('comauto',level=1).index == clrd.loc[clrd['LOB'] == 'comauto'].index
+    assert clrd.xs('comauto',level=1).index.equals(clrd.loc[clrd['LOB'] == 'comauto'].index)
 
 def test_validate_assumption(raa: Triangle) -> None:
     """

--- a/chainladder/core/tests/test_triangle.py
+++ b/chainladder/core/tests/test_triangle.py
@@ -1012,6 +1012,10 @@ def test_triangle_init_from_dict() -> None:
 
     assert tri_from_df == tri_from_dict
 
+def test_xs(clrd):
+    assert clrd.xs('Adriatic Ins Co') == clrd.loc['Adriatic Ins Co']
+    assert clrd.xs(('Agway Ins Co','comauto')) == clrd.loc['Agway Ins Co','comauto']
+    assert clrd.xs('comauto',level=1) == clrd.loc[clrd['LOB'] == 'comauto']
 
 def test_validate_assumption(raa: Triangle) -> None:
     """

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,6 @@ dependencies = [
     "numba>0.54",
     "sparse>=0.9",
     "numpy",
-    "matplotlib",
     "dill",
     "patsy",
 ]
@@ -67,6 +66,7 @@ docs = [
     "sphinx-togglebutton",
     "ipython",
     "parso>=0.8",
+    "matplotlib",  # For plots in docs notebooks
     "polars",  # For docs examples
     "statsmodels",  # For docs example
 ]
@@ -78,7 +78,8 @@ test = [
     "ipython",
     "pytest-cov",  # For coverage testing
     "dask",
-    'statsmodels'
+    'statsmodels',
+    "matplotlib",  # Required by docs notebooks tested via nbmake
 ]
 performance = [
     "dask",  # For distributed computing


### PR DESCRIPTION
## Summary of Changes  
adding xs per requested by #720 

## Related GitHub Issue(s)  
#720 

## Additional Context for Reviewers  


- [x ] I passed tests locally for both code (`pytest`) and documentation changes (`uv run jb build docs --builder=custom --custom-builder=doctest`)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces a new index-slicing entrypoint (`TrianglePandas.xs`) and adjusts dependency packaging by dropping `matplotlib` from required installs, which could impact environments that relied on it being present by default.
> 
> **Overview**
> Adds a pandas-like `xs` method on `TrianglePandas` to slice by MultiIndex key/level with an explicit `drop_level` option (defaulting to preserving existing `Triangle.loc` index behavior), including handling the fully-sliced case by assigning a default `Total` index.
> 
> Extends triangle tests to cover `xs` behavior across first-level, multi-level tuple keys, `drop_level=True` semantics, and slicing by a non-zero index level.
> 
> Updates packaging to remove `matplotlib` from core dependencies and instead include it in the `docs` and `test` optional extras.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 31ee55c56d47bc40f5e86e75c8b877220f33cdcd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->