### PR TITLE
Annotate matplotlib dependency as required for TriangleDisplay.heatmap() (#758)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ dependencies = [
     "numba>0.54",
     "sparse>=0.9",
     "numpy",
-    "matplotlib",
+    "matplotlib",  # Required for TriangleDisplay.heatmap()
     "dill",
     "patsy",
 ]


### PR DESCRIPTION
Closes #758.

Per @genedan's review: matplotlib is required at runtime by `TriangleDisplay.heatmap()` even though it isn't imported directly, so it must remain a core dependency. The original change moving it to docs/test extras has been reverted. Instead, this PR keeps matplotlib as a core dep and adds an inline comment so future contributors know why it can't be moved.

If a maintainer later decides matplotlib should be optional, the comment also serves as a pointer to the affected API.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only updates `pyproject.toml` metadata by adding a clarifying comment to an existing dependency, with no runtime code changes.
> 
> **Overview**
> Clarifies why `matplotlib` is included in core dependencies by adding an inline comment in `pyproject.toml` (noting it’s required for `TriangleDisplay.heatmap()`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a9772ce43716c4467eb02718e0378ef747264ca8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->