### PR TITLE
Fix Adjustments API page linking to chainladder.workflow (#757)

### DIFF
--- a/docs/library/api.md
+++ b/docs/library/api.md
@@ -107,9 +107,9 @@ Classes
 
 .. _adjustments_ref:
 
-:mod:`chainladder.workflow`: Adjustments
-========================================
-.. automodule:: chainladder.workflow
+:mod:`chainladder.adjustments`: Adjustments
+===========================================
+.. automodule:: chainladder.adjustments
  :no-members:
  :no-inherited-members:
 


### PR DESCRIPTION
Closes #757.

The Adjustments section in `docs/library/api.md` was a copy-paste of the Workflow section directly below it. Both the `:mod:` link in the header and the `.. automodule::` directive pointed at `chainladder.workflow`, so the rendered Adjustments page on RTD hyperlinked to the Workflow module instead of its own.

The four classes listed in that section (`BootstrapODPSample`, `BerquistSherman`, `Trend`, `ParallelogramOLF`) all live in `chainladder.adjustments`, which is the correct target.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change that corrects an incorrect module link; no runtime code paths are affected.
> 
> **Overview**
> Fixes the API reference docs so the **Adjustments** section links and auto-documents `chainladder.adjustments` instead of incorrectly pointing to `chainladder.workflow`, ensuring the rendered page targets the right module.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bf3ba82bc4162b7c41edf279b6365ab164fd9f6b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->