### PR TITLE
adding xs

### DIFF
--- a/chainladder/core/pandas.py
+++ b/chainladder/core/pandas.py
@@ -445,6 +445,29 @@ class TrianglePandas:
     def round(self, decimals=0, *args, **kwargs):
         return round(self, decimals)
 
+    def xs(self,index_key,level=None,drop_level=False):
+        '''
+        mimics xs from pandas. key differences 
+            - is always 0 and therefore not an argument in the function 
+            - drop-level is set to be False be default, to retain Triangle.loc behavior
+        main use case for this function is when slicing beyond the first field in the index (such as LOB in the clrd dataset)
+        '''
+        mi = pd.MultiIndex.from_frame(self.index)
+
+        lvl = 0 if level is None else level
+        loc, new_ax = mi.get_loc_level(index_key, level=lvl, drop_level=drop_level)
+
+        # create the tuple of the indexer
+        _indexer = [slice(None)] * 2
+        _indexer[0] = loc
+        indexer = tuple(_indexer)
+        result = self.iloc[indexer]
+        if new_ax is not None:
+            new_ax_df = new_ax.to_frame(index=None)[new_ax.names]
+            result.index = new_ax_df
+        else:
+            result.index = pd.DataFrame(data=['Total'],columns=['Total'])
+        return result
 
 def add_triangle_agg_func(
         cls: Type[TrianglePandas],

--- a/chainladder/core/pandas.py
+++ b/chainladder/core/pandas.py
@@ -25,6 +25,9 @@ if TYPE_CHECKING:
         Series
     )
     from types import ModuleType
+    from pandas._typing import(
+        IndexLabel
+    )
     from typing import (
         Literal,
         Self,
@@ -445,11 +448,14 @@ class TrianglePandas:
     def round(self, decimals=0, *args, **kwargs):
         return round(self, decimals)
 
-    def xs(self,index_key,level=None,drop_level=False):
+    def xs(
+        self,
+        index_key:IndexLabel,
+        level:IndexLabel | None = None,
+        drop_level:bool = True):
         '''
-        mimics xs from pandas. key differences 
-            - is always 0 and therefore not an argument in the function 
-            - drop-level is set to be False be default, to retain Triangle.loc behavior
+        mimics xs from pandas. key difference
+            - this function only slides the index, therefore axis is always 0 and not an argument in the function
         main use case for this function is when slicing beyond the first field in the index (such as LOB in the clrd dataset)
         '''
         mi = pd.MultiIndex.from_frame(self.index)

--- a/chainladder/core/tests/test_triangle.py
+++ b/chainladder/core/tests/test_triangle.py
@@ -1026,12 +1026,19 @@ def test_validate_assumption(raa: Triangle) -> None:
         )
 
 def test_xs(clrd):
-    assert clrd.xs('Adriatic Ins Co') == clrd.loc['Adriatic Ins Co']
     # when slicing with .loc on the first term in the index, Triangle will drop the term 
-    assert clrd.xs('Adriatic Ins Co',drop_level = True).index.equals(clrd.loc['Adriatic Ins Co'].index)
-    assert clrd.xs(('Agway Ins Co','comauto')) == clrd.loc['Agway Ins Co','comauto']
-    assert clrd.xs(('Agway Ins Co','comauto')).index.equals(clrd.loc['Agway Ins Co','comauto'].index)
+    assert clrd.xs('Adriatic Ins Co') == clrd.loc['Adriatic Ins Co']
+    assert clrd.xs('Adriatic Ins Co').index.equals(clrd.loc['Adriatic Ins Co'].index)
+    # when slicing with .loc on the all term in the index, Triangle will not drop any term 
+    assert clrd.xs(('Agway Ins Co','comauto'), drop_level=False) == clrd.loc['Agway Ins Co','comauto']
+    assert clrd.xs(('Agway Ins Co','comauto'), drop_level=False).index.equals(clrd.loc['Agway Ins Co','comauto'].index)
     # when all index terms are included in xs and drop_level is True, the default 'Total' index value is provided
     assert clrd.xs(('Agway Ins Co','comauto'), drop_level=True).index.equals(cl.load_sample('genins').index)
-    assert clrd.xs('comauto',level=1) == clrd.loc[clrd['LOB'] == 'comauto']
-    assert clrd.xs('comauto',level=1).index.equals(clrd.loc[clrd['LOB'] == 'comauto'].index)
+    # when slicing with .loc on the second or subsequent terms in the index, Triangle will not drop the term 
+    assert clrd.xs('comauto',level=1, drop_level=False) == clrd.loc[clrd['LOB'] == 'comauto']
+    assert clrd.xs('comauto',level=1, drop_level=False).index.equals(clrd.loc[clrd['LOB'] == 'comauto'].index)
+    # level works with either integer index or name of the index column
+    assert clrd.xs('comauto',level=1) == clrd.xs('comauto',level='LOB')
+    assert clrd.xs('comauto',level=1).index.equals(clrd.xs('comauto',level='LOB').index)
+
+

--- a/chainladder/core/tests/test_triangle.py
+++ b/chainladder/core/tests/test_triangle.py
@@ -1024,3 +1024,14 @@ def test_validate_assumption(raa: Triangle) -> None:
             triangle=raa,
             value=raa, axis=3  # noqa - incorrect type provided on purpose.
         )
+
+def test_xs(clrd):
+    assert clrd.xs('Adriatic Ins Co') == clrd.loc['Adriatic Ins Co']
+    # when slicing with .loc on the first term in the index, Triangle will drop the term 
+    assert clrd.xs('Adriatic Ins Co',drop_level = True).index.equals(clrd.loc['Adriatic Ins Co'].index)
+    assert clrd.xs(('Agway Ins Co','comauto')) == clrd.loc['Agway Ins Co','comauto']
+    assert clrd.xs(('Agway Ins Co','comauto')).index.equals(clrd.loc['Agway Ins Co','comauto'].index)
+    # when all index terms are included in xs and drop_level is True, the default 'Total' index value is provided
+    assert clrd.xs(('Agway Ins Co','comauto'), drop_level=True).index.equals(cl.load_sample('genins').index)
+    assert clrd.xs('comauto',level=1) == clrd.loc[clrd['LOB'] == 'comauto']
+    assert clrd.xs('comauto',level=1).index.equals(clrd.loc[clrd['LOB'] == 'comauto'].index)


### PR DESCRIPTION
## Summary of Changes  
adding xs to enable more flexible slicing, particular on index terms beyond the first

## Related GitHub Issue(s)  
requested by #720 

## Additional Context for Reviewers  


- [x] I passed tests locally for both code (`pytest`) and documentation changes (`uv run jb build docs --builder=custom --custom-builder=doctest`)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk because the change is additive and covered by new tests, but it touches index-slicing behavior where edge cases (full index selection and `drop_level`) could affect downstream expectations.
> 
> **Overview**
> Adds a new `TrianglePandas.xs()` method that mirrors pandas `xs` for **row-index cross-section slicing**, including `level` selection and `drop_level` handling for MultiIndex-style triangle indexes.
> 
> Extends the test suite with `test_xs` to validate behavior for first-level slicing, deeper-level slicing (e.g., `LOB`), and the special case where all index levels are selected (defaulting the index to `Total` when `drop_level=True`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 632571cb3018c7513a2faca3b9dbdf3a0c0237a7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->