### PR TITLE
Callable

### DIFF
--- a/chainladder/core/pandas.py
+++ b/chainladder/core/pandas.py
@@ -445,6 +445,29 @@ class TrianglePandas:
     def round(self, decimals=0, *args, **kwargs):
         return round(self, decimals)
 
+    def xs(self,index_key,level=None,drop_level=False):
+        '''
+        mimics xs from pandas. key differences 
+            - is always 0 and therefore not an argument in the function 
+            - drop-level is set to be False be default, to retain Triangle.loc behavior
+        main use case for this function is when slicing beyond the first field in the index (such as LOB in the clrd dataset)
+        '''
+        mi = pd.MultiIndex.from_frame(self.index)
+
+        lvl = 0 if level is None else level
+        loc, new_ax = mi.get_loc_level(index_key, level=lvl, drop_level=drop_level)
+
+        # create the tuple of the indexer
+        _indexer = [slice(None)] * 2
+        _indexer[0] = loc
+        indexer = tuple(_indexer)
+        result = self.iloc[indexer]
+        if new_ax is not None:
+            new_ax_df = new_ax.to_frame(index=None)[new_ax.names]
+            result.index = new_ax_df
+        else:
+            result.index = pd.DataFrame(data=['Total'],columns=['Total'])
+        return result
 
 def add_triangle_agg_func(
         cls: Type[TrianglePandas],

--- a/chainladder/core/slice.py
+++ b/chainladder/core/slice.py
@@ -13,6 +13,8 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from chainladder import Triangle
 
+_LOCABLES = ['ldf_','std_err_','sigma_','std_residuals_']
+
 class _LocBase:
     """
     Base class for pandas style loc/iloc indexing.
@@ -113,7 +115,14 @@ class Location(_LocBase):
     """ class to generate .loc[] functionality """
 
     def __getitem__(self, key):
-        obj = self.get_idx(self.key_to_slice(key))
+        idx = self.key_to_slice(key)
+        obj = self.get_idx(idx)
+        for attr in _LOCABLES:
+            if hasattr(self.obj,'attr'):
+                if idx[2] == slice(None, None, None) and idx[3] == slice(None, None, None):
+                    if getattr(self.obj,attr,None).index.equals(self.obj.index):
+                        if getattr(self.obj,attr,None).columns.equals(self.obj.columns):
+                            setattr(obj, attr, getattr(self.obj,attr,None).loc[key])
         if len(obj) > 1 and obj.index.iloc[:, 0].nunique() == 1:
             obj.set_index(obj.index.iloc[:, 1:], inplace=True)
         return obj
@@ -165,7 +174,6 @@ class Location(_LocBase):
         else:
             raise AttributeError("Unable to slice.")
 
-
     def key_to_slice(self, key):
         """ Converts keys to integer slices """
         key = self.format_key(key)
@@ -184,7 +192,15 @@ class Ilocation(_LocBase):
     """
 
     def __getitem__(self, key: tuple):
-        return self.get_idx(self._normalize_index(key))
+        idx = self._normalize_index(key)
+        obj = self.get_idx(idx)
+        for attr in _LOCABLES:
+            if hasattr(self.obj,attr):
+                if idx[2] == slice(None, None, None) and idx[3] == slice(None, None, None):
+                    if getattr(self.obj,attr,None).index.equals(self.obj.index):
+                        if getattr(self.obj,attr,None).columns.equals(self.obj.columns):
+                            setattr(obj, attr, getattr(self.obj,attr,None).iloc[key])
+        return obj
 
     def __setitem__(self, key, values):
         super().__setitem__(self._normalize_index(key), values)

--- a/chainladder/core/slice.py
+++ b/chainladder/core/slice.py
@@ -118,11 +118,13 @@ class Location(_LocBase):
         idx = self.key_to_slice(key)
         obj = self.get_idx(idx)
         for attr in _LOCABLES:
-            if hasattr(self.obj,'attr'):
-                if idx[2] == slice(None, None, None) and idx[3] == slice(None, None, None):
-                    if getattr(self.obj,attr,None).index.equals(self.obj.index):
-                        if getattr(self.obj,attr,None).columns.equals(self.obj.columns):
-                            setattr(obj, attr, getattr(self.obj,attr,None).loc[key])
+            if hasattr(self.obj,attr) and hasattr(self.obj,'index') and hasattr(self.obj,'columns'):
+                if hasattr(getattr(self.obj,attr,None),'index') and hasattr(getattr(self.obj,attr,None),'columns'):
+                    if isinstance(idx[2],slice) and isinstance(idx[3],slice):
+                        if idx[2] == slice(None, None, None) and idx[3] == slice(None, None, None):
+                            if getattr(self.obj,attr,None).index.equals(self.obj.index):
+                                if getattr(self.obj,attr,None).columns.equals(self.obj.columns):
+                                    setattr(obj, attr, getattr(self.obj,attr,None).loc[key])
         if len(obj) > 1 and obj.index.iloc[:, 0].nunique() == 1:
             obj.set_index(obj.index.iloc[:, 1:], inplace=True)
         return obj
@@ -195,11 +197,13 @@ class Ilocation(_LocBase):
         idx = self._normalize_index(key)
         obj = self.get_idx(idx)
         for attr in _LOCABLES:
-            if hasattr(self.obj,attr):
-                if idx[2] == slice(None, None, None) and idx[3] == slice(None, None, None):
-                    if getattr(self.obj,attr,None).index.equals(self.obj.index):
-                        if getattr(self.obj,attr,None).columns.equals(self.obj.columns):
-                            setattr(obj, attr, getattr(self.obj,attr,None).iloc[key])
+            if hasattr(self.obj,attr) and hasattr(self.obj,'index') and hasattr(self.obj,'columns'):
+                if hasattr(getattr(self.obj,attr,None),'index') and hasattr(getattr(self.obj,attr,None),'columns'):
+                    if isinstance(idx[2],slice) and isinstance(idx[3],slice):
+                        if idx[2] == slice(None, None, None) and idx[3] == slice(None, None, None):
+                            if getattr(self.obj,attr,None).index.equals(self.obj.index):
+                                if getattr(self.obj,attr,None).columns.equals(self.obj.columns):
+                                    setattr(obj, attr, getattr(self.obj,attr,None).iloc[key])
         return obj
 
     def __setitem__(self, key, values):

--- a/chainladder/core/tests/test_slicing.py
+++ b/chainladder/core/tests/test_slicing.py
@@ -1,16 +1,26 @@
 
 import numpy as np
 import pytest
+import chainladder as cl
 
+_LOCABLES = cl.core.slice._LOCABLES
 
 def test_slice_by_boolean(clrd):
     assert (
         clrd[clrd["LOB"] == "ppauto"].loc["Wolverine Mut Ins Co"]["CumPaidLoss"]
         == clrd.loc["Wolverine Mut Ins Co"].loc["ppauto"]["CumPaidLoss"])
+    clrd_devs = cl.Development().fit_transform(clrd)
+    locable = getattr(clrd_devs,_LOCABLES[0])
+    assert (
+        locable[locable["LOB"] == "ppauto"].loc["Wolverine Mut Ins Co"]["CumPaidLoss"]
+        == getattr(clrd_devs.loc["Wolverine Mut Ins Co"].loc["ppauto"]["CumPaidLoss"],_LOCABLES[0]))
 
 
 def test_slice_by_loc(clrd):
     assert clrd.loc["Aegis Grp"].loc["comauto"].index.iloc[0, 0] == "comauto"
+    clrd_devs = cl.Development().fit_transform(clrd)
+    locable = getattr(clrd_devs,_LOCABLES[0])
+    assert locable.loc["Aegis Grp"].loc["comauto"].index.iloc[0, 0] == "comauto"
 
 
 def test_slice_origin(raa):
@@ -25,21 +35,37 @@ def test_slice_development(raa):
 
 def test_slice_by_loc_iloc(clrd):
     assert clrd.groupby("LOB").sum().loc["comauto"].index.iloc[0, 0] == "comauto"
+    clrd_devs = cl.Development().fit_transform(clrd.groupby("LOB").sum())
+    locable = getattr(clrd_devs,_LOCABLES[0])
+    assert locable.loc["comauto"].index.iloc[0, 0] == "comauto"
     assert len(clrd.loc[clrd.index.iloc[150]]) == 1
 
 
 def test_slicers_honor_order(clrd):
+    clrd_devs = cl.Development().fit_transform(clrd.groupby("LOB").sum())
     clrd = clrd.groupby("LOB").sum()
+    locable = getattr(clrd_devs,_LOCABLES[0])
     assert clrd.iloc[[1, 0], :].iloc[0, 1] == clrd.iloc[1, 1]  # row
+    assert locable.iloc[[1, 0], :].iloc[0, 1] == getattr(clrd_devs.iloc[1, 1],_LOCABLES[0])  # row
     assert clrd.iloc[[1, 0], [1, 0]].iloc[0, 0] == clrd.iloc[1, 1]  # col
+    assert locable.iloc[[1, 0], [1, 0]].iloc[0, 0] == getattr(clrd_devs.iloc[1, 1],_LOCABLES[0])  # col
     assert clrd.loc[:, ["CumPaidLoss", "IncurLoss"]].iloc[0, 0] == clrd.iloc[0, 1]
+    assert locable.loc[:, ["CumPaidLoss", "IncurLoss"]].iloc[0, 0] == getattr(clrd_devs.iloc[0, 1],_LOCABLES[0])
     assert (
         clrd.loc[["ppauto", "medmal"], ["CumPaidLoss", "IncurLoss"]].iloc[0, 0]
         == clrd.iloc[3]["CumPaidLoss"]
     )
     assert (
+        locable.loc[["ppauto", "medmal"], ["CumPaidLoss", "IncurLoss"]].iloc[0, 0]
+        == getattr(clrd_devs.iloc[3]["CumPaidLoss"],_LOCABLES[0])
+    )
+    assert (
         clrd.loc[clrd["LOB"] == "comauto", ["CumPaidLoss", "IncurLoss"]]
         == clrd[clrd["LOB"] == "comauto"].iloc[:, [1, 0]]
+    )
+    assert (
+        locable.loc[clrd["LOB"] == "comauto", ["CumPaidLoss", "IncurLoss"]]
+        == getattr(clrd_devs[clrd["LOB"] == "comauto"].iloc[:, [1, 0]],_LOCABLES[0])
     )
     assert clrd.groupby("LOB").sum() == clrd
 
@@ -52,7 +78,10 @@ def test_backends(clrd):
 
 
 def test_union_columns(clrd):
+    clrd_devs = cl.Development().fit_transform(clrd)
+    locable = getattr(clrd_devs,_LOCABLES[0])
     assert clrd.iloc[:, :3] + clrd.iloc[:, 3:] == clrd
+    assert locable.iloc[:, :3] + getattr(clrd_devs.iloc[:, 3:],_LOCABLES[0]) == getattr(clrd_devs,_LOCABLES[0])
 
 
 def test_4loc(clrd):
@@ -72,14 +101,22 @@ def test_4loc(clrd):
 
 
 def test_loc_ellipsis(clrd):
+    clrd_devs = cl.Development().fit_transform(clrd)
+    locable = getattr(clrd_devs,_LOCABLES[0])
     assert (
         clrd.loc["Aegis Grp"] == clrd.loc["Adriatic Ins Co":"Aegis Grp"].loc["Aegis Grp"]
     )
+    assert (
+        locable.loc["Aegis Grp"] == getattr(clrd_devs.loc["Adriatic Ins Co":"Aegis Grp"].loc["Aegis Grp"],_LOCABLES[0])
+    )
     assert clrd.loc["Aegis Grp", ..., :] == clrd.loc["Aegis Grp"]
+    assert locable.loc["Aegis Grp", ..., :] == getattr(clrd_devs.loc["Aegis Grp"],_LOCABLES[0])
     assert clrd.loc[..., 24:] == clrd.loc[..., :, 24:]
     assert clrd.loc[:, ..., 24:] == clrd.loc[..., :, 24:]
     assert clrd.loc[:, "CumPaidLoss"] == clrd.loc[:, "CumPaidLoss", ...]
+    assert locable.loc[:, "CumPaidLoss"] == getattr(clrd_devs.loc[:, "CumPaidLoss", ...],_LOCABLES[0])
     assert clrd.loc[..., "CumPaidLoss", :, :] == clrd.loc[:, "CumPaidLoss", :, :]
+    assert locable.loc[..., "CumPaidLoss", :, :] == getattr(clrd_devs.loc[:, "CumPaidLoss", :, :],_LOCABLES[0])
 
 
 def test_missing_first_lag(raa):
@@ -90,15 +127,22 @@ def test_missing_first_lag(raa):
 
 
 def test_reverse_slice_integrity(clrd):
+    clrd_devs = cl.Development().fit_transform(clrd)
+    locable = getattr(clrd_devs,_LOCABLES[0])
     assert clrd.iloc[::-1, ::-1].shape == clrd.shape
     assert np.all(clrd.iloc[:, ::-1].columns.values == clrd.columns[::-1])
     assert clrd.iloc[clrd.index.index[::-1]] + clrd == 2 * clrd
-
+    assert locable.iloc[::-1, ::-1].shape == locable.shape
+    assert np.all(locable.iloc[:, ::-1].columns.values == locable.columns[::-1])
+    assert locable.iloc[locable.index.index[::-1]] + locable == 2 * locable
 
 def test_loc_tuple(clrd):
+    clrd_devs = cl.Development().fit_transform(clrd)
+    locable = getattr(clrd_devs,_LOCABLES[0])
     assert len(clrd.loc[("Adriatic Ins Co", "othliab")]) == 1
     assert clrd.loc[clrd.index] == clrd
-
+    assert len(locable.loc[("Adriatic Ins Co", "othliab")]) == 1
+    assert locable.loc[locable.index] == locable
 
 def test_at_iat(raa):
     raa1 = raa.copy()
@@ -111,6 +155,17 @@ def test_at_iat(raa):
     raa2.iat[-1, -1, 4, 0] = 5
     assert raa1 == raa2
 
+def test_at_iat_exceptions(raa):
+    with pytest.raises(ValueError):
+        raa.iat[0,0,4,:]
+    with pytest.raises(ValueError):
+        raa.at['Total','values', '1985', 0:2]
+
+def test_loc_iloc_exceptions(raa):
+    with pytest.raises(ValueError):
+        raa.loc['Total','values',:,[12,36,48]]
+    with pytest.raises(ValueError):
+        raa.loc['Something','values',:,:]
 
 @pytest.mark.xfail
 def test_sparse_at_iat(prism):

--- a/chainladder/core/tests/test_triangle.py
+++ b/chainladder/core/tests/test_triangle.py
@@ -1024,3 +1024,14 @@ def test_validate_assumption(raa: Triangle) -> None:
             triangle=raa,
             value=raa, axis=3  # noqa - incorrect type provided on purpose.
         )
+
+def test_xs(clrd):
+    assert clrd.xs('Adriatic Ins Co') == clrd.loc['Adriatic Ins Co']
+    # when slicing with .loc on the first term in the index, Triangle will drop the term 
+    assert clrd.xs('Adriatic Ins Co',drop_level = True).index.equals(clrd.loc['Adriatic Ins Co'].index)
+    assert clrd.xs(('Agway Ins Co','comauto')) == clrd.loc['Agway Ins Co','comauto']
+    assert clrd.xs(('Agway Ins Co','comauto')).index.equals(clrd.loc['Agway Ins Co','comauto'].index)
+    # when all index terms are included in xs and drop_level is True, the default 'Total' index value is provided
+    assert clrd.xs(('Agway Ins Co','comauto'), drop_level=True).index.equals(cl.load_sample('genins').index)
+    assert clrd.xs('comauto',level=1) == clrd.loc[clrd['LOB'] == 'comauto']
+    assert clrd.xs('comauto',level=1).index.equals(clrd.loc[clrd['LOB'] == 'comauto'].index)


### PR DESCRIPTION
## Summary of Changes  


## Related GitHub Issue(s)  


## Additional Context for Reviewers  


- [ ] I passed tests locally for both code (`pytest`) and documentation changes (`uv run jb build docs --builder=custom --custom-builder=doctest`)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core slicing semantics (`.loc`/`.iloc`) and adds new `xs` indexing behavior, which can subtly change results for fitted triangles and downstream computations if index alignment assumptions are wrong.
> 
> **Overview**
> Adds a pandas-like `Triangle.xs()` helper to slice by a specific index key/level while optionally retaining index levels (defaulting to `drop_level=False` to match existing `Triangle.loc` expectations).
> 
> Updates `Triangle.loc`/`Triangle.iloc` slicing to also slice and carry through fitted subtriangle attributes (e.g., `ldf_`, `std_err_`, `sigma_`, `std_residuals_`) when they share the same `index`/`columns`, and expands tests to validate this behavior plus new exception cases for invalid `at`/`iat` and `loc` inputs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 411fafc810a4489244e96a0dc94d8a4660bdd1b6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->