### PR TITLE
#717

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -7,4 +7,4 @@
 ## Additional Context for Reviewers  
 
 
-- [ ] I passed tests locally for both code (`pytest`) and documentation changes (`uv run jb build docs --builder=custom --custom-builder=doctest`)
+- [ ] I passed tests locally for both code (`uv run pytest`) and documentation changes (`uv run jb build docs --builder=custom --custom-builder=doctest`)

--- a/docs/getting_started/install.md
+++ b/docs/getting_started/install.md
@@ -3,15 +3,18 @@
 We strongly encourage users to install chainladder in a dedicated virtual environment.
 
 ## General Installation
-Install the chainladder package using `pip`:
+We recommend **uv** for installing `chainladder`, but you can use any of the managers below:
 
 
 [![](https://pepy.tech/badge/chainladder)](https://pepy.tech/project/chainladder)
 
 
-Installing `chainladder` using `pip`:
-
-`pip install chainladder`
+| Manager | Command | Source |
+|:---|:---|:---|
+| uv (recommended) | `uv add chainladder` | PyPI |
+| pip | `pip install chainladder` | PyPI |
+| pixi | `pixi add chainladder` | conda-forge |
+| conda | `conda install -c conda-forge chainladder` | conda-forge |
 
 Alternatively, if you have git and want to enjoy unreleased features, you can
 install directly from `Github`:


### PR DESCRIPTION
## Summary of Changes  
Add more installation options

## Related GitHub Issue(s)  
Closes #717 

## Additional Context for Reviewers  
I don't see 0.9.2 on conda yet, but this ticket does not impact the build on conda. The build will take a few hours to publish on conda.

- [x] I passed tests locally for both code (`pytest`) and documentation changes (`uv run jb build docs --builder=custom --custom-builder=doctest`)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only updates with no runtime/codepath impact; risk is limited to potential confusion if install/test commands are incorrect.
> 
> **Overview**
> Updates the PR template to use `uv run pytest` instead of `pytest` for the local test checklist.
> 
> Expands the installation docs to recommend `uv` and adds a table of install commands for `uv`, `pip`, `pixi`, and `conda` (including the package source).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c2c748ce09c006c87eea6f29d9d69b8e0b2a9489. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->