### PR TITLE
test(development): assert exclusions-ignored UserWarning in drop tests (#765)

### DIFF
--- a/chainladder/development/base.py
+++ b/chainladder/development/base.py
@@ -247,6 +247,13 @@ class DevelopmentBase(
 
         weights = index_array_weights
 
+        # NOTE: The "Some exclusions have been ignored..." UserWarning below is
+        # asserted by the test suite (see chainladder/development/tests/
+        # test_development.py and test_incremental.py, which use
+        # pytest.warns(..., match="exclusions have been ignored")).
+        # Do not modify the warning message or remove the warnings.warn(...)
+        # call without updating the corresponding pytest.warns matchers,
+        # otherwise those tests will fail.
         if warning_flag:
             if preserve == 1:
                 warning = (
@@ -323,6 +330,13 @@ class DevelopmentBase(
             index_array_weights,
         )
 
+        # NOTE: The "Some exclusions have been ignored..." UserWarning below is
+        # asserted by the test suite (see chainladder/development/tests/
+        # test_development.py and test_incremental.py, which use
+        # pytest.warns(..., match="exclusions have been ignored")).
+        # Do not modify the warning message or remove the warnings.warn(...)
+        # call without updating the corresponding pytest.warns matchers,
+        # otherwise those tests will fail.
         if warning_flag:
             if preserve == 1:
                 warning = (
@@ -534,6 +548,13 @@ class DevelopmentBase(
             ldf_count[..., None] < preserve_array[..., None], w, index_array_weights
         )
 
+        # NOTE: The "Some exclusions have been ignored..." UserWarning below is
+        # asserted by the test suite (see chainladder/development/tests/
+        # test_development.py and test_incremental.py, which use
+        # pytest.warns(..., match="exclusions have been ignored")).
+        # Do not modify the warning message or remove the warnings.warn(...)
+        # call without updating the corresponding pytest.warns matchers,
+        # otherwise those tests will fail.
         if warning_flag:
             if self.preserve == 1:
                 warning = (
@@ -606,6 +627,13 @@ class DevelopmentBase(
             factor_ranks.transpose((0, 1, 3, 2)) < max_rank[..., None]
         ) & (factor_ranks.transpose((0, 1, 3, 2)) > min_rank[..., None] - 1)
 
+        # NOTE: The "Some exclusions have been ignored..." UserWarning below is
+        # asserted by the test suite (see chainladder/development/tests/
+        # test_development.py and test_incremental.py, which use
+        # pytest.warns(..., match="exclusions have been ignored")).
+        # Do not modify the warning message or remove the warnings.warn(...)
+        # call without updating the corresponding pytest.warns matchers,
+        # otherwise those tests will fail.
         if warning_flag:
             if self.preserve == 1:
                 warning = (

--- a/chainladder/development/tests/test_development.py
+++ b/chainladder/development/tests/test_development.py
@@ -69,12 +69,11 @@ def test_drophighlow():
     )
     assert np.all(lhs == rhs)
 
-    lhs = np.round(
-        cl.Development(drop_high=[2, 3, 3, 3], drop_low=[0, 1, 0], preserve=2)
-        .fit(raa)
-        .cdf_.values,
-        4,
-    ).flatten()
+    with pytest.warns(UserWarning, match="exclusions have been ignored"):
+        dev = cl.Development(
+            drop_high=[2, 3, 3, 3], drop_low=[0, 1, 0], preserve=2
+        ).fit(raa)
+    lhs = np.round(dev.cdf_.values, 4).flatten()
     rhs = np.array(
         [
             5.7403,
@@ -90,31 +89,33 @@ def test_drophighlow():
     )
     assert np.all(lhs == rhs)
 
-    lhs = np.round(cl.Development(drop_high=1).fit(raa).cdf_.values, 4).flatten()
+    with pytest.warns(UserWarning, match="exclusions have been ignored"):
+        dev = cl.Development(drop_high=1).fit(raa)
+    lhs = np.round(dev.cdf_.values, 4).flatten()
     rhs = np.array(
         [7.2190, 2.5629, 1.6592, 1.3570, 1.1734, 1.0669, 1.0419, 1.0121, 1.0092]
     )
     assert np.all(lhs == rhs)
 
-    lhs = np.round(
-        cl.Development(drop_high=1, drop_low=1).fit(raa).cdf_.values, 4
-    ).flatten()
+    with pytest.warns(UserWarning, match="exclusions have been ignored"):
+        dev = cl.Development(drop_high=1, drop_low=1).fit(raa)
+    lhs = np.round(dev.cdf_.values, 4).flatten()
     rhs = np.array(
         [9.0982, 2.8731, 1.8320, 1.4713, 1.2522, 1.0963, 1.0604, 1.0263, 1.0092]
     )
     assert np.all(lhs == rhs)
 
-    lhs = np.round(
-        cl.Development(drop_high=[2, 1, 1], drop_low=1).fit(raa).cdf_.values, 4
-    ).flatten()
+    with pytest.warns(UserWarning, match="exclusions have been ignored"):
+        dev = cl.Development(drop_high=[2, 1, 1], drop_low=1).fit(raa)
+    lhs = np.round(dev.cdf_.values, 4).flatten()
     rhs = np.array(
         [8.4905, 3.0589, 1.9504, 1.5664, 1.3142, 1.1403, 1.0822, 1.0426, 1.0092]
     )
     assert np.all(lhs == rhs)
 
-    lhs = np.round(
-        cl.Development(drop_high=1, drop_low=1, n_periods=5).fit(raa).cdf_.values, 4
-    ).flatten()
+    with pytest.warns(UserWarning, match="exclusions have been ignored"):
+        dev = cl.Development(drop_high=1, drop_low=1, n_periods=5).fit(raa)
+    lhs = np.round(dev.cdf_.values, 4).flatten()
     rhs = np.array(
         [16.3338, 3.2092, 1.8124, 1.4793, 1.2522, 1.0963, 1.0604, 1.0263, 1.0092]
     )
@@ -274,27 +275,31 @@ def test_new_drop_4(clrd):
 def test_new_drop_5(clrd):
     clrd = clrd.groupby("LOB")[["IncurLoss", "CumPaidLoss"]].sum()
     # drop_hi/low without preserve
-    compare_new_drop(
-        cl.Development(drop_high=1, drop_low=1, preserve=3).fit(clrd), clrd
-    )
+    with pytest.warns(UserWarning, match="exclusions have been ignored"):
+        dev = cl.Development(drop_high=1, drop_low=1, preserve=3).fit(clrd)
+    compare_new_drop(dev, clrd)
 
 
 def test_new_drop_5a(clrd):
     clrd = clrd.groupby("LOB")[["IncurLoss", "CumPaidLoss"]].sum()
     # drop_hi/low without preserve
-    assert np.array_equal(
-        cl.Development(drop_high=1, drop_low=1, preserve=3)
-        ._set_weight_func(clrd.age_to_age, clrd.age_to_age)
-        .values,
-        cl.Development(
-            drop_high=True,
-            drop_low=[True, True, True, True, True, True, True, True, True],
-            preserve=3,
+    with pytest.warns(UserWarning, match="exclusions have been ignored"):
+        lhs = (
+            cl.Development(drop_high=1, drop_low=1, preserve=3)
+            ._set_weight_func(clrd.age_to_age, clrd.age_to_age)
+            .values
         )
-        ._set_weight_func(clrd.age_to_age)
-        .values,
-        True,
-    )
+    with pytest.warns(UserWarning, match="exclusions have been ignored"):
+        rhs = (
+            cl.Development(
+                drop_high=True,
+                drop_low=[True, True, True, True, True, True, True, True, True],
+                preserve=3,
+            )
+            ._set_weight_func(clrd.age_to_age)
+            .values
+        )
+    assert np.array_equal(lhs, rhs, True)
 
 
 def test_new_drop_6(clrd):
@@ -306,9 +311,11 @@ def test_new_drop_6(clrd):
 def test_new_drop_7(clrd):
     clrd = clrd.groupby("LOB")[["IncurLoss", "CumPaidLoss"]].sum()
     # drop_above/below with preserve
-    compare_new_drop(
-        cl.Development(drop_above=1.01, drop_below=0.95, preserve=3).fit(clrd), clrd
-    )
+    with pytest.warns(UserWarning, match="exclusions have been ignored"):
+        dev = cl.Development(
+            drop_above=1.01, drop_below=0.95, preserve=3
+        ).fit(clrd)
+    compare_new_drop(dev, clrd)
 
 
 def test_new_drop_8():
@@ -404,15 +411,16 @@ def test_4d_drop(clrd):
 
 def test_pipeline(clrd):
     clrd = clrd.groupby("LOB")[["IncurLoss", "CumPaidLoss"]].sum()
-    dev1 = cl.Development(
-        n_periods=7,
-        drop_valuation=1995,
-        drop=("1992", 12),
-        drop_above=1.05,
-        drop_below=0.95,
-        drop_high=1,
-        drop_low=1,
-    ).fit(clrd)
+    with pytest.warns(UserWarning, match="exclusions have been ignored"):
+        dev1 = cl.Development(
+            n_periods=7,
+            drop_valuation=1995,
+            drop=("1992", 12),
+            drop_above=1.05,
+            drop_below=0.95,
+            drop_high=1,
+            drop_low=1,
+        ).fit(clrd)
     pipe = cl.Pipeline(
         steps=[
             ("n_periods", cl.Development(n_periods=7)),
@@ -422,7 +430,8 @@ def test_pipeline(clrd):
             ("drop_hilo", cl.Development(drop_high=1, drop_low=1)),
         ]
     )
-    dev2 = pipe.fit(X=clrd)
+    with pytest.warns(UserWarning, match="exclusions have been ignored"):
+        dev2 = pipe.fit(X=clrd)
     assert np.array_equal(
         dev1.w_v2_.values, dev2.named_steps.drop_hilo.w_v2_.values, True
     )

--- a/chainladder/development/tests/test_incremental.py
+++ b/chainladder/development/tests/test_incremental.py
@@ -1,5 +1,6 @@
 import chainladder as cl
 import numpy as np
+import pytest
 
 
 def test_schmidt():
@@ -55,15 +56,16 @@ def test_pipeline():
     clrd = cl.load_sample("clrd").groupby("LOB")[["IncurLoss", "CumPaidLoss"]].sum()
     dev = cl.Development().fit_transform(clrd)
     ult = cl.Chainladder().fit(clrd)
-    dev1 = cl.IncrementalAdditive(
-        n_periods=7,
-        drop_valuation=1995,
-        drop=("1992", 12),
-        drop_above=1.05,
-        drop_below=-1,
-        drop_high=1,
-        drop_low=1,
-    ).fit(clrd, sample_weight=ult.ultimate_ * 3)
+    with pytest.warns(UserWarning, match="exclusions have been ignored"):
+        dev1 = cl.IncrementalAdditive(
+            n_periods=7,
+            drop_valuation=1995,
+            drop=("1992", 12),
+            drop_above=1.05,
+            drop_below=-1,
+            drop_high=1,
+            drop_low=1,
+        ).fit(clrd, sample_weight=ult.ultimate_ * 3)
     pipe = cl.Pipeline(
         steps=[
             ("n_periods", cl.IncrementalAdditive(n_periods=7)),
@@ -76,7 +78,8 @@ def test_pipeline():
             ("drop_hilo", cl.IncrementalAdditive(drop_high=1, drop_low=1)),
         ]
     )
-    dev2 = pipe.fit(X=clrd, sample_weight=ult.ultimate_ * 3)
+    with pytest.warns(UserWarning, match="exclusions have been ignored"):
+        dev2 = pipe.fit(X=clrd, sample_weight=ult.ultimate_ * 3)
     assert np.array_equal(
         dev1.zeta_.values, dev2.named_steps.drop_hilo.zeta_.values, True
     )


### PR DESCRIPTION
Closes #765.

Per @kennethshsu's call on the issue thread to use `pytest.warns` uniformly and not blanket-silence with `@pytest.mark.filterwarnings`, this wraps each `.fit()` / `._set_weight_func()` call that emits `UserWarning: "Some exclusions have been ignored..."` in `pytest.warns(UserWarning, match="exclusions have been ignored")`.

This makes the contract explicit at each call site: the test fails if the warning stops firing OR if its message changes. The two calls in `test_drophighlow` that don't warn (`drop_high=0` and `drop_high=[T,F,T,F]`) were left untouched, since wrapping them would assert a warning that doesn't fire.

### Affected tests

`chainladder/development/tests/test_development.py`:
- `test_drophighlow` — wrapped 5 of 7 `.fit()` calls (the two that don't warn left as-is)
- `test_new_drop_5` — wrapped the single `.fit()`
- `test_new_drop_5a` — wrapped both `_set_weight_func` calls (factored out lhs/rhs locals for the `pytest.warns` blocks)
- `test_new_drop_7` — wrapped the single `.fit()`
- `test_pipeline` — wrapped both `dev1` and pipeline `.fit()`

`chainladder/development/tests/test_incremental.py`:
- `test_pipeline` — wrapped both `dev1` and pipeline `.fit()`; added `import pytest`

### Verification

Local run on the branch:

```
671 passed, 12 xfailed (pre-existing)
```

Targeted `pytest chainladder/development/tests/` warning-summary count for `"exclusions have been ignored"` drops from 10 to 4. The remaining 4 are pytest's source-line accounting from inside the `pytest.warns` blocks (deduplicated by warning location), not leaked warnings — running `pytest -W "error::UserWarning"` on the targeted set still passes, confirming no warnings escape the context managers.

### Out of scope

Other warning families flagged in #765 (e.g. `X and sample_weight not aligned`, accumulate-overflow RuntimeWarnings, infer-format) are deliberately not touched here. Happy to file follow-up issues if the maintainers want them addressed individually.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to tests and clarifying comments around an existing `UserWarning` message, with no changes to development calculation logic.
> 
> **Overview**
> Tests now *explicitly assert* the existing `UserWarning` emitted when `preserve` forces exclusions to be ignored by wrapping affected `.fit()` / `._set_weight_func()` calls in `pytest.warns(..., match="exclusions have been ignored")` (including pipeline tests for both `Development` and `IncrementalAdditive`).
> 
> `DevelopmentBase` adds inline notes next to each warning site to prevent accidental edits to the warning text or removal of `warnings.warn(...)` without updating the test matchers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 44decd5168b378493d8b22e49780ac9c597ea1b9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->