### PR TITLE
adding column support for callable developmentconstant

### DIFF
--- a/chainladder/development/constant.py
+++ b/chainladder/development/constant.py
@@ -18,7 +18,7 @@ class DevelopmentConstant(DevelopmentBase):
     style: string, optional (default='ldf')
         Type of pattern given to the Estimator. Options include 'cdf' or 'ldf'.
     callable_axis: 0 or 1
-        If a callable is supplied, the axis (index or column) along which to apply
+        If a callable is supplied, the axis, index (0) or column (1) along which to apply
         the callable. If patterns is not a callable, then this parameter is ignored.
     groupby:
         option to group levels of the triangle index together for the purposes
@@ -60,11 +60,18 @@ class DevelopmentConstant(DevelopmentBase):
         xp = obj.get_array_module()
         obj = obj.iloc[..., :1, :-1]*0+1
         if callable(self.patterns):
-            ldf = obj.index.apply(self.patterns, axis=self.callable_axis)
-            ldf = (
-                pd.concat(ldf.apply(pd.DataFrame, index=[0]).values, axis=0)
-                  .fillna(1)[obj.ddims].values)
-            ldf = xp.array(ldf[:, None, None, :])
+            if self.callable_axis == 0:
+                ldf = obj.index.apply(self.patterns, axis=1)                
+                ldf = (
+                    pd.concat(ldf.apply(pd.DataFrame, index=[0]).values, axis=0)
+                    .fillna(1)[obj.ddims].values)
+                ldf = xp.array(ldf[:, None, None, :])
+            elif self.callable_axis == 1:
+                ldf = obj.columns.to_frame(index=False).apply(self.patterns, axis=1)
+                ldf = (
+                    pd.concat(ldf.apply(pd.DataFrame, index=[0]).values, axis=0)
+                    .fillna(1)[obj.ddims].values)
+                ldf = xp.array(ldf[None, :, None, :])
         else:
             ldf = xp.array([float(self.patterns[item]) for item in obj.ddims])
             ldf = ldf[None, None, None, :]

--- a/chainladder/development/tests/test_constant.py
+++ b/chainladder/development/tests/test_constant.py
@@ -53,4 +53,4 @@ def test_constant_callable_axis1(clrd, atol):
         return patterns.loc[x.loc['columns']].to_dict()
     lhs = cl.DevelopmentConstant(patterns=paid_cdfs, callable_axis=1, style='cdf').fit(agway).cdf_.sum().sum()
     rhs = sum([sum(l[:-1]) for l in cdfs.values()])
-    assert (lhs - rhs) < atol
+    assert abs(lhs - rhs) < atol

--- a/chainladder/development/tests/test_constant.py
+++ b/chainladder/development/tests/test_constant.py
@@ -22,7 +22,7 @@ def test_constant_ldf(raa):
     dev_c = cl.DevelopmentConstant(patterns=link_ratios, style="ldf").fit(raa)
     assert xp.allclose(dev.ldf_.values, dev_c.ldf_.values, atol=1e-5)
 
-def test_constant_callable(clrd, atol):
+def test_constant_callable_axis0(clrd, atol):
     agway = clrd.loc['Agway Ins Co', 'CumPaidLoss']
     def paid_cdfs(x):
         """ A function that returns different CDFs depending on a specified LOB """
@@ -35,5 +35,22 @@ def test_constant_callable(clrd, atol):
         'wkcomp': [4.106, 1.865, 1.418, 1.234, 1.141, 1.09, 1.056, 1.03, 1.01, 1]}
         patterns = pd.DataFrame(cdfs, index=range(12, 132, 12)).T
         return patterns.loc[x.loc['LOB']].to_dict()
-    model = cl.DevelopmentConstant(patterns=paid_cdfs, callable_axis=1, style='cdf')
+    model = cl.DevelopmentConstant(patterns=paid_cdfs, callable_axis=0, style='cdf')
     assert abs(model.fit_transform(agway).cdf_.loc['comauto'].iloc[..., 0].sum() - 3.832) < atol
+
+def test_constant_callable_axis1(clrd, atol):
+    agway = cl.load_sample('clrd').loc['Agway Ins Co', 'comauto']
+    cdfs = {
+        'IncurLoss': [3.832, 1.874, 1.386, 1.181, 1.085, 1.043, 1.022, 1.013, 1.007, 1],
+        'CumPaidLoss': [24.168, 4.127, 2.103, 1.528, 1.275, 1.161, 1.088, 1.047, 1.018, 1],
+        'BulkLoss': [10.887, 3.416, 1.957, 1.433, 1.231, 1.119, 1.06, 1.031, 1.011, 1],
+        'EarnedPremDIR': [2.559, 1.417, 1.181, 1.084, 1.04, 1.019, 1.009, 1.004, 1.001, 1],
+        'EarnedPremCeded': [13.703, 5.613, 2.92, 1.765, 1.385, 1.177, 1.072, 1.034, 1.008, 1],
+        'EarnedPremNet': [4.106, 1.865, 1.418, 1.234, 1.141, 1.09, 1.056, 1.03, 1.01, 1]}
+    def paid_cdfs(x):
+        """ A function that returns different CDFs depending on a specified column """
+        patterns = pd.DataFrame(cdfs, index=range(12, 132, 12)).T
+        return patterns.loc[x.loc['columns']].to_dict()
+    lhs = cl.DevelopmentConstant(patterns=paid_cdfs, callable_axis=1, style='cdf').fit(agway).cdf_.sum().sum()
+    rhs = sum([sum(l[:-1]) for l in cdfs.values()])
+    assert (lhs - rhs) < atol


### PR DESCRIPTION
## Summary of Changes  


## Related GitHub Issue(s)  


## Additional Context for Reviewers  


- [ ] I passed tests locally for both code (`uv run pytest`) and documentation changes (`uv run jb build docs --builder=custom --custom-builder=doctest`)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core development pattern construction when `patterns` is callable; incorrect axis handling could change LDF/CDF outputs, though the change is small and covered by new tests for both axes.
> 
> **Overview**
> `DevelopmentConstant` now supports callable `patterns` applied along either the triangle **index** (`callable_axis=0`) or **columns** (`callable_axis=1`), shaping the resulting LDF array appropriately for broadcasting.
> 
> Tests were updated to clarify the existing index-axis behavior and to add coverage for the new column-axis callable mode.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f296dfff564584139da65a7ae1e4b0f9490e18f7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->