### PR TITLE
rebasing to main

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -2,9 +2,9 @@ name: Unit Tests
 
 
 on:
-  # push:
-  #   branches:
-  #   - '*'
+  push:
+    branches:
+    - '*'
 
   pull_request:
 

--- a/README.rst
+++ b/README.rst
@@ -1,30 +1,36 @@
 .. -*- mode: rst -*-
 
-.. |PyPI version| image:: https://badgen.net/pypi/v/chainladder
-   :target: https://pypi.python.org/pypi/chainladder
-
 .. |Python versions| image:: https://badgen.net/pypi/python/chainladder
    :target: https://pypi.python.org/pypi/chainladder
 
-.. |License| image:: https://badgen.net/pypi/license/chainladder
+.. |PyPI version| image:: https://badgen.net/pypi/v/chainladder
    :target: https://pypi.python.org/pypi/chainladder
 
 .. |Downloads| image:: https://badgen.net/pypi/dm/chainladder
    :target: https://pypi.python.org/pypi/chainladder
 
+.. |Conda-forge version| image:: https://img.shields.io/conda/vn/conda-forge/chainladder.svg?label=conda-forge
+   :target: https://anaconda.org/conda-forge/chainladder
+
+.. |Conda-forge downloads| image:: https://img.shields.io/conda/dn/conda-forge/chainladder.svg?label=conda-forge%20downloads
+   :target: https://anaconda.org/conda-forge/chainladder
+
+.. |License| image:: https://badgen.net/pypi/license/chainladder
+   :target: https://pypi.python.org/pypi/chainladder
+
 .. |Build Status| image:: https://github.com/casact/chainladder-python/actions/workflows/pytest.yml/badge.svg
    :target: https://github.com/casact/chainladder-python/actions/workflows/pytest.yml
-
-.. |Documentation Status| image:: https://readthedocs.org/projects/chainladder-python/badge/?version=main
-   :target: https://chainladder-python.readthedocs.io/main/
 
 .. |codecov io| image:: https://codecov.io/gh/casact/chainladder-python/branch/master/graphs/badge.svg
    :target: https://codecov.io/github/casact/chainladder-python?branch=latest
 
+.. |Documentation Status| image:: https://readthedocs.org/projects/chainladder-python/badge/?version=main
+   :target: https://chainladder-python.readthedocs.io/main/
+
 chainladder (python)
 ====================
 
-|PyPI version| |Python versions| |License| |Downloads| |Build Status| |codecov io| |Documentation Status|
+|Python versions| |PyPI version| |Downloads| |Conda-forge version| |Conda-forge downloads| |License| |Build Status| |codecov io| |Documentation Status|
 
 chainladder: Property and Casualty Loss Reserving in Python
 ------------------------------------------------------------
@@ -34,7 +40,7 @@ Welcome! The chainladder package was built to be able to handle all of your actu
 This package strives to be minimalistic in needing its own API. The syntax mimics popular packages `pandas`_ for data manipulation and `scikit-learn`_ for model
 construction. An actuary that is already familiar with these tools will be able to pick up this package with ease. You will be able to save your mental energy for actual actuarial work.
 
-Chainladder is built by a group of volunteers, and we need YOUR help!
+Chainladder is built by a group of volunteers, and we need ***YOUR*** help!
 
 This package is written in Python, if you are looking for a similar package written in R, please visit `chainladder`_.
 
@@ -43,10 +49,10 @@ This package is written in Python, if you are looking for a similar package writ
 .. _chainladder: https://github.com/mages/ChainLadder
 
 
-Dedicated Documentation Site
+Documentation Site
 ----------------------------
 
-We have a dedicated documentation website, where you can find installation instructions, tutorials, example galleries, sample datasets,  API references, change log history, and more.
+We have a documentation website, where you can find installation instructions, tutorials, example galleries, sample datasets,  API references, change log history, and more.
 
 Visit `Chainladder-Python on Read the Docs`_.
 

--- a/chainladder/adjustments/parallelogram.py
+++ b/chainladder/adjustments/parallelogram.py
@@ -8,7 +8,7 @@ from chainladder.core.io import EstimatorIO
 
 class ParallelogramOLF(BaseEstimator, TransformerMixin, EstimatorIO):
     """
-    Estimator to create and apply on-level factors to a Triangle object.  This
+    Estimator to create and apply on-level factors to a Triangle object. This
     is commonly used for premium vectors expressed as a Triangle object.
 
     Parameters
@@ -21,10 +21,19 @@ class ParallelogramOLF(BaseEstimator, TransformerMixin, EstimatorIO):
         5% decrease should be stated as -0.05
     date_col: str
         A list-like set of effective dates corresponding to each of the changes
-    approximation_grain: str
-        The resolution of the internal calendar used for calculating the on-level factors: 
-        monthly ('M') or daily ('D'). Daily is finer and adjusts for leap years when assigning
-        factors to origin periods.
+    approximation_grain: str {"M", "D"} (default="M")
+        The resolution of the internal calendar spacing used to calculate on-level
+        factors can be set to monthly (`'M'`) or daily (`'D'`). Under each
+        `approximation_grain`, periods are treated as discrete intervals and a
+        weighted current rate level is estimated. In monthly mode, each month is
+        treated as an equal-length period, consistent with the methodology presented
+        in the Friedland text, although this assumes that all months within a year
+        contain the same number of days. In daily mode, each calendar day is treated
+        as a full period, providing finer granularity and more accurately accounting
+        for differences in month length and leap years when assigning factors to
+        origin periods.
+    policy_length: int (default=12)
+        The length of the policy in months.
     vertical_line:
         Rates are typically stated on an effective date basis and premiums on
         and earned basis.  By default, this argument is False and produces
@@ -45,12 +54,14 @@ class ParallelogramOLF(BaseEstimator, TransformerMixin, EstimatorIO):
         change_col="",
         date_col="",
         approximation_grain="M",
+        policy_length=12,
         vertical_line=False,
     ):
         self.rate_history = rate_history
         self.change_col = change_col
         self.date_col = date_col
         self.approximation_grain = approximation_grain
+        self.policy_length = policy_length
         self.vertical_line = vertical_line
 
     def fit(self, X, y=None, sample_weight=None):
@@ -86,6 +97,7 @@ class ParallelogramOLF(BaseEstimator, TransformerMixin, EstimatorIO):
             start_date=X.origin[0].to_timestamp(how="s"),
             end_date=X.origin[-1].to_timestamp(how="e"),
             grain=X.origin_grain,
+            policy_length=self.policy_length,
             vertical_line=self.vertical_line,
             approximation_grain=self.approximation_grain,
         )
@@ -98,7 +110,7 @@ class ParallelogramOLF(BaseEstimator, TransformerMixin, EstimatorIO):
                 r = (r.groupby(self.date_col)[self.change_col].prod() - 1).reset_index()
                 date = r[self.date_col]
                 values = r[self.change_col]
-                olf = parallelogram_olf(values=values, date=date, **kw).values[
+                olf = parallelogram_olf(values=values, dates=date, **kw).values[
                     None, None
                 ]
                 if X.array_backend == "cupy":
@@ -111,7 +123,7 @@ class ParallelogramOLF(BaseEstimator, TransformerMixin, EstimatorIO):
             r = (r.groupby(self.date_col)[self.change_col].prod() - 1).reset_index()
             date = r[self.date_col]
             values = r[self.change_col]
-            olf = parallelogram_olf(values=values, date=date, **kw)
+            olf = parallelogram_olf(values=values, dates=date, **kw)
             self.olf_ = ((idx * 0 + 1) * olf.values[None, None]).latest_diagonal
         return self
 

--- a/chainladder/adjustments/tests/test_parallelogram.py
+++ b/chainladder/adjustments/tests/test_parallelogram.py
@@ -1,5 +1,7 @@
+import pytest
 import chainladder as cl
 import pandas as pd
+import numpy as np
 
 
 def test_parallelogram(clrd):
@@ -32,3 +34,351 @@ def test_parallelogram(clrd):
     assert X.get_array_module().all(
         X.olf_.loc["wkcomp", "EarnedPremNet", "1996"].values - 1.1 < 0.005
     )
+
+
+def test_non_vertical_line():
+    true_olf = (
+        1.20
+        / (
+            (1 - 0.5 * ((31 + 31 + 30 + 31 + 30 + 31) / 365) ** 2) * 1.0
+            + (0.5 * ((31 + 31 + 30 + 31 + 30 + 31) / 365) ** 2) * 1.2
+        )
+        - 1
+    )
+
+    result = (
+        cl.parallelogram_olf([0.20], ["7/1/2017"], approximation_grain="D")
+        .loc["2017"]
+        .iloc[0]
+        - 1
+    )
+
+    assert true_olf == result
+
+    # Monthly approximation
+    rate_history = pd.DataFrame(
+        {
+            "EffDate": ["2010-07-01", "2011-01-01", "2012-07-01", "2013-04-01"],
+            "RateChange": [0.035, 0.05, 0.10, -0.01],
+        }
+    )
+
+    data = pd.DataFrame(
+        {"Year": list(range(2006, 2016)), "EarnedPremium": [10_000] * 10}
+    )
+
+    prem_tri = cl.Triangle(
+        data, origin="Year", columns="EarnedPremium", cumulative=True
+    )
+    prem_tri = cl.ParallelogramOLF(
+        rate_history,
+        change_col="RateChange",
+        date_col="EffDate",
+        approximation_grain="M",
+        vertical_line=False,
+    ).fit_transform(prem_tri)
+    assert (
+        np.round(prem_tri.olf_.to_frame().values, 6).flatten()
+        == [
+            1.183471,
+            1.183471,
+            1.183471,
+            1.183471,
+            1.178316,
+            1.120181,
+            1.075556,
+            1.004236,
+            0.999684,
+            1.000000,
+        ]
+    ).all()
+
+    # Daily approximation
+    rate_history = pd.DataFrame(
+        {
+            "EffDate": ["2010-07-01", "2011-01-01", "2012-07-01", "2013-04-01"],
+            "RateChange": [0.035, 0.05, 0.10, -0.01],
+        }
+    )
+
+    data = pd.DataFrame(
+        {"Year": list(range(2006, 2016)), "EarnedPremium": [10_000] * 10}
+    )
+
+    prem_tri = cl.Triangle(
+        data, origin="Year", columns="EarnedPremium", cumulative=True
+    )
+    prem_tri = cl.ParallelogramOLF(
+        rate_history,
+        change_col="RateChange",
+        date_col="EffDate",
+        approximation_grain="D",
+        vertical_line=False,
+    ).fit_transform(prem_tri)
+    assert (
+        np.round(prem_tri.olf_.to_frame().values, 6).flatten()
+        == [
+            1.183471,
+            1.183471,
+            1.183471,
+            1.183471,
+            1.178231,
+            1.120105,
+            1.075410,
+            1.004073,
+            0.999693,
+            1.000000,
+        ]
+    ).all()
+
+
+def test_vertical_line():
+    olf = cl.parallelogram_olf(
+        [0.20], ["7/1/2017"], approximation_grain="D", vertical_line=True
+    )
+    true_olf = 1.2 / ((1 - 184 / 365) * 1.0 + (184 / 365) * 1.2)
+    assert abs(olf.loc["2017"].iloc[0] - true_olf) < 0.00001
+
+
+def test_policy_length():
+    rate_history = pd.DataFrame(
+        {
+            "EffDate": ["2010-07-01", "2011-01-01", "2012-04-01"],
+            "RateChange": [0.05, 0.1, -0.01],
+        }
+    )
+    data = pd.DataFrame(
+        {"Year": [2010, 2011, 2012, 2013, 2014], "EarnedPremium": [10_000] * 5}
+    )
+    prem_tri = cl.Triangle(
+        data, origin="Year", columns="EarnedPremium", cumulative=True
+    )
+
+    prem_tri = cl.ParallelogramOLF(
+        rate_history, change_col="RateChange", date_col="EffDate", policy_length=12
+    ).fit_transform(prem_tri)
+    assert (
+        np.round(prem_tri.olf_.values.flatten(), 6)
+        == [1.136348, 1.043056, 0.992792, 0.999684, 1]
+    ).all()
+
+    prem_tri = cl.ParallelogramOLF(
+        rate_history, change_col="RateChange", date_col="EffDate", policy_length=6
+    ).fit_transform(prem_tri)
+    assert (
+        np.round(prem_tri.olf_.values.flatten(), 6)
+        == [1.129333, 1.013023, 0.994975, 1, 1]
+    ).all()
+
+    rate_history = pd.DataFrame(
+        {
+            "EffDate": ["2010-07-01", "2011-10-01", "2012-04-01"],
+            "RateChange": [0.35, 0.149, -0.095],
+        }
+    )
+    data = pd.DataFrame(
+        {"Year": [2010, 2011, 2012, 2013, 2014], "EarnedPremium": [10_000] * 5}
+    )
+    prem_tri = cl.Triangle(
+        data, origin="Year", columns="EarnedPremium", cumulative=True
+    )
+
+    prem_tri = cl.ParallelogramOLF(
+        rate_history,
+        change_col="RateChange",
+        date_col="EffDate",
+        policy_length=12,
+        approximation_grain="M",
+    ).fit_transform(prem_tri)
+    assert (
+        np.round(prem_tri.olf_.values.flatten(), 6)
+        == [1.344949, 1.069526, 0.966045, 0.996730, 1]
+    ).all()
+
+    prem_tri = cl.ParallelogramOLF(
+        rate_history,
+        change_col="RateChange",
+        date_col="EffDate",
+        policy_length=6,
+        approximation_grain="M",
+    ).fit_transform(prem_tri)
+    assert (
+        np.round(prem_tri.olf_.values.flatten(), 6)
+        == [1.290842, 1.030251, 0.958285, 1, 1]
+    ).all()
+
+    rate_history = pd.DataFrame(
+        {
+            "EffDate": ["2010-07-01"],
+            "RateChange": [0.20],
+        }
+    )
+    data = pd.DataFrame(
+        {"Year": [2010, 2011, 2012, 2013, 2014], "EarnedPremium": [10_000] * 5}
+    )
+    prem_tri = cl.Triangle(
+        data,
+        origin="Year",
+        columns="EarnedPremium",
+        cumulative=True,
+    )
+
+    lhs = np.round(
+        cl.ParallelogramOLF(
+            rate_history,
+            change_col="RateChange",
+            date_col="EffDate",
+            policy_length=24,
+            approximation_grain="M",
+        )
+        .fit_transform(prem_tri)
+        .olf_.to_frame()
+        .values.flatten(),
+        6,
+    )
+    rhs = [1.185185, 1.090909, 1.010526, 1, 1]
+    assert np.all(lhs == rhs)
+
+    data = [
+        [2002, 61183, 0],
+        [2003, 69175, 0.05],
+        [2004, 99322, 0.075],
+        [2005, 138151, 0.15],
+        [2006, 107578, 0.1],
+        [2007, 62438, -0.2],
+        [2008, 47797, -0.2],
+    ]
+    columns = ["Calendar Year", "Earned Premiums", "Rate Changes"]
+    df_prem = pd.DataFrame(data, columns=columns)
+    df_prem["Date"] = pd.to_datetime(
+        df_prem["Calendar Year"].astype(int).astype(str) + "-01-01"
+    )
+
+    assert (
+        cl.parallelogram_olf(df_prem["Rate Changes"], df_prem["Date"])
+        .reset_index()["OLF"]
+        .notna()
+        .all()
+    )
+    assert (
+        cl.parallelogram_olf(df_prem["Rate Changes"], df_prem["Date"], policy_length=12)
+        .reset_index()["OLF"]
+        .notna()
+        .all()
+    )
+    assert (
+        cl.parallelogram_olf(df_prem["Rate Changes"], df_prem["Date"], policy_length=6)
+        .reset_index()["OLF"]
+        .notna()
+        .all()
+    )
+    assert (
+        cl.parallelogram_olf(
+            df_prem["Rate Changes"],
+            df_prem["Date"],
+            policy_length=6,
+            approximation_grain="D",
+        )
+        .reset_index()["OLF"]
+        .notna()
+        .all()
+    )
+
+
+def test_rate_impact_middle_of_year():
+    rate_history = pd.DataFrame(
+        {
+            "EffDate": ["2010-01-01"],
+            "RateChange": [0.20],
+        }
+    )
+    data = pd.DataFrame(
+        {"Year": [2010, 2011, 2012, 2013, 2014], "EarnedPremium": [10_000] * 5}
+    )
+    prem_tri = cl.Triangle(
+        data,
+        origin="Year",
+        columns="EarnedPremium",
+        cumulative=True,
+    )
+
+    monthly = np.round(
+        cl.ParallelogramOLF(
+            rate_history,
+            change_col="RateChange",
+            date_col="EffDate",
+            policy_length=24,
+            approximation_grain="M",
+        )
+        .fit_transform(prem_tri)
+        .olf_.to_frame()
+        .values.flatten(),
+        6,
+    )
+    # print(monthly)
+    daily = np.round(
+        cl.ParallelogramOLF(
+            rate_history,
+            change_col="RateChange",
+            date_col="EffDate",
+            policy_length=24,
+            approximation_grain="D",
+        )
+        .fit_transform(prem_tri)
+        .olf_.to_frame()
+        .values.flatten(),
+        6,
+    )
+    assert np.all(
+        monthly == daily
+    )  # when rate change is effective on 1/1, there's no difference in daily or monthly approximatation
+
+
+def test_rate_impact_beginning_of_year():
+    rate_history = pd.DataFrame(
+        {
+            "EffDate": ["2010-07-01"],
+            "RateChange": [0.20],
+        }
+    )
+    data = pd.DataFrame(
+        {"Year": [2010, 2011, 2012, 2013, 2014], "EarnedPremium": [10_000] * 5}
+    )
+    prem_tri = cl.Triangle(
+        data,
+        origin="Year",
+        columns="EarnedPremium",
+        cumulative=True,
+    )
+
+    monthly = np.round(
+        cl.ParallelogramOLF(
+            rate_history,
+            change_col="RateChange",
+            date_col="EffDate",
+            policy_length=24,
+            approximation_grain="M",
+        )
+        .fit_transform(prem_tri)
+        .olf_.to_frame()
+        .values.flatten(),
+        6,
+    )
+    # print(monthly)
+    daily = np.round(
+        cl.ParallelogramOLF(
+            rate_history,
+            change_col="RateChange",
+            date_col="EffDate",
+            policy_length=24,
+            approximation_grain="D",
+        )
+        .fit_transform(prem_tri)
+        .olf_.to_frame()
+        .values.flatten(),
+        6,
+    )
+    assert np.array_equal(
+        np.where(monthly > daily, ">", np.where(monthly == daily, "=", "<")),
+        np.array([">", ">", ">", "=", "="]),
+    )  # this is true becuase there are less "days" in the first half of the year (from Jan - Jun) compared to (Jul - Dec), and only the first three origins would need to be brought to current rate level

--- a/chainladder/utils/tests/test_utilities.py
+++ b/chainladder/utils/tests/test_utilities.py
@@ -8,108 +8,6 @@ import pandas as pd
 from pathlib import Path
 
 
-def test_non_vertical_line():
-    true_olf = (
-        1.20
-        / (
-            (1 - 0.5 * ((31 + 31 + 30 + 31 + 30 + 31) / 365) ** 2) * 1.0
-            + (0.5 * ((31 + 31 + 30 + 31 + 30 + 31) / 365) ** 2) * 1.2
-        )
-        - 1
-    )
-
-    result = (
-        cl.parallelogram_olf([0.20], ["7/1/2017"], approximation_grain="D")
-        .loc["2017"]
-        .iloc[0]
-        - 1
-    )
-
-    assert true_olf == result
-
-    # Monthly approximation
-    rate_history = pd.DataFrame(
-        {
-            "EffDate": ["2010-07-01", "2011-01-01", "2012-07-01", "2013-04-01"],
-            "RateChange": [0.035, 0.05, 0.10, -0.01],
-        }
-    )
-
-    data = pd.DataFrame(
-        {"Year": list(range(2006, 2016)), "EarnedPremium": [10_000] * 10}
-    )
-
-    prem_tri = cl.Triangle(
-        data, origin="Year", columns="EarnedPremium", cumulative=True
-    )
-    prem_tri = cl.ParallelogramOLF(
-        rate_history,
-        change_col="RateChange",
-        date_col="EffDate",
-        approximation_grain="M",
-        vertical_line=False,
-    ).fit_transform(prem_tri)
-    assert (
-        np.round(prem_tri.olf_.to_frame().values, 6).flatten()
-        == [
-            1.183471,
-            1.183471,
-            1.183471,
-            1.183471,
-            1.178316,
-            1.120181,
-            1.075556,
-            1.004236,
-            0.999684,
-            1.000000,
-        ]
-    ).all()
-
-    # Daily approximation
-    rate_history = pd.DataFrame(
-        {
-            "EffDate": ["2010-07-01", "2011-01-01", "2012-07-01", "2013-04-01"],
-            "RateChange": [0.035, 0.05, 0.10, -0.01],
-        }
-    )
-
-    data = pd.DataFrame(
-        {"Year": list(range(2006, 2016)), "EarnedPremium": [10_000] * 10}
-    )
-
-    prem_tri = cl.Triangle(
-        data, origin="Year", columns="EarnedPremium", cumulative=True
-    )
-    prem_tri = cl.ParallelogramOLF(
-        rate_history,
-        change_col="RateChange",
-        date_col="EffDate",
-        approximation_grain="D",
-        vertical_line=False,
-    ).fit_transform(prem_tri)
-    assert (
-        np.round(prem_tri.olf_.to_frame().values, 6).flatten()
-        == [
-            1.183471,
-            1.183471,
-            1.183471,
-            1.183471,
-            1.178231,
-            1.120105,
-            1.075410,
-            1.004073,
-            0.999693,
-            1.000000,
-        ]
-    ).all()
-
-
-def test_vertical_line():
-    olf = cl.parallelogram_olf(
-        [0.20], ["7/1/2017"], approximation_grain="D", vertical_line=True
-    )
-    true_olf = 1.2 / ((1 - 184 / 365) * 1.0 + (184 / 365) * 1.2)
-    assert abs(olf.loc["2017"].iloc[0] - true_olf) < 0.00001
 
 
 def test_triangle_json_io(clrd):
@@ -157,33 +55,38 @@ def test_json_df():
     )
     assert abs(cl.read_json(x.to_json()).lambda_ - x.lambda_).sum() < 1e-5
 
+
 def test_read_csv_single(raa):
     # Test the read_csv function for a single dimensional input.
-    
+
     # Read in the csv file.
     from pathlib import Path
+
     raa_csv_path = Path(__file__).parent.parent / "data" / "raa.csv"
 
     assert raa == cl.read_csv(
         filepath_or_buffer=raa_csv_path,
-        origin = "origin",
-        development = "development",
-        columns = ["values"],
-        index = None,
-        cumulative = True)
+        origin="origin",
+        development="development",
+        columns=["values"],
+        index=None,
+        cumulative=True,
+    )
+
 
 def test_read_csv_multi(clrd):
     # Test the read_csv function for multidimensional input.
 
     # Read in the csv file.
     from pathlib import Path
+
     clrd_csv_path = Path(__file__).parent.parent / "data" / "clrd.csv"
 
     assert clrd == cl.read_csv(
         filepath_or_buffer=clrd_csv_path,
-        origin = "AccidentYear",
-        development = "DevelopmentYear",
-        columns = [
+        origin="AccidentYear",
+        development="DevelopmentYear",
+        columns=[
             "IncurLoss",
             "CumPaidLoss",
             "BulkLoss",
@@ -191,9 +94,10 @@ def test_read_csv_multi(clrd):
             "EarnedPremCeded",
             "EarnedPremNet",
         ],
-        index = ["GRNAME","LOB"],
-        cumulative = True
-    ) 
+        index=["GRNAME", "LOB"],
+        cumulative=True,
+    )
+
 
 def test_concat(clrd):
     tri = clrd.groupby("LOB").sum()

--- a/chainladder/utils/utility_functions.py
+++ b/chainladder/utils/utility_functions.py
@@ -12,18 +12,10 @@ import pandas as pd
 
 from chainladder.utils.sparse import sp
 from io import StringIO
-from patsy import dmatrix # noqa
-from sklearn.base import (
-    BaseEstimator,
-    TransformerMixin
-)
+from patsy import dmatrix  # noqa
+from sklearn.base import BaseEstimator, TransformerMixin
 
-from typing import (
-    Iterable,
-    Union,
-    Optional,
-    TYPE_CHECKING
-)
+from typing import Iterable, Union, Optional, TYPE_CHECKING
 
 if TYPE_CHECKING:
     from chainladder import Triangle
@@ -33,28 +25,21 @@ if TYPE_CHECKING:
     from sparse import COO
     from types import ModuleType
     from typing import AnyStr
-    from pandas._typing import (
-        FilePath,
-        ReadCsvBuffer
-    )
+    from pandas._typing import FilePath, ReadCsvBuffer
 
 
-def load_sample(
-        key: str,
-        *args,
-        **kwargs
-) -> Triangle:
+def load_sample(key: str, *args, **kwargs) -> Triangle:
     """Function to load a dataset already included in the chainladder package. These consist of CSV
     files located in the repository directory chainladder/utils/data.
 
     Parameters
     ----------
     key: str (not case sensitive)
-        The name of the dataset. The name should match the file name, without extension, of one of 
+        The name of the dataset. The name should match the file name, without extension, of one of
         the files in the sample data folder.
 
-        Datasets that are commonly used in examples are: raa, clrd, and prism. 
-        
+        Datasets that are commonly used in examples are: raa, clrd, and prism.
+
         And a complete list of available datasets is: abc, auto, berqsherm, cc_sample, clrd, clrd2025, genins, ia_sample, liab, m3ir5, mack_1997, mcl, mortgage, mw2008, mw2014, prism, quarterly, raa, tail_sample, ukmotor, usaa, usauto, xyz.
 
     Returns
@@ -64,7 +49,7 @@ def load_sample(
 
     Examples
     --------
-    
+
     Loading "raa" as an example.
 
     .. testsetup::
@@ -95,7 +80,6 @@ def load_sample(
     """
     from chainladder import Triangle
 
-
     # Set base path to be the parent directory of this file, e.g., the utils folder.
     utils_path: AnyStr = os.path.dirname(os.path.abspath(__file__))
 
@@ -110,8 +94,10 @@ def load_sample(
             what data are available.
             
             You supplied: {}
-            """.format(key)
-         )
+            """.format(
+                key
+            )
+        )
 
     # Set initial values for arguments to Triangle __init__. These may be overridden by
     # values specific to the data set.
@@ -121,25 +107,12 @@ def load_sample(
     index: list | None = None
     cumulative: bool = True
 
-    if key.lower() in [
-        "mcl",
-        "usaa",
-        "quarterly",
-        "auto",
-        "usauto",
-        "tail_sample"
-    ]:
-        columns: list = [
-            "incurred",
-            "paid"
-        ]
+    if key.lower() in ["mcl", "usaa", "quarterly", "auto", "usauto", "tail_sample"]:
+        columns: list = ["incurred", "paid"]
     if key.lower() == "clrd":
         origin: str = "AccidentYear"
         development: str = "DevelopmentYear"
-        index: list = [
-            "GRNAME",
-            "LOB"
-        ]
+        index: list = ["GRNAME", "LOB"]
         columns: list = [
             "IncurLoss",
             "CumPaidLoss",
@@ -151,10 +124,7 @@ def load_sample(
     if key.lower() == "clrd2025":
         origin: str = "AccidentYear"
         development: str = "DevelopmentYear"
-        index: list = [
-            "GRNAME",
-            "LOB"
-        ]
+        index: list = ["GRNAME", "LOB"]
         columns: list = [
             "IncurredLosses",
             "CumPaidLoss",
@@ -167,158 +137,118 @@ def load_sample(
         origin: str = "AccidentYear"
         development: str = "DevelopmentYear"
         index: list = ["LOB"]
-        columns: list = [
-            "Incurred",
-            "Paid",
-            "Reported",
-            "Closed"
-        ]
+        columns: list = ["Incurred", "Paid", "Reported", "Closed"]
     if key.lower() == "xyz":
         origin: str = "AccidentYear"
         development: str = "DevelopmentYear"
-        columns: list = [
-            "Incurred",
-            "Paid",
-            "Reported",
-            "Closed",
-            "Premium"
-        ]
-    if key.lower() in [
-        "liab",
-        "auto"
-    ]:
+        columns: list = ["Incurred", "Paid", "Reported", "Closed", "Premium"]
+    if key.lower() in ["liab", "auto"]:
         index: list = ["lob"]
-    if key.lower() in [
-        "cc_sample",
-        "ia_sample"
-    ]:
-        columns: list = [
-            "loss",
-            "exposure"
-        ]
+    if key.lower() in ["cc_sample", "ia_sample"]:
+        columns: list = ["loss", "exposure"]
     if key.lower() in ["prism"]:
-        columns: list = [
-            "reportedCount",
-            "closedPaidCount",
-            "Paid",
-            "Incurred"
-        ]
+        columns: list = ["reportedCount", "closedPaidCount", "Paid", "Incurred"]
         index: list = [
             "ClaimNo",
             "Line",
             "Type",
             "ClaimLiability",
             "Limit",
-            "Deductible"
+            "Deductible",
         ]
         origin: str = "AccidentDate"
         development: str = "PaymentDate"
         cumulative: bool = False
-    if 'mack_1997' in key.lower():
-        columns = ['Case Incurred']
-        origin = 'Accident Year'
-        development = 'Calendar Year'
+    if "mack_1997" in key.lower():
+        columns = ["Case Incurred"]
+        origin = "Accident Year"
+        development = "Calendar Year"
         cumulative: bool = True
     # Friedland datasets
-    if 'friedland' in key.lower():
-        columns: list = [
-            'Paid Claims',
-            'Reported Claims'
-        ]
+    if "friedland" in key.lower():
+        columns: list = ["Paid Claims", "Reported Claims"]
         origin: str = "Accident Year"
-        development: str = 'Calendar Year'
+        development: str = "Calendar Year"
         cumulative: bool = True
         index: None = None
-        if 'autoprop' in key.lower():
+        if "autoprop" in key.lower():
             columns: list = [
-                'Reported ALAE',
-                'Paid ALAE',
-                'Reported Claims',
-                'Paid Claims'
+                "Reported ALAE",
+                "Paid ALAE",
+                "Reported Claims",
+                "Paid Claims",
             ]
-        if 'auto_salsub' in key.lower():
+        if "auto_salsub" in key.lower():
             columns: list = [
-                'Reported Salvage and Subrogation',
-                'Received Salvage and Subrogation',
-                'Reported Claims',
-                'Paid Claims'
+                "Reported Salvage and Subrogation",
+                "Received Salvage and Subrogation",
+                "Reported Claims",
+                "Paid Claims",
             ]
-        if 'berq_sher_auto' in key.lower():
+        if "berq_sher_auto" in key.lower():
             columns: list = [
-                'Paid Claims',
-                'Closed Claim Counts',
-                'Reported Claim Counts',
-                'Disposal Rate'
+                "Paid Claims",
+                "Closed Claim Counts",
+                "Reported Claim Counts",
+                "Disposal Rate",
             ]
-        if 'gl_insurer' in key.lower():
+        if "gl_insurer" in key.lower():
             columns: list = [
-                'Closed Claim Counts',
-                'Reported Claim Counts',
-                'Disposal Rate',
-                'Paid Claims'
+                "Closed Claim Counts",
+                "Reported Claim Counts",
+                "Disposal Rate",
+                "Paid Claims",
             ]
-        if 'med_mal' in key.lower():
+        if "med_mal" in key.lower():
             columns: list = [
-                'Reported Claims',
-                'Paid Claims',
-                'Case Outstanding',
-                'Open Claim Counts'
+                "Reported Claims",
+                "Paid Claims",
+                "Case Outstanding",
+                "Open Claim Counts",
             ]
-        if 'qs' in key.lower():
+        if "qs" in key.lower():
             columns: list = [
-                'Gross Reported Claims',
-                'Net Reported Claims',
-                'Net to Gross'
+                "Gross Reported Claims",
+                "Net Reported Claims",
+                "Net to Gross",
             ]
-        if 'auto_case' in key.lower():
+        if "auto_case" in key.lower():
+            columns: list = ["Case Outstanding", "Paid Claims"]
+        if "wc_self_insurer" in key.lower():
             columns: list = [
-                'Case Outstanding',
-                'Paid Claims'
+                "Closed Claim Counts",
+                "Reported Claim Counts",
+                "Paid Claims",
+                "Paid Severities",
+                "Reported Claims",
+                "Reported Severities",
             ]
-        if 'wc_self_insurer' in key.lower():
+        if "xol" in key.lower():
             columns: list = [
-                'Closed Claim Counts',
-                'Reported Claim Counts',
-                'Paid Claims',
-                'Paid Severities',
-                'Reported Claims',
-                'Reported Severities'
+                "Gross Reported Claims",
+                "Net Reported Claims",
+                "Ceded Reported Claims",
             ]
-        if 'xol' in key.lower():
+        if "xyz_case" in key.lower():
+            columns: list = ["Case Outstanding", "Paid Claims"]
+        if "xyz_disp" in key.lower():
+            columns: list = ["Disposal Rate", "Closed Claim Counts", "Paid Claims"]
+        if "xyz_freq_sev" in key.lower():
             columns: list = [
-                'Gross Reported Claims',
-                'Net Reported Claims',
-                'Ceded Reported Claims'
+                "Closed Claim Counts",
+                "Reported Claim Counts",
+                "Reported Claims",
+                "Reported Severities",
             ]
-        if 'xyz_case' in key.lower():
+        if "auto_freq_sev" in key.lower():
             columns: list = [
-                'Case Outstanding',
-                'Paid Claims'
-            ]
-        if 'xyz_disp' in key.lower():
-            columns: list = [
-                'Disposal Rate',
-                'Closed Claim Counts',
-                'Paid Claims'
-            ]
-        if 'xyz_freq_sev' in key.lower():
-            columns: list = [
-                'Closed Claim Counts',
-                'Reported Claim Counts',
-                'Reported Claims',
-                'Reported Severities'
-            ]
-        if 'auto_freq_sev' in key.lower():
-            columns: list = [
-                'Closed Claim Counts',
-                'Reported Claim Counts',
-                'Reported Claims',
-                'Reported Severity'
+                "Closed Claim Counts",
+                "Reported Claim Counts",
+                "Reported Claims",
+                "Reported Severity",
             ]
             origin: str = "Accident Half-Year"
             development: str = "Calendar Half-Year"
-
-
 
     df = pd.read_csv(filepath_or_buffer=dataset_path)
 
@@ -330,7 +260,7 @@ def load_sample(
         columns=columns,
         cumulative=cumulative,
         *args,
-        **kwargs
+        **kwargs,
     )
 
 
@@ -338,21 +268,22 @@ def read_pickle(path):
     with open(path, "rb") as pkl:
         return dill.load(pkl)
 
+
 def read_csv(
-        filepath_or_buffer: FilePath | ReadCsvBuffer[bytes] | ReadCsvBuffer[str],
-        origin: Optional[str | list] = None,
-        development: Optional[str | list] = None,
-        columns: Optional[str | list] = None,
-        index: Optional[str | list] = None,
-        origin_format: Optional[str] = None,
-        development_format: Optional[str] = None,
-        cumulative: Optional[bool] = None,
-        array_backend: str = None,
-        pattern=False,
-        trailing: bool = True,
-        *args, 
-        **kwargs
-        ) -> Triangle:
+    filepath_or_buffer: FilePath | ReadCsvBuffer[bytes] | ReadCsvBuffer[str],
+    origin: Optional[str | list] = None,
+    development: Optional[str | list] = None,
+    columns: Optional[str | list] = None,
+    index: Optional[str | list] = None,
+    origin_format: Optional[str] = None,
+    development_format: Optional[str] = None,
+    cumulative: Optional[bool] = None,
+    array_backend: str = None,
+    pattern=False,
+    trailing: bool = True,
+    *args,
+    **kwargs,
+) -> Triangle:
     """
     Funtion that creates Triangle directly from input. Wrapper for pandas dataframe:
     https://pandas.pydata.org/docs/reference/api/pandas.read_csv.html
@@ -360,11 +291,11 @@ def read_csv(
     Parameters
     ----------
     filepath_or_buffer: str, path object or file-like object
-        Any valid string path is acceptable. The string could be a URL. Valid URL schemes 
-        include http, ftp, s3, gs, and file. For file URLs, a host is expected. A local 
+        Any valid string path is acceptable. The string could be a URL. Valid URL schemes
+        include http, ftp, s3, gs, and file. For file URLs, a host is expected. A local
         file could be: file://localhost/path/to/table.csv.
         If you want to pass in a path object, pandas accepts any os.PathLike.
-        By file-like object, we refer to objects with a read() method, such as a 
+        By file-like object, we refer to objects with a read() method, such as a
         file handle (e.g. via builtin open function) or StringIO.
     origin: str or list
          A representation of the accident, reporting or more generally the
@@ -443,18 +374,17 @@ def read_csv(
         convertible to DataFrame.
     """
 
-
     from chainladder import Triangle
 
-    #Chainladder implementation of: https://pandas.pydata.org/docs/reference/api/pandas.read_csv.html
-    #This will allow the user to create a trignel directly from csv instead in csv -> dataframe -> triangle
+    # Chainladder implementation of: https://pandas.pydata.org/docs/reference/api/pandas.read_csv.html
+    # This will allow the user to create a trignel directly from csv instead in csv -> dataframe -> triangle
 
-    #create a data frame using the *args and **kwargs that the user specified
-    local_dataframe = pd.read_csv(filepath_or_buffer,*args, **kwargs)
+    # create a data frame using the *args and **kwargs that the user specified
+    local_dataframe = pd.read_csv(filepath_or_buffer, *args, **kwargs)
 
-    #pass the created local_dataframe in the Triangle constructor 
+    # pass the created local_dataframe in the Triangle constructor
     local_triangle = Triangle(
-        data = local_dataframe, 
+        data=local_dataframe,
         origin=origin,
         development=development,
         columns=columns,
@@ -464,10 +394,11 @@ def read_csv(
         cumulative=cumulative,
         array_backend=array_backend,
         pattern=pattern,
-        trailing = trailing
+        trailing=trailing,
     )
 
     return local_triangle
+
 
 def read_json(json_str, array_backend=None):
     from chainladder import Triangle
@@ -535,109 +466,97 @@ def read_json(json_str, array_backend=None):
 
 def parallelogram_olf(
     values,
-    date,
+    dates,
     start_date=None,
     end_date=None,
     grain="Y",
+    policy_length=12,
     approximation_grain="M",
     vertical_line=False,
 ):
     """Parallelogram approach to on-leveling."""
-    date = pd.to_datetime(date)
-    if not start_date:
-        start_date = "{}-01-01".format(date.min().year)
-    if not end_date:
-        end_date = "{}-12-31".format(date.max().year)
-    start_date = pd.to_datetime(start_date) - pd.tseries.offsets.DateOffset(days=1)
+    if approximation_grain not in ["M", "D"]:
+        raise ValueError("approximation_grain must be M or D")
 
-    date_freq = {
-        "M": "MS",
-        "D": "D",
-    }
-    if approximation_grain not in ['M', 'D']:
-        raise ValueError("approximation_grain must be " "M" " or " "D" "")
+    dates = pd.to_datetime(dates)
+
+    if start_date:
+        start_date = pd.to_datetime(start_date) - pd.tseries.offsets.DateOffset(days=1)
+    else:
+        start_date = pd.to_datetime("{}-01-01".format(dates.min().year))
+
+    if not end_date:
+        end_date = pd.to_datetime("{}-12-31".format(dates.max().year))
+
+    lookback_years = max(1, -(-policy_length // 12))
+
     date_idx = pd.date_range(
-        start_date - pd.tseries.offsets.DateOffset(years=1),
+        start_date - pd.tseries.offsets.DateOffset(years=lookback_years),
         end_date,
-        freq=date_freq[approximation_grain],
+        freq={"M": "MS", "D": "D"}[approximation_grain],
     )
 
-    rate_changes = pd.Series(np.array(values), np.array(date))
-    rate_changes = rate_changes.reindex(date_idx, fill_value=0)
-
-    cum_rate_changes = np.cumprod(1 + rate_changes.values)
-    cum_rate_changes = pd.Series(cum_rate_changes, rate_changes.index)
+    rate_changes = pd.Series(np.array(values), np.array(dates)).reindex(
+        date_idx, fill_value=0
+    )
+    cum_rate_changes = pd.Series(
+        np.cumprod(1 + rate_changes.values), rate_changes.index
+    )
     crl = cum_rate_changes.iloc[-1]
 
-    cum_avg_rate_non_leaps = cum_rate_changes
-    cum_avg_rate_leaps = cum_rate_changes
+    rolling_num_base = {
+        "M": policy_length,
+        "D": int(365 * policy_length / 12),
+    }[approximation_grain]
+    dropdates_base = {
+        "M": 12 * lookback_years,
+        "D": 366 * lookback_years,
+    }[approximation_grain]
 
-    if not vertical_line:
-        rolling_num = {
-            "M": 12,
-            "D": 365,
-        }
+    def _fcrl_for_leap(is_leap_year: bool):
+        # In monthly mode every month is treated as an equal length period, so a
+        # leap day has no effect on the rolling window or the lookback drop.
+        if approximation_grain == "M":
+            is_leap_year = False
 
-        cum_avg_rate_non_leaps = cum_rate_changes.rolling(
-            rolling_num[approximation_grain]
-        ).mean()
-        cum_avg_rate_non_leaps = (
-            cum_avg_rate_non_leaps + cum_avg_rate_non_leaps.shift(1).values
-        ) / 2
+        if is_leap_year:
+            leap_day = 1
+        else:
+            leap_day = 0
 
-        cum_avg_rate_leaps = cum_rate_changes.rolling(
-            rolling_num[approximation_grain] + 1
-        ).mean()
-        cum_avg_rate_leaps = (
-            cum_avg_rate_leaps + cum_avg_rate_leaps.shift(1).values
-        ) / 2
+        if vertical_line:  # rectangle method, rate change impact is immediate
+            cum_avg = cum_rate_changes
 
-    dropdates_num = {
-        "M": 12,
-        "D": 366,
-    }
-    cum_avg_rate_non_leaps = cum_avg_rate_non_leaps.iloc[
-        dropdates_num[approximation_grain] :
-    ]
-    cum_avg_rate_leaps = cum_avg_rate_leaps.iloc[
-        dropdates_num[approximation_grain] + 1 :
-    ]
+        else:  # parallelogram method, rate change impact is overtime
+            #
+            average_period = max(rolling_num_base + leap_day, 1)
 
-    fcrl_non_leaps = (
-        cum_avg_rate_non_leaps.groupby(cum_avg_rate_non_leaps.index.to_period(grain))
-        .mean()
-        .reset_index()
-    )
-    fcrl_non_leaps.columns = ["Origin", "OLF"]
-    fcrl_non_leaps["Origin"] = fcrl_non_leaps["Origin"].astype(str)
-    fcrl_non_leaps["OLF"] = crl / fcrl_non_leaps["OLF"]
+            cum_avg = cum_rate_changes.rolling(average_period).mean()
+            cum_avg = (cum_avg + cum_avg.shift(1).values) / 2
 
-    fcrl_leaps = (
-        cum_avg_rate_leaps.groupby(cum_avg_rate_leaps.index.to_period(grain))
-        .mean()
-        .reset_index()
-    )
-    fcrl_leaps.columns = ["Origin", "OLF"]
-    fcrl_leaps["Origin"] = fcrl_leaps["Origin"].astype(str)
-    fcrl_leaps["OLF"] = crl / fcrl_leaps["OLF"]
+        cum_avg = cum_avg.iloc[dropdates_base + leap_day :]
+
+        fcrl = cum_avg.groupby(cum_avg.index.to_period(grain)).mean().reset_index()
+        fcrl.columns = ["Origin", "OLF"]
+        fcrl["Origin"] = fcrl["Origin"].astype(str)
+        fcrl["OLF"] = crl / fcrl["OLF"]
+
+        return fcrl
+
+    fcrl_non_leaps = _fcrl_for_leap(False)
+    fcrl_leaps = fcrl_non_leaps if approximation_grain == "M" else _fcrl_for_leap(True)
 
     combined = fcrl_non_leaps.join(fcrl_leaps, lsuffix="_non_leaps", rsuffix="_leaps")
     combined["is_leap"] = pd.to_datetime(
-        combined["Origin_non_leaps"], format="%Y" + ("-%M" if grain == "M" else "")
+        combined["Origin_non_leaps"], format="%Y" + ("-%m" if grain == "M" else "")
     ).dt.is_leap_year
-    
 
-    if approximation_grain == "M":
-        combined["final_OLF"] = combined["OLF_non_leaps"]
-    else:
-        combined["final_OLF"] = np.where(
-            combined["is_leap"], combined["OLF_leaps"], combined["OLF_non_leaps"]
-        )
+    combined["final_OLF"] = np.where(
+        combined["is_leap"], combined["OLF_leaps"], combined["OLF_non_leaps"]
+    )
 
     combined.drop(
-        ["OLF_non_leaps", "Origin_leaps", "OLF_leaps", "is_leap"],
-        axis=1,
-        inplace=True,
+        ["OLF_non_leaps", "Origin_leaps", "OLF_leaps", "is_leap"], axis=1, inplace=True
     )
     combined.columns = ["Origin", "OLF"]
 
@@ -732,10 +651,7 @@ def concat(
         return out
 
 
-def num_to_value(
-        arr: ArrayLike,
-        value
-) -> ArrayLike:
+def num_to_value(arr: ArrayLike, value) -> ArrayLike:
     """
     Function that turns all zeros to nan values in an array.
     """
@@ -748,13 +664,12 @@ def num_to_value(
             arr: COO = sp.COO(
                 coords=arr.coords,
                 data=arr.data,
-                fill_value=sp.COO.nan, # noqa
-                shape=arr.shape
+                fill_value=sp.COO.nan,  # noqa
+                shape=arr.shape,
             )
         else:
             arr: COO = sp.COO(
-                num_to_nan(np.nan_to_num(arr.todense())),
-                fill_value=value
+                num_to_nan(np.nan_to_num(arr.todense())), fill_value=value
             )
     else:
         arr[arr == 0] = value
@@ -779,10 +694,7 @@ def num_to_nan(arr: ArrayLike) -> ArrayLike:
     from chainladder import Triangle
 
     # Take the nan specific to the module of the backend used. e.g., numpy, cupy, sparse, etc.
-    xp: ModuleType = Triangle.get_array_module(
-        None,
-        arr=arr
-    )
+    xp: ModuleType = Triangle.get_array_module(None, arr=arr)
 
     return num_to_value(arr, xp.nan)
 
@@ -794,11 +706,16 @@ def minimum(x1, x2):
 def maximum(x1, x2):
     return x1.maximum(x2)
 
-def to_period(dateseries: pd.Series, freq:str):
-    if freq[:2] != '2Q':
+
+def to_period(dateseries: pd.Series, freq: str):
+    if freq[:2] != "2Q":
         return dateseries.dt.to_period(freq)
     else:
-        return dateseries.where(dateseries.dt.to_period(freq).dt.strftime('%q').isin(['1','3']),dateseries.dt.date + pd.DateOffset(months=-3)).dt.to_period(freq)
+        return dateseries.where(
+            dateseries.dt.to_period(freq).dt.strftime("%q").isin(["1", "3"]),
+            dateseries.dt.date + pd.DateOffset(months=-3),
+        ).dt.to_period(freq)
+
 
 class PatsyFormula(BaseEstimator, TransformerMixin):
     """A sklearn-style Transformer for patsy formulas.
@@ -926,30 +843,44 @@ def model_diagnostics(model, name=None, groupby=None):
     return concat(triangles, 0)
 
 
-def PTF_formula(alpha: list = None, gamma: list = None, iota: list = None,dgrain: int = 12):
-    """ Helper formula that builds a patsy formula string for the BarnettZehnwirth 
-    estimator.  Each axis's parameters can be grouped together. Groups of origin 
-    parameters (alpha) are set equal, and are specified by the first period in each bin. 
-    Groups of development (gamma) and valuation (iota) parameters are fit to 
+def PTF_formula(
+    alpha: list = None, gamma: list = None, iota: list = None, dgrain: int = 12
+):
+    """Helper formula that builds a patsy formula string for the BarnettZehnwirth
+    estimator.  Each axis's parameters can be grouped together. Groups of origin
+    parameters (alpha) are set equal, and are specified by the first period in each bin.
+    Groups of development (gamma) and valuation (iota) parameters are fit to
     separate linear trends, specified a list denoting the endpoints of the linear pieces.
     In other words, development and valuation trends are fit to a piecewise linear model.
     A triangle must be supplied to provide some critical information.
     """
-    formula_parts=[]
-    if(alpha):
+    formula_parts = []
+    if alpha:
         # The intercept term takes the place of the first alpha
-        for ind,a in enumerate(alpha):
-            if(a==0):
-                alpha=alpha[:ind]+alpha[(ind+1):]
-        formula_parts += ['+'.join([f'I({x} <= origin)' for x in alpha])]
-    if(gamma): 
+        for ind, a in enumerate(alpha):
+            if a == 0:
+                alpha = alpha[:ind] + alpha[(ind + 1) :]
+        formula_parts += ["+".join([f"I({x} <= origin)" for x in alpha])]
+    if gamma:
         # preprocess gamma to align with grain
-        graingamma = [(i+1)*dgrain for i in gamma]
-        for ind in range(1,len(graingamma)):
-            formula_parts += ['+'.join([f'I((np.minimum({graingamma[ind]},development) - np.minimum({graingamma[ind-1]},development))/{dgrain})'])]
-    if(iota):
-        for ind in range(1,len(iota)):
-            formula_parts += ['+'.join([f'I(np.minimum({iota[ind]},valuation) - np.minimum({iota[ind-1]},valuation))'])]
-    if(formula_parts):
-        return '+'.join(formula_parts)
-    return ''
+        graingamma = [(i + 1) * dgrain for i in gamma]
+        for ind in range(1, len(graingamma)):
+            formula_parts += [
+                "+".join(
+                    [
+                        f"I((np.minimum({graingamma[ind]},development) - np.minimum({graingamma[ind-1]},development))/{dgrain})"
+                    ]
+                )
+            ]
+    if iota:
+        for ind in range(1, len(iota)):
+            formula_parts += [
+                "+".join(
+                    [
+                        f"I(np.minimum({iota[ind]},valuation) - np.minimum({iota[ind-1]},valuation))"
+                    ]
+                )
+            ]
+    if formula_parts:
+        return "+".join(formula_parts)
+    return ""


### PR DESCRIPTION
## Summary of Changes  


## Related GitHub Issue(s)  


## Additional Context for Reviewers  


- [ ] I passed tests locally for both code (`uv run pytest`) and documentation changes (`uv run jb build docs --builder=custom --custom-builder=doctest`)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Updates the core `parallelogram_olf` calculation (including leap-year/rolling-window handling) and its API, which can change on-level factors produced for existing users; breadth is limited but math-heavy.
> 
> **Overview**
> Enhances on-level factor generation by adding a `policy_length` parameter and refactoring `parallelogram_olf` to use a policy-term-based rolling window with explicit leap-year handling; the function signature changes from `date` to `dates`, and `ParallelogramOLF` now threads `policy_length` through.
> 
> Moves and significantly expands OLF test coverage into `adjustments/tests/test_parallelogram.py` (vertical vs non-vertical, monthly vs daily, multiple policy lengths, and edge cases), and removes the old utility tests.
> 
> Minor maintenance: enable GitHub Actions unit tests on `push`, refresh README badges/wording, and apply small style/type-hint cleanups in `utility_functions.py`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5c1fc2394069315ce9779702b27421d6223cdb6d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->