### PR TITLE
Improved docstring and added two examples

### DIFF
--- a/chainladder/adjustments/parallelogram.py
+++ b/chainladder/adjustments/parallelogram.py
@@ -15,12 +15,14 @@ class ParallelogramOLF(BaseEstimator, TransformerMixin, EstimatorIO):
     ----------
 
     rate_history: pd.DataFrame
-        A DataFrame with
+        A DataFrame with two columns: one containing the effective dates of the rate
+        changes and the other containing the rate changes expressed as a decimal.
+        For example, 5% decrease should be stated as -0.05.
     change_col: str
         The column containing the rate changes expressed as a decimal. For example,
-        5% decrease should be stated as -0.05
+        5% decrease should be stated as -0.05.
     date_col: str
-        A list-like set of effective dates corresponding to each of the changes
+        A list-like set of effective dates corresponding to each of the changes.
     approximation_grain: str {"M", "D"} (default="M")
         The resolution of the internal calendar spacing used to calculate on-level
         factors can be set to monthly (`'M'`) or daily (`'D'`). Under each
@@ -34,7 +36,7 @@ class ParallelogramOLF(BaseEstimator, TransformerMixin, EstimatorIO):
         origin periods.
     policy_length: int (default=12)
         The length of the policy in months.
-    vertical_line:
+    vertical_line: bool (default=False)
         Rates are typically stated on an effective date basis and premiums on
         and earned basis.  By default, this argument is False and produces
         parallelogram OLFs. If True, Parallelograms become squares.  This is
@@ -46,6 +48,97 @@ class ParallelogramOLF(BaseEstimator, TransformerMixin, EstimatorIO):
 
     olf_:
         A triangle representation of the on-level factors
+
+    Examples
+    --------
+
+    Premium vectors are expressed as a Triangle object. This example shows how to create and apply on-level factors to a Triangle object with one rate change.
+
+    ..  testsetup::
+
+        import chainladder as cl
+
+    ..  testcode::
+
+        import pandas as pd
+        import numpy as np
+
+        xyz = cl.load_sample("xyz")
+        olf = (
+            cl.ParallelogramOLF(
+                rate_history=pd.DataFrame(
+                    {
+                        "EffDate": ["2001-07-01"],
+                        "RateChange": [0.20],
+                    }
+                ),
+                change_col="RateChange",
+                date_col="EffDate",
+            )
+            .fit_transform(xyz["Premium"])
+            .olf_
+        )
+        xyz["Leveled Premium"] = xyz["Premium"] * olf
+        print(np.round(xyz["Leveled Premium"], 0))
+
+    ..  testoutput::
+
+                   12        24        36        48       60       72       84       96       108      120      132
+        1998       NaN       NaN   24000.0   24000.0  24000.0  24000.0  24000.0  24000.0  24000.0  24000.0  24000.0
+        1999       NaN   37800.0   37800.0   37800.0  37800.0  37800.0  37800.0  37800.0  37800.0  37800.0      NaN
+        2000   54000.0   54000.0   54000.0   54000.0  54000.0  54000.0  54000.0  54000.0  54000.0      NaN      NaN
+        2001   58537.0   58537.0   58537.0   58537.0  58537.0  58537.0  58537.0  58537.0      NaN      NaN      NaN
+        2002   62485.0   62485.0   62485.0   62485.0  62485.0  62485.0  62485.0      NaN      NaN      NaN      NaN
+        2003   69175.0   69175.0   69175.0   69175.0  69175.0  69175.0      NaN      NaN      NaN      NaN      NaN
+        2004   99322.0   99322.0   99322.0   99322.0  99322.0      NaN      NaN      NaN      NaN      NaN      NaN
+        2005  138151.0  138151.0  138151.0  138151.0      NaN      NaN      NaN      NaN      NaN      NaN      NaN
+        2006  107578.0  107578.0  107578.0       NaN      NaN      NaN      NaN      NaN      NaN      NaN      NaN
+        2007   62438.0   62438.0       NaN       NaN      NaN      NaN      NaN      NaN      NaN      NaN      NaN
+        2008   47797.0       NaN       NaN       NaN      NaN      NaN      NaN      NaN      NaN      NaN      NaN
+
+    Of course, we can have multiple rate changes, or assuems that policies are 24 months
+    long with `policy_length`.
+    We can also get more accurate OLFs by using the `approximation_grain`
+    argument to set the resolution of the internal calendar spacing used to
+    calculate on-level factors.
+
+    ..  testcode::
+
+        xyz = cl.load_sample("xyz")
+        olf = (
+            cl.ParallelogramOLF(
+                rate_history=pd.DataFrame(
+                    {
+                        "EffDate": ["2001-07-01", "2023-10-01"],
+                        "RateChange": [0.20, -0.05],
+                    }
+                ),
+                change_col="RateChange",
+                date_col="EffDate",
+                policy_length=24,
+                approximation_grain="D",
+            )
+            .fit_transform(xyz["Premium"])
+            .olf_
+        )
+        xyz["Leveled Premium"] = xyz["Premium"] * olf
+        print(np.round(xyz["Leveled Premium"], 0))
+
+    ..  testoutput::
+
+                   12        24        36        48       60       72       84       96       108      120      132
+        1998       NaN       NaN   24000.0   24000.0  24000.0  24000.0  24000.0  24000.0  24000.0  24000.0  24000.0
+        1999       NaN   37800.0   37800.0   37800.0  37800.0  37800.0  37800.0  37800.0  37800.0  37800.0      NaN
+        2000   54000.0   54000.0   54000.0   54000.0  54000.0  54000.0  54000.0  54000.0  54000.0      NaN      NaN
+        2001   59247.0   59247.0   59247.0   59247.0  59247.0  59247.0  59247.0  59247.0      NaN      NaN      NaN
+        2002   66720.0   66720.0   66720.0   66720.0  66720.0  66720.0  66720.0      NaN      NaN      NaN      NaN
+        2003   69891.0   69891.0   69891.0   69891.0  69891.0  69891.0      NaN      NaN      NaN      NaN      NaN
+        2004   99322.0   99322.0   99322.0   99322.0  99322.0      NaN      NaN      NaN      NaN      NaN      NaN
+        2005  138151.0  138151.0  138151.0  138151.0      NaN      NaN      NaN      NaN      NaN      NaN      NaN
+        2006  107578.0  107578.0  107578.0       NaN      NaN      NaN      NaN      NaN      NaN      NaN      NaN
+        2007   62438.0   62438.0       NaN       NaN      NaN      NaN      NaN      NaN      NaN      NaN      NaN
+        2008   47797.0       NaN       NaN       NaN      NaN      NaN      NaN      NaN      NaN      NaN      NaN
+
     """
 
     def __init__(

--- a/chainladder/core/tests/test_slicing.py
+++ b/chainladder/core/tests/test_slicing.py
@@ -1,4 +1,3 @@
-
 import numpy as np
 import pytest
 
@@ -6,7 +5,8 @@ import pytest
 def test_slice_by_boolean(clrd):
     assert (
         clrd[clrd["LOB"] == "ppauto"].loc["Wolverine Mut Ins Co"]["CumPaidLoss"]
-        == clrd.loc["Wolverine Mut Ins Co"].loc["ppauto"]["CumPaidLoss"])
+        == clrd.loc["Wolverine Mut Ins Co"].loc["ppauto"]["CumPaidLoss"]
+    )
 
 
 def test_slice_by_loc(clrd):
@@ -15,7 +15,7 @@ def test_slice_by_loc(clrd):
 
 def test_slice_origin(raa):
     assert raa[raa.origin > "1985"].shape == (1, 1, 5, 10)
-    raa.loc[..., raa.origin<='1994', :]
+    raa.loc[..., raa.origin <= "1994", :]
 
 
 def test_slice_development(raa):
@@ -73,7 +73,8 @@ def test_4loc(clrd):
 
 def test_loc_ellipsis(clrd):
     assert (
-        clrd.loc["Aegis Grp"] == clrd.loc["Adriatic Ins Co":"Aegis Grp"].loc["Aegis Grp"]
+        clrd.loc["Aegis Grp"]
+        == clrd.loc["Adriatic Ins Co":"Aegis Grp"].loc["Aegis Grp"]
     )
     assert clrd.loc["Aegis Grp", ..., :] == clrd.loc["Aegis Grp"]
     assert clrd.loc[..., 24:] == clrd.loc[..., :, 24:]
@@ -103,13 +104,20 @@ def test_loc_tuple(clrd):
 def test_at_iat(raa):
     raa1 = raa.copy()
     raa2 = raa.copy()
-    raa1.at['Total','values', '1985', 120]
-    raa1.at['Total','values', '1985', 120] = 5
-    raa1.at['Total','values', '1985', 12] = 5
+    raa1.at["Total", "values", "1985", 120]
+    raa1.at["Total", "values", "1985", 120] = 5
+    raa1.at["Total", "values", "1985", 12] = 5
     raa2.iat[0, 0, 4, -1] = 5
     raa2.iat[0, 0, 4, -1]
     raa2.iat[-1, -1, 4, 0] = 5
     assert raa1 == raa2
+
+
+def test_at_iat_exceptions(raa):
+    with pytest.raises(ValueError):
+        raa.iat[0, 0, 4, :]
+    with pytest.raises(ValueError):
+        raa.at["Total", "values", "1985", 0:2]
 
 
 @pytest.mark.xfail
@@ -120,16 +128,16 @@ def test_sparse_at_iat(prism):
 def test_sparse_at_iat1(prism):
     t = prism.copy()
     t.iat[0, 0, 0, 0] = 5.0
-    t.at[12138, 'reportedCount', '2008-01', 1] = 0
+    t.at[12138, "reportedCount", "2008-01", 1] = 0
     assert t == prism
 
 
 def test_sparse_column_assignment(prism):
     t = prism.copy()
-    out = t['Paid']
-    t['Paid2'] = t['Paid'] # New from physical
-    t['Paid2'] = lambda x: x['Paid'] # Existing from virtual
-    t['Paid'] = t['Paid2'] # Existing from physical
-    t['Paid3'] = lambda t: t['Paid'] # New from virtual
-    assert out == t['Paid']
+    out = t["Paid"]
+    t["Paid2"] = t["Paid"]  # New from physical
+    t["Paid2"] = lambda x: x["Paid"]  # Existing from virtual
+    t["Paid"] = t["Paid2"]  # Existing from physical
+    t["Paid3"] = lambda t: t["Paid"]  # New from virtual
+    assert out == t["Paid"]
     assert t.shape == (34244, 6, 120, 120)

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,6 @@
+coverage:
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 0.1%


### PR DESCRIPTION
## Summary of Changes  
Improved docstrings for the parallelogram method and added examples

## Related GitHub Issue(s)  
#704 

## Additional Context for Reviewers  
Should be pretty easy to review

- [x] I passed tests locally for both code (`uv run pytest`) and documentation changes (`uv run jb build docs --builder=custom --custom-builder=doctest`)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Primarily documentation and test adjustments; no changes to runtime adjustment logic, with only minor risk of doctest/CI config affecting builds.
> 
> **Overview**
> **Enhances `ParallelogramOLF` docs** by clarifying parameter descriptions (notably `rate_history` and `vertical_line`) and adding two doctest-style usage examples demonstrating single vs. multiple rate changes, different `policy_length`, and daily vs. monthly `approximation_grain`.
> 
> **Updates slicing tests** with minor formatting cleanup and adds `test_at_iat_exceptions` to assert `.at`/`.iat` raise `ValueError` when given non-scalar selectors.
> 
> Adds a basic `codecov.yml` to enable project coverage status reporting with an auto target and small threshold.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c633764cb87d4996b96686bdb31a1d8b44a87b9d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->