### PR TITLE
Return Python bool from is_ultimate and conduct proper doctests

### DIFF
--- a/chainladder/core/triangle.py
+++ b/chainladder/core/triangle.py
@@ -917,7 +917,7 @@ class Triangle(TriangleBase):
         self._pattern = pattern
 
     @property
-    def is_ultimate(self) ->  np.bool:
+    def is_ultimate(self) ->  bool:
         """
         Indicates whether the Triangle includes an ultimate valuation column.
 
@@ -942,7 +942,7 @@ class Triangle(TriangleBase):
         .. testcode::
 
             tr = cl.load_sample('ukmotor')
-            print(bool(tr.is_ultimate))
+            print(tr.is_ultimate)
 
         .. testoutput::
 
@@ -954,13 +954,13 @@ class Triangle(TriangleBase):
         .. testcode::
 
             ult = cl.Chainladder().fit(tr).ultimate_
-            print(bool(ult.is_ultimate))
+            print(ult.is_ultimate)
 
         .. testoutput::
 
             True
         """
-        return sum(self.valuation >= options.ULT_VAL[:4]) > 0
+        return bool((self.valuation >= options.ULT_VAL[:4]).any())
 
     @property
     def latest_diagonal(self) -> Triangle:


### PR DESCRIPTION
## Summary of Changes  

The `is_ultimate` attribute of `Triangle` now returns a Python boolean (i.e. `True`/`False`) as intended.  The doctest, which suppressed the error by converting the return value to a bool when testing, was modified to test the output directly without modifying it.

## Related GitHub Issue(s)  

https://github.com/casact/chainladder-python/issues/785

## Additional Context for Reviewers  


- [ ] I passed tests locally for both code (`uv run pytest`) and documentation changes (`uv run jb build docs --builder=custom --custom-builder=doctest`)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small change to a read-only property to consistently return a native `bool`; behavioral impact should be limited to type/printing and truthiness checks.
> 
> **Overview**
> `Triangle.is_ultimate` now returns a native Python `bool` (and updates its type hint accordingly) instead of a NumPy boolean.
> 
> The implementation switches from a `sum(...) > 0` check to an `.any()`-based check wrapped in `bool(...)`, and the doctest examples were updated to assert the returned value directly (removing `bool(...)` casts).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 471134c9393dcdc2c573eba69ea6284ba8efc094. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->