### PR TITLE
developmentconstant callable on columns

### DIFF
--- a/chainladder/development/constant.py
+++ b/chainladder/development/constant.py
@@ -18,7 +18,7 @@ class DevelopmentConstant(DevelopmentBase):
     style: string, optional (default='ldf')
         Type of pattern given to the Estimator. Options include 'cdf' or 'ldf'.
     callable_axis: 0 or 1
-        If a callable is supplied, the axis (index or column) along which to apply
+        If a callable is supplied, the axis, index (0) or column (1) along which to apply
         the callable. If patterns is not a callable, then this parameter is ignored.
     groupby:
         option to group levels of the triangle index together for the purposes
@@ -60,11 +60,20 @@ class DevelopmentConstant(DevelopmentBase):
         xp = obj.get_array_module()
         obj = obj.iloc[..., :1, :-1]*0+1
         if callable(self.patterns):
-            ldf = obj.index.apply(self.patterns, axis=self.callable_axis)
-            ldf = (
-                pd.concat(ldf.apply(pd.DataFrame, index=[0]).values, axis=0)
-                  .fillna(1)[obj.ddims].values)
-            ldf = xp.array(ldf[:, None, None, :])
+            if self.callable_axis == 0:
+                ldf = obj.index.apply(self.patterns, axis=1)                
+                ldf = (
+                    pd.concat(ldf.apply(pd.DataFrame, index=[0]).values, axis=0)
+                    .fillna(1)[obj.ddims].values)
+                ldf = xp.array(ldf[:, None, None, :])
+            elif self.callable_axis == 1:
+                ldf = obj.columns.to_frame(index=False).apply(self.patterns, axis=1)
+                ldf = (
+                    pd.concat(ldf.apply(pd.DataFrame, index=[0]).values, axis=0)
+                    .fillna(1)[obj.ddims].values)
+                ldf = xp.array(ldf[None, :, None, :])
+            else:
+                raise ValueError('callable axis needs to be 0 or 1')
         else:
             ldf = xp.array([float(self.patterns[item]) for item in obj.ddims])
             ldf = ldf[None, None, None, :]

--- a/chainladder/development/tests/test_constant.py
+++ b/chainladder/development/tests/test_constant.py
@@ -1,6 +1,7 @@
 import chainladder as cl
 import numpy as np
 import pandas as pd
+import pytest
 
 
 def test_constant_cdf(raa):
@@ -22,7 +23,7 @@ def test_constant_ldf(raa):
     dev_c = cl.DevelopmentConstant(patterns=link_ratios, style="ldf").fit(raa)
     assert xp.allclose(dev.ldf_.values, dev_c.ldf_.values, atol=1e-5)
 
-def test_constant_callable(clrd, atol):
+def test_constant_callable_axis0(clrd, atol):
     agway = clrd.loc['Agway Ins Co', 'CumPaidLoss']
     def paid_cdfs(x):
         """ A function that returns different CDFs depending on a specified LOB """
@@ -35,5 +36,23 @@ def test_constant_callable(clrd, atol):
         'wkcomp': [4.106, 1.865, 1.418, 1.234, 1.141, 1.09, 1.056, 1.03, 1.01, 1]}
         patterns = pd.DataFrame(cdfs, index=range(12, 132, 12)).T
         return patterns.loc[x.loc['LOB']].to_dict()
-    model = cl.DevelopmentConstant(patterns=paid_cdfs, callable_axis=1, style='cdf')
+    model = cl.DevelopmentConstant(patterns=paid_cdfs, callable_axis=0, style='cdf')
     assert abs(model.fit_transform(agway).cdf_.loc['comauto'].iloc[..., 0].sum() - 3.832) < atol
+
+def test_constant_callable_axis1(clrd, atol):
+    agway = clrd.loc['Agway Ins Co', 'comauto']
+    cdfs = {
+        'IncurLoss': [3.832, 1.874, 1.386, 1.181, 1.085, 1.043, 1.022, 1.013, 1.007, 1],
+        'CumPaidLoss': [24.168, 4.127, 2.103, 1.528, 1.275, 1.161, 1.088, 1.047, 1.018, 1],
+        'BulkLoss': [10.887, 3.416, 1.957, 1.433, 1.231, 1.119, 1.06, 1.031, 1.011, 1],
+        'EarnedPremDIR': [2.559, 1.417, 1.181, 1.084, 1.04, 1.019, 1.009, 1.004, 1.001, 1],
+        'EarnedPremCeded': [13.703, 5.613, 2.92, 1.765, 1.385, 1.177, 1.072, 1.034, 1.008, 1],
+        'EarnedPremNet': [4.106, 1.865, 1.418, 1.234, 1.141, 1.09, 1.056, 1.03, 1.01, 1]}
+    patterns = pd.DataFrame(cdfs, index=range(12, 132, 12)).T
+    def paid_cdfs(x):
+        """ A function that returns different CDFs depending on a specified column """
+        return patterns.loc[x.loc['columns']].to_dict()
+    with pytest.raises(ValueError):
+        xerror = cl.DevelopmentConstant(patterns=paid_cdfs, callable_axis=2, style='cdf').fit(agway)
+    lhs = cl.DevelopmentConstant(patterns=paid_cdfs, callable_axis=1, style='cdf').fit(agway).cdf_
+    assert np.all(abs(lhs.values[0,:,0,:]-patterns.values[:,:-1]) < atol)

--- a/docs/gallery/plot_callable_dev_constant.ipynb
+++ b/docs/gallery/plot_callable_dev_constant.ipynb
@@ -84,7 +84,7 @@
     "# If it works with pandas apply on the triangle index...\n",
     "agway.index.apply(paid_cdfs, axis=1)\n",
     "# ... then it will work in DevelopmentConstant\n",
-    "model = cl.DevelopmentConstant(patterns=paid_cdfs, callable_axis=1, style='cdf')\n",
+    "model = cl.DevelopmentConstant(patterns=paid_cdfs, callable_axis=0, style='cdf')\n",
     "\n",
     "model.fit(agway)"
    ]


### PR DESCRIPTION
## Summary of Changes  
resubmitting #782

implementing column axis for callable developmentconstant

## Related GitHub Issue(s)  
#759

## Additional Context for Reviewers  


- [x] I passed tests locally for both code (`uv run pytest`) and documentation changes (`uv run jb build docs --builder=custom --custom-builder=doctest`)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core development-factor fitting logic and changes callable behavior based on axis selection; risk is moderate due to potential shape/broadcasting differences and new error path.
> 
> **Overview**
> `DevelopmentConstant.fit` now supports applying callable `patterns` over *either* the triangle index (`callable_axis=0`) or columns (`callable_axis=1`), building appropriately shaped LDF arrays and raising a `ValueError` for invalid axes.
> 
> Tests were expanded to cover both axis modes (including invalid-axis assertion), and the callable-patterns documentation notebook was updated to reflect the new `callable_axis` semantics.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ec9404bb5684be3f2d8c6d9f75a19ec40d68cdc1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->