### PR TITLE
REFACTOR: Cleanup dead Pandas 1.x code.

### DIFF
--- a/chainladder/core/base.py
+++ b/chainladder/core/base.py
@@ -423,11 +423,7 @@ class TriangleBase(
         months: np.ndarray = (dates.dt.year * 12 + dates.dt.month).unique()
         diffs: np.ndarray = np.diff(np.sort(months))
         if np.all(np.mod(diffs,12) == 0):
-            grain = (
-                "Y"
-                if version.Version(pd.__version__) >= version.Version("2.2.0")
-                else "A"
-            )
+            grain = "Y"
         elif np.all(np.mod(diffs,6) == 0):
             grain = "2Q"
         elif np.all(np.mod(diffs,3) == 0):
@@ -584,10 +580,10 @@ class TriangleBase(
         else:
             raise NotImplementedError()
 
-    def _interchange_dataframe(self, data: DataFrameXchg) -> DataFrame:
+    @staticmethod
+    def _interchange_dataframe(data: DataFrameXchg) -> DataFrame:
         """
         Convert an object supporting the __dataframe__ protocol to a pandas DataFrame.
-        Requires pandas version > 1.5.2.
 
         Parameters
         ----------
@@ -598,16 +594,9 @@ class TriangleBase(
         out: pd.DataFrame
             A pandas DataFrame.
         """
-        # Check if pandas version is greater than 1.5.2
-        if version.parse(pd.__version__) >= version.parse("1.5.2"):
-            return pd.api.interchange.from_dataframe(data)
 
-        else:
-            # Raise an error prompting the user to upgrade pandas
-            raise NotImplementedError(
-                "Your version of pandas does not support the DataFrame interchange API. "
-                "Please upgrade pandas to a version greater than 1.5.2 to use this feature."
-            )
+        return pd.api.interchange.from_dataframe(data)
+
 
     def __array_function__(self, func, types, args, kwargs):
         from chainladder.utils.utility_functions import concat

--- a/chainladder/core/base.py
+++ b/chainladder/core/base.py
@@ -4,8 +4,6 @@
 from __future__ import annotations
 
 import pandas as pd
-from packaging import version
-
 import numpy as np
 import warnings
 

--- a/chainladder/core/display.py
+++ b/chainladder/core/display.py
@@ -188,30 +188,18 @@ class TriangleDisplay:
                 shape_size - 1
             ) + 1
             gmap = gmap.replace(np.nan, (shape_size + 1) / 2)
-            if pd.__version__ >= "1.3":
-                default_output = (
-                    data.style.format(fmt_str)
-                    .background_gradient(
-                        cmap=cmap,
-                        low=low,
-                        high=high,
-                        axis=None,
-                        subset=subset,
-                        gmap=gmap,
-                    )
-                    .to_html()
+            default_output = (
+                data.style.format(fmt_str)
+                .background_gradient(
+                    cmap=cmap,
+                    low=low,
+                    high=high,
+                    axis=None,
+                    subset=subset,
+                    gmap=gmap,
                 )
-            else:
-                default_output = (
-                    data.style.format(fmt_str)
-                    .background_gradient(
-                        cmap=cmap,
-                        low=low,
-                        high=high,
-                        axis=axis,
-                    )
-                    .render()
-                )
+                .to_html()
+            )
             output_xnan = re.sub("<td.*nan.*td>", "<td></td>", default_output)
         else:
             raise ValueError("heatmap() only works with a single triangle.")

--- a/chainladder/core/pandas.py
+++ b/chainladder/core/pandas.py
@@ -571,7 +571,7 @@ def add_groupby_agg_func(cls, k: str, v: str):
             )
             obj.origin_grain = self.obj._get_grain(odims)
             split = obj.origin_grain.split("-")
-            obj.origin_grain = {"A": "Y", "2Q": "S"}.get(split[0], split[0])
+            obj.origin_grain = {"2Q": "S"}.get(split[0], split[0])
             obj.odims = odims.values
         obj._set_slicers()
         if auto_sparse:

--- a/chainladder/core/triangle.py
+++ b/chainladder/core/triangle.py
@@ -670,7 +670,6 @@ class Triangle(TriangleBase):
             return pd.Series(["(All)"])
         else:
             freq = {
-                "Y": "Y",
                 "S": "2Q",
                 "H": "2Q",
             }.get(self.origin_grain, self.origin_grain)
@@ -681,7 +680,6 @@ class Triangle(TriangleBase):
     def origin(self, value) -> None:
         self._len_check(self.origin, value)
         freq = {
-            "Y": "Y",
             "S": "2Q",
         }.get(self.origin_grain, self.origin_grain)
         freq = freq if freq == "M" else freq + "-" + self.origin_close

--- a/chainladder/core/triangle.py
+++ b/chainladder/core/triangle.py
@@ -670,7 +670,6 @@ class Triangle(TriangleBase):
             return pd.Series(["(All)"])
         else:
             freq = {
-                "Y": "Y",
                 "S": "2Q",
                 "H": "2Q",
             }.get(self.origin_grain, self.origin_grain)

--- a/chainladder/core/triangle.py
+++ b/chainladder/core/triangle.py
@@ -6,7 +6,6 @@ from __future__ import annotations
 import pandas as pd
 import numpy as np
 import warnings
-from packaging import version
 from chainladder.core.base import TriangleBase
 from chainladder.utils.sparse import sp
 from chainladder.core.slice import VirtualColumns

--- a/chainladder/core/triangle.py
+++ b/chainladder/core/triangle.py
@@ -37,11 +37,11 @@ class Triangle(TriangleBase):
     ----------
     data: DataFrame or DataFrameXchg, or dict
         A single dataframe that contains columns representing all other
-        arguments to the Triangle constructor. If using pandas version > 1.5.2,
-        one may supply a DataFrame-like object (referred to as DataFrameXchg)
-        supporting the __dataframe__ protocol, which will then be converted to
-        a pandas DataFrame. If supplying a dict, it must be structured such that
-        a pandas DataFrame created from it will be accepted by the constructor.
+        arguments to the Triangle constructor. One may supply a DataFrame-like
+        object (referred to as DataFrameXchg) supporting the __dataframe__ protocol,
+        which will then be converted to a pandas DataFrame. If supplying a dict,
+        it must be structured such that a pandas DataFrame created from it will be
+        accepted by the constructor.
     origin: str or list
          A representation of the accident, reporting or more generally the
          origin period of the triangle that will map to the Origin dimension
@@ -473,9 +473,9 @@ class Triangle(TriangleBase):
         self.is_cumulative: bool = cumulative
         self.virtual_columns = VirtualColumns(self)
         self._pattern: bool = pattern
-        
+
         split: list[str] = self.origin_grain.split("-")
-        self.origin_grain: str = {"A": "Y", "2Q": "S"}.get(split[0], split[0])
+        self.origin_grain: str = {"2Q": "S"}.get(split[0], split[0])
 
         if len(split) == 1:
             self.origin_close: str = "DEC"
@@ -483,7 +483,8 @@ class Triangle(TriangleBase):
             self.origin_close: str = split[1]
 
         split: list[str] = self.development_grain.split("-")
-        self.development_grain: str = {"A": "Y", "2Q": "S"}.get(split[0], split[0])
+        self.development_grain: str = {"2Q": "S"}.get(split[0], split[0])
+
         grain_sort: list = ["Y", "S", "Q", "M"]
         self.development_grain: str = grain_sort[
             max(
@@ -670,11 +671,7 @@ class Triangle(TriangleBase):
             return pd.Series(["(All)"])
         else:
             freq = {
-                "Y": (
-                    "Y"
-                    if version.Version(pd.__version__) >= version.Version("2.2.0")
-                    else "A"
-                ),
+                "Y": "Y",
                 "S": "2Q",
                 "H": "2Q",
             }.get(self.origin_grain, self.origin_grain)
@@ -682,10 +679,10 @@ class Triangle(TriangleBase):
             return pd.DatetimeIndex(self.odims, name="origin").to_period(freq=freq)
 
     @origin.setter
-    def origin(self, value):
+    def origin(self, value) -> None:
         self._len_check(self.origin, value)
         freq = {
-            "Y": "A" if float(".".join(pd.__version__.split(".")[:-1])) < 2.2 else "Y",
+            "Y": "Y",
             "S": "2Q",
         }.get(self.origin_grain, self.origin_grain)
         freq = freq if freq == "M" else freq + "-" + self.origin_close


### PR DESCRIPTION
## Summary of Changes  

Cleans up dead code checking for pandas 1.x installations.

## Related GitHub Issue(s)  

#805

## Additional Context for Reviewers  

Dropping checks for grain "A" vs "Y" is safe to do. However "2Q" is still used in the library and "S" seems to be a custom grain level anyway and is not a pandas 1 vs 2 vs 3 issue so I have left that in.

- [x] I passed tests locally for both code (`uv run pytest`) and documentation changes (`uv run jb build docs --builder=custom --custom-builder=doctest`)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it drops version-conditional behavior and now assumes newer pandas APIs (e.g., `Period` freq `'Y'`, DataFrame interchange, Styler `.to_html()`), which could break consumers on older pandas versions.
> 
> **Overview**
> **Cleans up dead pandas-compat logic** by removing `packaging.version` checks and hard-coding modern pandas behaviors.
> 
> Annual grain handling is standardized to `'Y'` (eliminating `'A'` mappings) across triangle grain inference and groupby/constructor normalization, and the DataFrame interchange path now unconditionally uses `pd.api.interchange.from_dataframe`. Display heatmaps are simplified to always use `Styler.background_gradient(..., axis=None, subset=..., gmap=...).to_html()`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 348834b33a591fb9fc5a1f477663edc26ce09068. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->