### PR TITLE
docs(triangle): document array_backend and pattern parameters (#521)

### DIFF
--- a/chainladder/core/triangle.py
+++ b/chainladder/core/triangle.py
@@ -71,15 +71,10 @@ class Triangle(TriangleBase):
         (i.e., calendar fiscal periods). When True, the period end is inferred
         from the data itself. This is useful when origin dates do not align
         with calendar period boundaries.
-    array_backend: str
+    array_backend: str, optional (default = None)
         Backend used to store the underlying values array. One of
         ``'numpy'``, ``'sparse'``, or ``'cupy'`` (if installed). If
-        ``None`` (default), falls back to ``cl.options.ARRAY_BACKEND``.
-    pattern: bool
-        Indicates whether the Triangle holds development patterns
-        (e.g. link ratios) rather than aggregated loss values. Defaults
-        to ``False``. Mirrors the ``is_pattern`` attribute and affects
-        array-backend selection and certain downstream methods.
+        ``None``, falls back to ``cl.options.ARRAY_BACKEND``.
 
     Attributes
     ----------

--- a/chainladder/core/triangle.py
+++ b/chainladder/core/triangle.py
@@ -71,6 +71,15 @@ class Triangle(TriangleBase):
         (i.e., calendar fiscal periods). When True, the period end is inferred
         from the data itself. This is useful when origin dates do not align
         with calendar period boundaries.
+    array_backend: str
+        Backend used to store the underlying values array. One of
+        ``'numpy'``, ``'sparse'``, or ``'cupy'`` (if installed). If
+        ``None`` (default), falls back to ``cl.options.ARRAY_BACKEND``.
+    pattern: bool
+        Indicates whether the Triangle holds development patterns
+        (e.g. link ratios) rather than aggregated loss values. Defaults
+        to ``False``. Mirrors the ``is_pattern`` attribute and affects
+        array-backend selection and certain downstream methods.
 
     Attributes
     ----------


### PR DESCRIPTION
Closes #521.

`array_backend` and `pattern` are real parameters of `Triangle.__init__` (chainladder/core/triangle.py:350-351) but the class docstring's Parameters section didn't list them. Added descriptions consistent with the existing `is_pattern` attribute documentation and the `options.ARRAY_BACKEND` fallback logic.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docstring-only update that adds missing `Triangle` constructor parameter documentation; no runtime behavior changes.
> 
> **Overview**
> Adds missing documentation for `Triangle`'s `array_backend` constructor parameter, including supported backends and the fallback to `cl.options.ARRAY_BACKEND`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d3124aacc21950cde2fcc05cd2930e74198a880e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->