### PR TITLE
docs: add Semiannual (S) to Triangle Grain section (#809)

### DIFF
--- a/docs/user_guide/triangle.ipynb
+++ b/docs/user_guide/triangle.ipynb
@@ -1120,8 +1120,9 @@
     "\n",
     "If your triangle has origin and development grains that are more frequent then\n",
     "yearly, you can easily swap to a higher grain using the `grain` method of the\n",
-    "`Triangle`. The `grain` method recognizes Yearly (Y), Quarterly (Q), and\n",
-    "Monthly (M) grains for both the origin period and development period."
+    "`Triangle`. The `grain` method recognizes Yearly (Y), Semiannual (S),\n",
+    "Quarterly (Q), and Monthly (M) grains for both the origin period and\n",
+    "development period.\n"
    ]
   },
   {


### PR DESCRIPTION
Refs #809 (part 1 of 2).

The [Triangle Grain section](https://chainladder-python.readthedocs.io/en/latest/user_guide/triangle.html#triangle-grain) of the user guide lists Yearly (Y), Quarterly (Q), and Monthly (M) grains but omits Semiannual (S). Semiannual is fully supported across the codebase (e.g. `Triangle.grain('OSDS')`, the format dicts in `triangle.py`, `development/base.py`, `development/clark.py`, etc.). This adds the missing grain to the docs.

### Out of scope

The other half of #809 — suppressing the `UserWarning: Could not infer format` that fires when running `cl.load_sample('quarterly')` in the same docs section — is left for a separate PR. The fallback in `chainladder/core/base.py` that emits the warning is intentional (it's the last entry in the format-tries list, passing no `format=`), so silencing it deserves its own review.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change that updates the listed supported `Triangle.grain` frequencies; no runtime or API behavior is modified.
> 
> **Overview**
> Updates the Triangle user guide’s *Triangle Grain* section to include **Semiannual (S)** as a recognized origin/development grain alongside Yearly, Quarterly, and Monthly, aligning the docs with existing `Triangle.grain` support.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 815ad259b74c0c685d9223a81808057f2ac77c2c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->