### PR TITLE
[Pandas 3] Replace DataFrame.groupby(...,axis=1) with double transpose.

### DIFF
--- a/chainladder/core/tests/test_triangle.py
+++ b/chainladder/core/tests/test_triangle.py
@@ -327,7 +327,7 @@ def test_groupby_axis1(clrd, prism):
     clrd = clrd.sum("origin").sum("development")
     groups = [i.find("Loss") >= 0 for i in clrd.columns]
     assert np.all(
-        clrd.to_frame(origin_as_datetime=False).groupby(groups, axis=1).sum()
+        clrd.to_frame(origin_as_datetime=False).T.groupby(groups).sum().T
         == clrd.groupby(groups, axis=1).sum().to_frame(origin_as_datetime=False)
     )
     assert np.all(

--- a/chainladder/core/tests/test_triangle.py
+++ b/chainladder/core/tests/test_triangle.py
@@ -8,6 +8,8 @@ import pytest
 
 from chainladder.utils.utility_functions import date_delta_adjustment
 
+from io import StringIO
+
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
@@ -21,7 +23,7 @@ except ImportError:
 
 def test_repr(raa):
     np.testing.assert_array_equal(
-        pd.read_html(raa._repr_html_())[0].set_index("Unnamed: 0").values,
+        pd.read_html(StringIO(raa._repr_html_()))[0].set_index("Unnamed: 0").values,
         raa.to_frame(origin_as_datetime=False).values,
     )
 

--- a/chainladder/utils/utility_functions.py
+++ b/chainladder/utils/utility_functions.py
@@ -456,7 +456,7 @@ def read_json(json_str, array_backend=None):
                 setattr(getattr(tri, k), "development_grain", tri.development_grain)
         if "dfs" in json_dict.keys():
             for k, v in json_dict["dfs"].items():
-                df = pd.read_json(v)
+                df = pd.read_json(StringIO(v))
                 if len(df.columns) == 1:
                     df = df.iloc[:, 0]
                 setattr(tri, k, df)


### PR DESCRIPTION
## Summary of Changes  

Replace DataFrame.groupby(...,axis=1) with double transpose.

## Related GitHub Issue(s)  

#727, #664

## Additional Context for Reviewers  

2rd PR in a series to address #664. Previous commits should drop out after prior PRs are merged in.

- [x] I passed tests locally for both code (`uv run pytest`) and documentation changes (`uv run jb build docs --builder=custom --custom-builder=doctest`)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk test-only change to accommodate pandas 3 deprecation of `DataFrame.groupby(..., axis=1)`; behavior should be identical aside from potential edge-case differences in transpose/groupby ordering.
> 
> **Overview**
> Updates `test_groupby_axis1` to replace `DataFrame.groupby(..., axis=1)` usage with a **double-transpose** pattern (`.T.groupby(...).sum().T`) when grouping columns, improving compatibility with pandas 3 while keeping the assertion semantics the same.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a6ffa8ea3335f80d2866ac9b5beccde30efa5a83. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->