### PR TITLE
rebasing

### DIFF
--- a/chainladder/__init__.py
+++ b/chainladder/__init__.py
@@ -1,10 +1,21 @@
+import numpy as np
+import pandas as pd
 from sklearn.utils import deprecated
+
+
+_DT64_DTYPE = pd.to_datetime(["2000-01-01"]).dtype
+_ULT_VAL: str = str(
+    pd.Timestamp("2262-01-01") - \
+    pd.Timedelta(1, unit=np.datetime_data(_DT64_DTYPE)[0])
+)
 
 class Options:
     ARRAY_BACKEND = "numpy"
     AUTO_SPARSE = True
     ARRAY_PRIORITY = ["dask", "sparse", "cupy", "numpy"]
-    ULT_VAL = "2261-12-31 23:59:59.999999999"
+    ULT_VAL: str = _ULT_VAL
+    DT64_UNIT: str = np.datetime_data(_DT64_DTYPE)[0]
+    DT64_DTYPE: str = str(_DT64_DTYPE)
 
     @classmethod
     def get_option(cls, option=None):
@@ -18,7 +29,7 @@ class Options:
         self.set_option('ARRAY_BACKEND', "numpy")
         self.set_option('AUTO_SPARSE', True)
         self.set_option('ARRAY_PRIORITY', ["dask", "sparse", "cupy", "numpy"])
-        self.set_option('ULT_VAL', "2261-12-31 23:59:59.999999999")
+        self.set_option('ULT_VAL', _ULT_VAL)
 
     def describe_option(self):
         pass

--- a/chainladder/core/base.py
+++ b/chainladder/core/base.py
@@ -540,12 +540,12 @@ class TriangleBase(
         ddim_arr = ddims - ddims[0]
         origin = np.minimum(self.odims, np.datetime64(self.valuation_date))
         val_array = origin.astype("datetime64[M]") + np.timedelta64(ddims[0], "M")
-        val_array = val_array.astype("datetime64[ns]") - np.timedelta64(1, "ns")
+        val_array = val_array.astype(options.DT64_DTYPE) - np.timedelta64(1, options.DT64_UNIT)
         val_array = val_array[:, None]
         s = slice(None, -1) if ddims[-1] == 9999 else slice(None, None)
         val_array = (
             val_array.astype("datetime64[M]") + ddim_arr[s][None, :] + 1
-        ).astype("datetime64[ns]") - np.timedelta64(1, "ns")
+        ).astype(options.DT64_DTYPE) - np.timedelta64(1, options.DT64_UNIT)
         if ddims[-1] == 9999:
             ult = np.repeat(np.datetime64(options.ULT_VAL), val_array.shape[0])[:, None]
             val_array = np.concatenate(

--- a/chainladder/core/pandas.py
+++ b/chainladder/core/pandas.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import numpy as np
 import pandas as pd
 
+from chainladder import options
 from chainladder.utils.utility_functions import num_to_nan
 from typing import TYPE_CHECKING
 
@@ -534,7 +535,7 @@ def add_triangle_agg_func(
         # If axis is development, set the ddims to be the valuation date.
         if axis == 3 and obj.values.shape[axis] == 1 and len(obj.ddims) > 1:
             obj.ddims = pd.DatetimeIndex(
-                [self.valuation_date], dtype="datetime64[ns]", freq=None
+                [self.valuation_date], dtype=options.DT64_DTYPE, freq=None
             )
         obj._set_slicers()
         if auto_sparse:

--- a/chainladder/core/tests/test_triangle.py
+++ b/chainladder/core/tests/test_triangle.py
@@ -6,6 +6,8 @@ import numpy as np
 import pandas as pd
 import pytest
 
+from chainladder.utils.utility_functions import date_delta_adjustment
+
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
@@ -914,7 +916,8 @@ def test_single_valuation_date_preserves_exact_date():
     )
 
     # Valuation date should be end of October 2025, not converted to a fiscal year
-    assert triangle.valuation_date == pd.Timestamp('2025-10-31 23:59:59.999999999')
+    val_date_exp: str = date_delta_adjustment("2025-11-01")
+    assert triangle.valuation_date == pd.Timestamp(val_date_exp)
     assert triangle.development_grain == 'M'
     assert int(triangle.valuation_date.strftime('%Y%m')) == 202510
 def test_OXDX_triangle():

--- a/chainladder/core/tests/test_triangle.py
+++ b/chainladder/core/tests/test_triangle.py
@@ -8,6 +8,8 @@ import pytest
 
 from chainladder.utils.utility_functions import date_delta_adjustment
 
+from io import StringIO
+
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
@@ -21,7 +23,7 @@ except ImportError:
 
 def test_repr(raa):
     np.testing.assert_array_equal(
-        pd.read_html(raa._repr_html_())[0].set_index("Unnamed: 0").values,
+        pd.read_html(StringIO(raa._repr_html_()))[0].set_index("Unnamed: 0").values,
         raa.to_frame(origin_as_datetime=False).values,
     )
 

--- a/chainladder/core/triangle.py
+++ b/chainladder/core/triangle.py
@@ -577,7 +577,7 @@ class Triangle(TriangleBase):
         if (
             development
             and len(development) == 1
-            and data[development[0]].dtype == "<M8[ns]"
+                and pd.api.types.is_datetime64_dtype(data[development[0]])
         ):
             u = data[data[development[0]] == options.ULT_VAL].copy()
             if len(u) > 0 and len(u) != len(data):

--- a/chainladder/utils/tests/test_utilities.py
+++ b/chainladder/utils/tests/test_utilities.py
@@ -5,6 +5,7 @@ import copy
 import numpy as np
 import pandas as pd
 
+from chainladder.utils.utility_functions import date_delta_adjustment
 from pathlib import Path
 
 
@@ -60,7 +61,6 @@ def test_read_csv_single(raa):
     # Test the read_csv function for a single dimensional input.
 
     # Read in the csv file.
-    from pathlib import Path
 
     raa_csv_path = Path(__file__).parent.parent / "data" / "raa.csv"
 
@@ -78,7 +78,6 @@ def test_read_csv_multi(clrd):
     # Test the read_csv function for multidimensional input.
 
     # Read in the csv file.
-    from pathlib import Path
 
     clrd_csv_path = Path(__file__).parent.parent / "data" / "clrd.csv"
 
@@ -170,3 +169,16 @@ def test_load_sample_clrd2025() -> None:
     # Accident years span 1998-2007.
     assert str(tri.origin.min()) == "1998"
     assert "2007" in [str(o) for o in tri.origin]
+
+def test_date_delta_adjustment() -> None:
+    """
+    Tests the date adjustment depending on Pandas default precision, nanosecond for Pandas 2, microsecond for Pandas 3.
+    """
+    result = date_delta_adjustment("2025-11-01")
+
+    expected = (
+        "2025-10-31 23:59:59.999999999"
+        if cl.options.DT64_UNIT == "ns"
+        else "2025-10-31 23:59:59.999999"
+    )
+    assert result == expected

--- a/chainladder/utils/utility_functions.py
+++ b/chainladder/utils/utility_functions.py
@@ -10,6 +10,7 @@ import os
 import numpy as np
 import pandas as pd
 
+from chainladder import options
 from chainladder.utils.sparse import sp
 from io import StringIO
 from patsy import dmatrix  # noqa
@@ -21,7 +22,6 @@ if TYPE_CHECKING:
     from chainladder import Triangle
     from numpy.typing import ArrayLike
     from pandas import DataFrame
-    from pandas.core.interchange.dataframe_protocol import DataFrame as DataFrameXchg
     from sparse import COO
     from types import ModuleType
     from typing import AnyStr
@@ -648,7 +648,7 @@ def concat(
     if ignore_index and axis == 0:
         out.key_labels = ["Index"]
     out.valuation_date = pd.Series([obj.valuation_date for obj in objs]).max()
-    if out.ddims.dtype == "datetime64[ns]" and type(out.ddims) == np.ndarray:
+    if out.ddims.dtype == options.DT64_DTYPE and type(out.ddims) == np.ndarray:
         out.ddims = pd.DatetimeIndex(out.ddims)
     out._set_slicers()
     if sort:
@@ -890,3 +890,48 @@ def PTF_formula(
     if formula_parts:
         return "+".join(formula_parts)
     return ""
+
+def date_delta_adjustment(date: str) -> str:
+    """
+    Subtracts the default pandas datetime delta from a date in "YYYY-MM-DD" string format.
+
+    Parameters
+    ----------
+    date: str
+        A date in "YYYY-MM-DD" format.
+
+    Returns
+    -------
+    The original date, minus one unit of the default precision level of pandas, e.g., nanosecond for Pandas 2
+    or microsecond for Pandas 3.
+
+    Examples
+    --------
+
+    .. testcode::
+        :options: +SKIP
+
+        import pandas as pd
+
+        print(date_delta_adjustment("2025-11-01"))
+
+    If using Pandas 2:
+
+    .. testoutput::
+
+        '2025-10-31 23:59:59.999999999'
+
+    If using Pandas 3:
+
+    .. testoutput::
+
+        '2025-10-31 23:59:59.999999'
+    """
+
+
+    res: str = str(
+        pd.Timestamp(date) - \
+        pd.Timedelta(1, unit=options.DT64_UNIT)
+    )
+
+    return res

--- a/chainladder/utils/utility_functions.py
+++ b/chainladder/utils/utility_functions.py
@@ -456,7 +456,7 @@ def read_json(json_str, array_backend=None):
                 setattr(getattr(tri, k), "development_grain", tri.development_grain)
         if "dfs" in json_dict.keys():
             for k, v in json_dict["dfs"].items():
-                df = pd.read_json(v)
+                df = pd.read_json(StringIO(v))
                 if len(df.columns) == 1:
                     df = df.iloc[:, 0]
                 setattr(tri, k, df)


### PR DESCRIPTION
## Summary of Changes  


## Related GitHub Issue(s)  


## Additional Context for Reviewers  


- [ ] I passed tests locally for both code (`uv run pytest`) and documentation changes (`uv run jb build docs --builder=custom --custom-builder=doctest`)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core date/valuation calculations and ultimate-value detection, so small precision changes could affect triangle indexing/serialization and downstream reserving results across pandas versions.
> 
> **Overview**
> **Datetime precision is now derived dynamically**: `Options` computes `ULT_VAL`, `DT64_UNIT`, and `DT64_DTYPE` from pandas’ default datetime64 precision instead of hardcoding nanoseconds.
> 
> Core triangle logic now uses these options when computing valuation timestamps (`TriangleBase.valuation`), when collapsing development axes (`core/pandas.py`), when normalizing ddims in `concat`, and when detecting ultimate rows in `_split_ult` (switches to a dtype check via `pd.api.types.is_datetime64_dtype`).
> 
> Tests were updated to be precision-agnostic (new `date_delta_adjustment` helper + assertions), and HTML/JSON parsing paths were tweaked to wrap strings with `StringIO` to satisfy newer pandas IO expectations.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fa3d68a789bb00aa1f9e73ed9b323db23c80cc4d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->