### PR TITLE
[TEST] Add tests for TriangleDisplay.

### DIFF
--- a/chainladder/core/display.py
+++ b/chainladder/core/display.py
@@ -205,8 +205,8 @@ class TriangleDisplay:
             raise ValueError("heatmap() only works with a single triangle.")
         if HTML:
             return HTML(output_xnan)
-        elif HTML is None:
-            raise ImportError("heatmap requires IPython.")
+        else:
+            raise ImportError("heatmap() requires IPython.")
 
     @property
     def _dimensionality(self) -> str:

--- a/chainladder/core/tests/test_display.py
+++ b/chainladder/core/tests/test_display.py
@@ -1,20 +1,59 @@
 from __future__ import annotations
 
+import chainladder as cl
 import importlib
-import sys
-import pytest
 import numpy as np
 import pandas as pd
+import pytest
+import sys
 
-import chainladder as cl
 
-from unittest import mock
 from chainladder.core.display import TriangleDisplay
-
+from lxml import etree, html as lxml_html
+from unittest import mock
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from chainladder import Triangle
+
+
+def check_html(html: str) -> None:
+    """
+    Parse the HTML and raise an assertion error if it is malformed.
+
+    Parameters
+    ----------
+    html: str
+        The HTML string.
+
+    Returns
+    -------
+    None
+
+    """
+
+    parser = etree.HTMLParser()
+    lxml_html.fromstring(html, parser=parser)
+
+    # Raise assertion error if one is detected. If so, print the error log as a list.
+    assert len(parser.error_log) == 0, list(parser.error_log)
+
+def test_check_html() -> None:
+    """
+    Make sure check_html does its job on a malformed string.
+
+    Parameters
+    ----------
+    html: str
+
+    Returns
+    -------
+    None
+
+    """
+    with pytest.raises(AssertionError):
+        check_html("<b><i>text</b></i>")
+
 
 def test_dimensionality_empty(empty_triangle: Triangle) -> None:
     """
@@ -118,8 +157,9 @@ def test_repr_html_single(raa):
     None
 
     """
-    assert "<table" in raa._repr_html_()
-
+    html_str: str = raa._repr_html_()
+    assert "<table" in html_str
+    check_html(html=html_str)
 
 def test_repr_html_multi(clrd: Triangle) -> None:
     """
@@ -135,10 +175,10 @@ def test_repr_html_multi(clrd: Triangle) -> None:
     None
 
     """
-    html = clrd._repr_html_()
-    assert "Triangle Summary" in html
-    assert "<table" in html
-
+    html_str = clrd._repr_html_()
+    assert "Triangle Summary" in html_str
+    assert "<table" in html_str
+    check_html(html=html_str)
 
 def test_get_format_str_all_nan() -> None:
     """

--- a/chainladder/core/tests/test_display.py
+++ b/chainladder/core/tests/test_display.py
@@ -1,5 +1,273 @@
+from __future__ import annotations
+
+import importlib
+import sys
 import pytest
+import numpy as np
+import pandas as pd
+
 import chainladder as cl
+
+from unittest import mock
+from chainladder.core.display import TriangleDisplay
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from chainladder import Triangle
+
+def test_dimensionality_empty(empty_triangle: Triangle) -> None:
+    """
+    Inspect the dimensionality of an empty triangle.
+
+    Parameters
+    ----------
+    empty_triangle: Triangle
+        An empty triangle.
+
+    Returns
+    -------
+    None
+
+    """
+
+    assert empty_triangle._dimensionality == "empty"
+
+
+def test_dimensionality_multi(clrd: Triangle) -> None:
+    """
+    Inspect dimensionality of a multidimensional triangle.
+
+    Parameters
+    ----------
+    clrd: Triangle
+        The clrd sample data set.
+
+    Returns
+    -------
+    None
+
+    """
+    assert clrd._dimensionality == "multi"
+
+
+def test_repr_empty(empty_triangle: Triangle) -> None:
+    """
+    Inspect the repr of an empty triangle.
+
+    Parameters
+    ----------
+    empty_triangle: Triangle
+        An empty triangle.
+
+    Returns
+    -------
+    None
+
+    """
+
+    assert repr(empty_triangle) == "Empty Triangle."
+
+
+def test_repr_multi(clrd: Triangle) -> None:
+    """
+    Inspect the repr of a multidimensional triangle.
+
+    Parameters
+    ----------
+    clrd: Triangle
+        The clrd sample data set.
+
+    Returns
+    -------
+    None
+
+    """
+    assert "Triangle Summary" in repr(clrd)
+
+
+def test_repr_html_empty(empty_triangle: Triangle):
+    """
+    Inspect the HTML representation of an empty triangle.
+
+    Parameters
+    ----------
+    empty_triangle: Triangle
+        An empty triangle.
+
+    Returns
+    -------
+    None
+
+    """
+
+    assert empty_triangle._repr_html_() == "Empty Triangle."
+
+
+def test_repr_html_single(raa):
+    """
+    Inspect the HTML representation of a single-dimensional triangle.
+
+    Parameters
+    ----------
+    raa: Triangle
+        The raa sample data set.
+
+    Returns
+    -------
+    None
+
+    """
+    assert "<table" in raa._repr_html_()
+
+
+def test_repr_html_multi(clrd: Triangle) -> None:
+    """
+    Inspect the HTML representation of a multidimensional triangle.
+
+    Parameters
+    ----------
+    clrd: Triangle
+        The clrd sample data set.
+
+    Returns
+    -------
+    None
+
+    """
+    html = clrd._repr_html_()
+    assert "Triangle Summary" in html
+    assert "<table" in html
+
+
+def test_get_format_str_all_nan() -> None:
+    """
+    Extract the format string from a DataFrame when data are all nan.
+
+    Returns
+    -------
+    None
+
+    """
+    data = pd.DataFrame([[np.nan, np.nan]])
+    assert TriangleDisplay._get_format_str(data) == ""
+
+
+def test_get_format_str_small() -> None:
+    """
+    Extract the format string from a DataFrame when mean of data is less than 10.
+
+    Returns
+    -------
+    None
+
+    """
+    data = pd.DataFrame([[1.0, 2.0]])
+    assert TriangleDisplay._get_format_str(data) == "{0:,.4f}"
+
+
+def test_get_format_str_medium() -> None:
+    """
+    Extract the format string from a DataFrame when mean of data is less than 1000.
+
+    Returns
+    -------
+    None
+
+    """
+    data = pd.DataFrame([[100.0, 200.0]])
+    assert TriangleDisplay._get_format_str(data) == "{0:,.2f}"
+
+
+def test_repr_format_semi_annual(prism: Triangle) -> None:
+    """
+    When origin has semiannual grain, "H1" and "H2" should appear in the index.
+
+    Parameters
+    ----------
+    prism: Triangle
+        The prism sample data set.
+
+    Returns
+    -------
+    None
+
+    """
+    prism = prism.sum()[["reportedCount"]]
+    semi = prism.grain("OSDM")
+    df = semi._repr_format()
+    assert any("H1" in str(i) or "H2" in str(i) for i in df.index)
+
+
+def test_heatmap_multi_raises(clrd: Triangle) -> None:
+    """
+    Heatmap only works on a single-dimension triangle. Raise a ValueError if multidimensional.
+
+    Parameters
+    ----------
+    clrd: Triangle
+        The clrd sample data set.
+
+    Returns
+    -------
+    None
+
+    """
+    with pytest.raises(ValueError, match="heatmap"):
+        clrd.heatmap()
+
+
+def test_heatmap_no_ipython(raa: Triangle) -> None:
+    """
+    Raise ImportError when calling heatmap when IPython is not installed.
+
+    Parameters
+    ----------
+    raa: Triangle
+        The raa sample data set.
+
+    Returns
+    -------
+    None
+
+    """
+    import chainladder.core.display as display_mod
+
+    blocked = {
+        "IPython": None,
+        "IPython.core": None,
+        "IPython.core.display": None
+    }
+    with mock.patch.dict(sys.modules, blocked):
+        importlib.reload(display_mod)
+        with pytest.raises(ImportError, match=r"heatmap\(\) requires IPython\."):
+            raa.heatmap()
+
+    importlib.reload(display_mod)
+
+
+def test_display_import_fallback_when_ipython_missing() -> None:
+    """
+    Set the variables of HTML and IPython in the display module to None when IPython is not installed.
+
+    Returns
+    -------
+    None
+
+    """
+    import chainladder.core.display as display_mod
+
+    blocked = {
+        "IPython": None,
+        "IPython.core": None,
+        "IPython.core.display": None
+    }
+    with mock.patch.dict(sys.modules, blocked):
+        importlib.reload(display_mod)
+        assert display_mod.HTML is None
+        assert display_mod.IPython is None
+
+    importlib.reload(display_mod)
 
 
 def test_heatmap_render(raa):
@@ -9,10 +277,6 @@ def test_heatmap_render(raa):
 
     except:
         assert False
-
-
-# def test_empty_triangle():
-#     assert cl.Triangle()
 
 
 def test_to_frame(raa):

--- a/conftest.py
+++ b/conftest.py
@@ -84,3 +84,7 @@ def xyz(request):
 @pytest.fixture
 def atol():
     return 1e-4
+
+@pytest.fixture
+def empty_triangle():
+    return cl.Triangle()


### PR DESCRIPTION
## Summary of Changes  

Adds unit tests for `core.display.py`

## Related GitHub Issue(s)  

#824

## Additional Context for Reviewers  

Adds a fixture called empty_triangle because it's used multiple times.

- [x] I passed tests locally for both code (`uv run pytest`) and documentation changes (`uv run jb build docs --builder=custom --custom-builder=doctest`)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: primarily adds test coverage and only changes runtime behavior by consistently raising `ImportError` when IPython/`HTML` is unavailable for `heatmap()`.
> 
> **Overview**
> Adds extensive unit tests for `TriangleDisplay` rendering and formatting, including `_dimensionality`, `__repr__`, `_repr_html_`, `_get_format_str`, semi-annual origin formatting, and `heatmap()` behavior.
> 
> Adjusts `heatmap()` to *always* raise `ImportError` (with updated message) when IPython’s `HTML` helper isn’t available, and adds an `empty_triangle` pytest fixture to reuse across tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b146e62f009a3a893ddb8994bfa169b4d3d4e98a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->