### PR TITLE
More robust PR template and contributing guidelines

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -7,10 +7,10 @@
 
 
 ## Additional Context for Reviewers  
-<!-- Include any additional info that would be helpful for reviewers. If applicable, disclose any AI tools used and if AI-generated content dominates the diffs. You do not need to disclose AI tools used visible to the public (e.g. bugbot). Please also disclose your actuarial credentials if you are not an ACAS or FCAS. -->
+<!-- Include any additional info that would be helpful for reviewers. If applicable, disclose any AI tools used and if AI-generated content dominates the diffs. You do not need to disclose AI tools used visible to the public (e.g. bugbot). -->
 
 
 ## Checklist
 - [ ] I passed tests locally for both code (`uv run pytest`) and documentation changes (`uv run jb build docs --builder=custom --custom-builder=doctest`)
-- [ ] I am an Associate of the Casualty Actuarial Society (ACAS) or a Fellow of the Casualty Actuarial Society (FCAS). If you are not a member of the CAS, please disclose this in the "Additional Context for Reviewers" section.
-- [ ] I attest that I am personally responsible for every diff in this PR, including both code and documentation changes. As the human in the loop, I sign off on any AI-assisted or AI-generated content and attest that I am not submitting "AI slop."
+- [ ] I am an Associate of the Casualty Actuarial Society (ACAS) or a Fellow of the Casualty Actuarial Society (FCAS).
+- [ ] I have reviewed every diff in this PR, including both code and documentation changes. I acknowledge that reviewers have the discretion to close any pull request deemed to be too verbose or overly reliant on AI.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,5 +1,5 @@
 ## Summary of Changes  
-<!-- Keep this short and concise, with a few sentences maximum. Ensure it accurately reflects the PR subject line, which will be used in the release notes. -->
+<!-- Keep this short and concise, with a few sentences max. Make sure it accurately reflects the PR subject line, which will be used in the release notes. -->
 
 
 ## Related GitHub Issue(s)  
@@ -7,7 +7,7 @@
 
 
 ## Additional Context for Reviewers  
-<!-- Include any additional info that would be helpful for reviewers. If applicable, disclose any AI tools used and approximately how much of the diff was AI-genereated. You do not need to disclose publicly available AI tools used such as bugbot. Please also disclose your actuarial credentials if you are not an ACAS or FCAS. -->
+<!-- Include any additional info that would be helpful for reviewers. If applicable, disclose any AI tools used and approximately how much of the diff was AI-genereated. You do not need to disclose publicly available AI tools used (e.g. bugbot). Please also disclose your actuarial credentials if you are not an ACAS or FCAS. -->
 
 
 ## Checklist

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -7,7 +7,7 @@
 
 
 ## Additional Context for Reviewers  
-<!-- Include any additional info that would be helpful for reviewers. If applicable, disclose any AI tools used and approximately how much of the diff was AI-genereated. You do not need to disclose publicly available AI tools used (e.g. bugbot). Please also disclose your actuarial credentials if you are not an ACAS or FCAS. -->
+<!-- Include any additional info that would be helpful for reviewers. If applicable, disclose any AI tools used and if AI-generated content dominates the diffs. You do not need to disclose AI tools used visible to the public (e.g. bugbot). Please also disclose your actuarial credentials if you are not an ACAS or FCAS. -->
 
 
 ## Checklist

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,10 +1,16 @@
 ## Summary of Changes  
+<!-- Keep this short and concise, with a few sentences maximum. Ensure it accurately reflects the PR subject line, which will be used in the release notes. -->
 
 
 ## Related GitHub Issue(s)  
+<!-- e.g. #123. Use "Closes", "Fixes", or "Resolves" before the number (e.g. "Closes #123") to auto close the issue when this PR is merged, e.g. "Closes #123". -->
 
 
 ## Additional Context for Reviewers  
+<!-- Include any additional info that would be helpful for reviewers. If applicable, disclose any AI tools used and approximately how much of the diff was AI-genereated. You do not need to disclose publicly available AI tools used such as bugbot. Please also disclose your actuarial credentials if you are not an ACAS or FCAS. -->
 
 
+## Checklist
 - [ ] I passed tests locally for both code (`uv run pytest`) and documentation changes (`uv run jb build docs --builder=custom --custom-builder=doctest`)
+- [ ] I am an Associate of the Casualty Actuarial Society (ACAS) or a Fellow of the Casualty Actuarial Society (FCAS). If you are not a member of the CAS, please disclose this in the "Additional Context for Reviewers" section.
+- [ ] I attest that I am personally responsible for every diff in this PR, including both code and documentation changes. As the human in the loop, I sign off on any AI-assisted or AI-generated content and attest that I am not submitting "AI slop."

--- a/docs/library/contributing.md
+++ b/docs/library/contributing.md
@@ -102,21 +102,23 @@ Contributions to documentation are especially helpful for new users.
 
 ## Pull Requests (PRs)
 
-**Guidelines for PRs:**  
+**Guidelines for PRs:** 
+
+We welcome all pull requests! Please keep in mind that each PR undergoes a thorough, line-by-line quality review and must pass all existing unit tests. Be prepared to answer questions from the maintainers and make revisions as needed.
 
 **PRs must:**  
-- Be submitted using the pull request template 
-- Pass all existing unit tests  
-- Disclose usage of AI coding agents
-- Undergo independent peer review by a qualified Actuary
+- Be submitted using the pull request template
+- Pass all existing unit tests
+- Disclose usage of any AI coding agents
+- Undergo independent peer review by another actuary
 
 **PRs are encouraged to:**  
-- Be small, focused, and modular  
-- Link to relevant Issue ticket(s)  
-- Include docstring updates for any code changes  
-- Update the documentation site for corresponding changes  
-- Follow established naming conventions  
-- Include new unit tests with reasonable coverage  
+- Be small, focused, and modular
+- Link to relevant Issue ticket(s)
+- Include docstring updates for any code changes
+- Update the documentation site for corresponding changes
+- Follow established naming conventions
+- Include new unit tests with reasonable coverage
 
 All PRs should be run locally before submission.
 
@@ -126,7 +128,7 @@ For codebase tests, run:
 uv run pytest
 ```
 
-For documentation changes, rebuild the docs locally with:
+For documentation changes, run:
 ```bash
 uv run jb build docs --builder=custom --custom-builder=doctest
 ```

--- a/docs/library/contributing.md
+++ b/docs/library/contributing.md
@@ -105,8 +105,10 @@ Contributions to documentation are especially helpful for new users.
 **Guidelines for PRs:**  
 
 **PRs must:**  
+- Be submitted using the pull request template 
 - Pass all existing unit tests  
-- Undergo independent peer review  
+- Disclose usage of AI coding agents
+- Undergo independent peer review by a qualified Actuary
 
 **PRs are encouraged to:**  
 - Be small, focused, and modular  
@@ -121,7 +123,7 @@ All PRs should be run locally before submission.
 For codebase tests, run:
 
 ```bash
-pytest
+uv run pytest
 ```
 
 For documentation changes, rebuild the docs locally with:


### PR DESCRIPTION
## Summary of Changes  
Improved the contribution guidelines and the PR template

## Related GitHub Issue(s)  
N/A

## Additional Context for Reviewers  
To better protect the quality of work of this package, I'd like to propose we put a few more guardrails on PRs so that anyone looking at this package knows there's a certain level of quality that is expected.

The [CAS Primer](https://www.casact.org/sites/default/files/2026-03/CAS-AI-Primer-Practical-Guidance-for-Actuaries.pdf) says that we should have a human in the loop and discloses AI tools used.

The [code](https://actuary.org/wp-content/uploads/2014/01/code_of_conduct.8_1.pdf) says only Qualified actuarial on the  with basis of basic, continuing ed, and experience met shall perform actuarial services. I think we should ask pull requests to make a self declaration if that's not the case.

There's also a bunch more relevant ASOPs that I skimmed through, like [ASOP 23 Data Quality](https://www.actuarialstandardsboard.org/asops/data-quality/), [ASOP 41 on Actuarial Communications](https://www.actuarialstandardsboard.org/asops/actuarial-communications/), and [ASOP 56 on Modeling](https://www.actuarialstandardsboard.org/asops/modeling-3/) that we should all consider, but I don't think it's necessary to bring them all in as a checklist in the PR template. 

Anyway, this is coming in as a PR, and I don't want to just introduce red tape, I'm also not married to these at all. Open to discussion.

- [ ] I passed tests locally for both code (`uv run pytest`) and documentation changes (`uv run jb build docs --builder=custom --custom-builder=doctest`)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only changes that adjust contributor expectations and checklists without affecting runtime code or releases.
> 
> **Overview**
> Updates the PR template to add inline guidance for writing summaries, linking issues, and providing reviewer context, plus a new checklist covering local test runs, CAS credential self-attestation (ACAS/FCAS), and confirmation that the author reviewed all diffs.
> 
> Revises `docs/library/contributing.md` to explicitly require using the PR template, running tests via `uv`, disclosing AI coding agent usage, and obtaining independent peer review, while also tightening the wording and commands around doc/test execution.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f4698691dbb5ba7dcec82143c5b3ccee595d8fc4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->