### PR TITLE
docs: add BootstrapODPSample doctest examples

### DIFF
--- a/chainladder/adjustments/bootstrap.py
+++ b/chainladder/adjustments/bootstrap.py
@@ -46,6 +46,72 @@ class BootstrapODPSample(DevelopmentBase):
         A set of triangles represented by each simulation
     scale_:
         The scale parameter to be used in generating process risk
+
+    Examples
+    --------
+
+    Generate ODP bootstrap samples of the RAA sample triangle. The estimator
+    re-samples standardized Pearson residuals to produce ``n_sims`` synthetic
+    triangles stacked along the index axis of ``resampled_triangles_``, and
+    exposes the scale parameter ``scale_`` used to generate process risk.
+    ``random_state`` and a small ``n_sims`` keep the output deterministic
+    and fast.
+
+    .. testsetup::
+
+        import warnings
+        warnings.filterwarnings("ignore")
+        import chainladder as cl
+
+    .. testcode::
+
+        raa = cl.load_sample('raa')
+        boot = cl.BootstrapODPSample(n_sims=100, random_state=42).fit(raa)
+        print(boot.resampled_triangles_.shape)
+        print(round(float(boot.scale_), 2))
+
+    .. testoutput::
+
+        (100, 1, 10, 10)
+        983.64
+
+    Because ``resampled_triangles_`` is itself a Triangle (with the simulation
+    index along the first axis), it can be fed straight into any downstream
+    reserving estimator to obtain a stochastic distribution of ultimates and
+    IBNR. Below, a deterministic chain-ladder is fit on the resampled triangle
+    and the total IBNR is summarised across the 100 simulations.
+
+    .. testcode::
+
+        sims = cl.BootstrapODPSample(
+            n_sims=100, random_state=42
+        ).fit_transform(raa)
+        ibnr = cl.Chainladder().fit(sims).ibnr_.sum('origin')
+        print(ibnr.shape)
+        print(round(float(ibnr.mean()), 2))
+        print(round(float(ibnr.std()), 2))
+
+    .. testoutput::
+
+        (100, 1, 1, 1)
+        51301.13
+        16149.47
+
+    Outlier link ratios can distort the residual distribution that the
+    bootstrap re-samples from. Setting ``drop_high=True`` excludes the highest
+    link ratio in each development column before computing residuals, which
+    shrinks ``scale_`` and tightens the simulated distribution.
+
+    .. testcode::
+
+        boot_dh = cl.BootstrapODPSample(
+            n_sims=100, random_state=42, drop_high=True
+        ).fit(raa)
+        print(round(float(boot_dh.scale_), 2))
+
+    .. testoutput::
+
+        648.94
     """
 
     def __init__(

--- a/chainladder/adjustments/bootstrap.py
+++ b/chainladder/adjustments/bootstrap.py
@@ -97,10 +97,12 @@ class BootstrapODPSample(DevelopmentBase):
         51301.13
         16149.47
 
-    Outlier link ratios can distort the residual distribution that the
-    bootstrap re-samples from. Setting ``drop_high=True`` excludes the highest
-    link ratio in each development column before computing residuals, which
-    shrinks ``scale_`` and tightens the simulated distribution.
+    The estimator also supports a leave-one-out sensitivity check on the
+    residual distribution. Setting ``drop_high=True`` excludes the highest
+    link ratio in each development column before computing residuals, without
+    making any outlier judgement, so the resulting ``scale_`` measures how
+    influential the column maxima are on the bootstrap. For the RAA triangle
+    this shrinks ``scale_`` from 983.64 to 648.94.
 
     .. testcode::
 


### PR DESCRIPTION
Adds a Sphinx doctest `Examples` section to the `BootstrapODPSample` class.

Refs #704 (Stochastic / Simulation → BootstrapODPSample row).

## Summary of Changes
- Adds an `Examples` block to `BootstrapODPSample` in `chainladder/adjustments/bootstrap.py`.
- Three `.. testcode::` / `.. testoutput::` groups covering:
  1. Basic `fit` on the RAA sample — shows `resampled_triangles_.shape` and `scale_`.
  2. Downstream stochastic IBNR — `Chainladder().fit(sims).ibnr_.sum('origin')` aggregated to mean / std across 100 simulations.
  3. Parameter effect — `drop_high=True` shrinks `scale_`.
- Uses `random_state=42` and `n_sims=100` so output is deterministic, fast, and stable across CI runners.
- Docstring-only; no runtime logic or public API changes.

## Related GitHub Issue(s)
- Refs #704
- Follows the conventions used in #714, #719, and the in-flight #801.

## Additional Context for Reviewers
- Doctest CI passed locally and on GitHub Actions (`Doctest (ubuntu-latest, 3.12)`).
- `pytest chainladder/adjustments/tests -q` → 16 passed.
- Intentionally excludes `.github/workflows/sync-main-to-docs.yml`, matching the split-PR convention from #801.
- Open to feedback on whether the IBNR example should also surface `total_process_risk_` / `total_parameter_risk_` from a paired `MackChainladder` view — happy to extend in a follow-up if useful.

- [x] I passed tests locally for both code (`uv run pytest`) and documentation changes (`uv run jb build docs --builder=custom --custom-builder=doctest`)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docstring-only documentation change; the only risk is doctest brittleness if numeric outputs or sampling behavior change across environments.
> 
> **Overview**
> Adds a new `Examples` section to the `BootstrapODPSample` docstring with Sphinx doctests.
> 
> The examples show (1) deterministic `fit` output (`resampled_triangles_.shape` and `scale_`) on the RAA sample, (2) feeding bootstrap samples into `Chainladder` to summarize simulated IBNR mean/std, and (3) how `drop_high=True` changes the resulting `scale_`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 48ab89774500f5df62ec2d7bd6be134e0258c72a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->