### PR TITLE
docs: add doctest examples for correlation classes

### DIFF
--- a/chainladder/core/correlation.py
+++ b/chainladder/core/correlation.py
@@ -46,6 +46,45 @@ class DevelopmentCorrelation:
     confidence_interval: tuple
         Range within which ``t_expectation`` must fall for independence assumption
         to be significant.
+
+    Examples
+    --------
+
+    Mack (1997) lists "successive development factors are uncorrelated" as
+    one of the assumptions underpinning the chain-ladder method. Before
+    relying on a ``Chainladder`` or ``MackChainladder`` ultimate it is good
+    practice to test that assumption on the triangle at hand.
+    ``DevelopmentCorrelation`` performs Mack's weighted Spearman rank test
+    across consecutive development columns and exposes both the test
+    statistic ``t_expectation`` and the no-correlation
+    ``confidence_interval``, so the decision is visible rather than reduced
+    to a single boolean.
+
+    .. testsetup::
+
+        import chainladder as cl
+
+    .. testcode::
+
+        raa = cl.load_sample('raa')
+        dc = cl.DevelopmentCorrelation(raa, p_critical=0.5)
+        print(round(float(dc.t_expectation.iloc[0, 0]), 4))
+        print(round(float(dc.confidence_interval[0]), 4))
+        print(round(float(dc.confidence_interval[1]), 4))
+        print(bool(dc.t_critical.iloc[0, 0]))
+
+    .. testoutput::
+
+        0.0696
+        -0.1275
+        0.1275
+        False
+
+    The Spearman statistic ``0.0696`` lies inside the 50% confidence band
+    ``(-0.1275, 0.1275)`` derived from ``t_variance = 2 / ((I - 2)(I - 3))``,
+    so the test does not reject independence and chain-ladder is appropriate
+    for RAA on this dimension. See the Mack chain-ladder section of the user
+    guide for the full assumption set.
     """
 
     def __init__(self, triangle, p_critical: float = 0.5):
@@ -171,6 +210,50 @@ class ValuationCorrelation:
         The expected value of Z.
     z_variance : Triangle or DataFrame
         The variance value of Z.
+
+    Examples
+    --------
+
+    Mack's second prerequisite for the chain-ladder method is that no
+    calendar period systematically inflates or deflates link ratios (for
+    example from a one-off reserve strengthening or a change in case
+    reserving practice). ``ValuationCorrelation`` flags any diagonal on
+    which the split of high versus low link ratios is unlikely under random
+    ordering, and can be evaluated per-diagonal (``total=False``, Mack 1997)
+    or for the whole triangle (``total=True``, Mack 1993).
+
+    .. testsetup::
+
+        import chainladder as cl
+
+    .. testcode::
+
+        raa = cl.load_sample('raa')
+        vc = cl.ValuationCorrelation(raa, p_critical=0.1, total=False)
+        print(vc.z_critical)
+
+    .. testoutput::
+
+               1982   1983   1984   1985   1986   1987   1988   1989   1990
+        1981  False  False  False  False  False  False  False  False  False
+
+    No diagonal crosses the 90% threshold, so the calendar-effect assumption
+    is supported. If any cell read ``True`` you would inspect that diagonal
+    before relying on Mack or chain-ladder ultimates.
+
+    .. testcode::
+
+        vc_total = cl.ValuationCorrelation(raa, p_critical=0.1, total=True)
+        print(round(float(vc_total.z.iloc[0, 0]), 4))
+        print(bool(vc_total.z_critical.iloc[0, 0]))
+
+    .. testoutput::
+
+        14.0
+        False
+
+    The whole-triangle ``z`` statistic also falls inside the no-effect band,
+    confirming the per-diagonal result.
     """
 
     def __init__(self, triangle: Triangle, p_critical: float = 0.1, total: bool = True):

--- a/chainladder/core/correlation.py
+++ b/chainladder/core/correlation.py
@@ -219,8 +219,7 @@ class ValuationCorrelation:
     example from a one-off reserve strengthening or a change in case
     reserving practice). ``ValuationCorrelation`` flags any diagonal on
     which the split of high versus low link ratios is unlikely under random
-    ordering, and can be evaluated per-diagonal (``total=False``, Mack 1997)
-    or for the whole triangle (``total=True``, Mack 1993).
+    ordering.
 
     .. testsetup::
 
@@ -240,6 +239,10 @@ class ValuationCorrelation:
     No diagonal crosses the 90% threshold, so the calendar-effect assumption
     is supported. If any cell read ``True`` you would inspect that diagonal
     before relying on Mack or chain-ladder ultimates.
+
+    The same test can be aggregated to a whole-triangle form
+    (``total=True``, Mack 1993) instead of the per-diagonal form
+    (``total=False``, Mack 1997) shown above:
 
     .. testcode::
 


### PR DESCRIPTION
Adds Sphinx doctest `Examples` sections to the `DevelopmentCorrelation` and `ValuationCorrelation` classes.

Refs #704 (Development Pattern Estimators → `DevelopmentCorrelation` and `ValuationCorrelation` rows).

## Summary of Changes
- Adds an `Examples` block to `DevelopmentCorrelation` in `chainladder/core/correlation.py`.
- Adds an `Examples` block to `ValuationCorrelation` in the same file.
- Each block opens with the Mack chain-ladder assumption being tested, then exercises the decision the user actually makes.

`DevelopmentCorrelation` example:
- Runs on the RAA sample.
- Prints `t_expectation`, both ends of `confidence_interval`, and the `t_critical` boolean — so the reader sees `0.0696` sitting inside `(-0.1275, 0.1275)` and understands why the test does not reject independence.

`ValuationCorrelation` example:
- One `testcode` block for `total=False` (Mack 1997) printing the per-diagonal `z_critical` matrix.
- A second `testcode` block for `total=True` (Mack 1993) printing the whole-triangle `z` and boolean (`14.0`, `False`).
- One-line interpretation tying each result back to the chain-ladder workflow.

All numeric outputs use `round(float(...), 4)` (same pattern as #836) so the doctest is stable across numpy versions and array backends. Docstring-only; no runtime logic or public API changes.

## Related GitHub Issue(s)
- Refs #704
- Follows the conventions used in #714, #719, and #836.

## Additional Context for Reviewers
- Doctest CI passed locally.
- `pytest chainladder/core/tests -x -q` → no regressions.
- Drafted against the four-point rubric @henrydingliu posted on #704 / #827: each example opens with a practical chain-ladder assumption check, stays consistent with Mack 1993 / 1997, points to the existing Mack section of the user guide rather than duplicating it, and prints the full decision signal (statistic, confidence band, boolean) rather than a single boolean.
- Intentionally excludes `.github/workflows/sync-main-to-docs.yml`, matching the split-PR convention from #801 and #836.
- Happy to also embed a worked `MackChainladder` call inside the example if reviewers want the chain-ladder tie-in to be more concrete — left out here to keep the PR small.

- [x] I passed tests locally for both code (`uv run pytest`) and documentation changes (`uv run jb build docs --builder=custom --custom-builder=doctest`)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docstring and doctest narrative only; no executable code or API behavior changes.
> 
> **Overview**
> **Documentation only** for `ValuationCorrelation` in `correlation.py`: the Sphinx `Examples` section is tightened so the opening text no longer mixes per-diagonal and whole-triangle modes in one sentence.
> 
> A short bridge paragraph now introduces the second doctest block, explaining that the same calendar-effect check can run as **per-diagonal** (`total=False`, Mack 1997) or **whole-triangle** (`total=True`, Mack 1993) before the existing `total=True` example that prints aggregated `z` and `z_critical`.
> 
> No changes to correlation logic, parameters, or public API—only how reviewers read the worked examples.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3d827d9eaacb83de31cbafa18298fe1cf9c08f65. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->