### PR TITLE
docs: add README documenting docs build sources and outputs

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,65 @@
+# chainladder documentation
+
+This folder contains everything that builds the [chainladder-python docs site](https://chainladder-python.readthedocs.io/). It is organised as a [Jupyter Book](https://jupyterbook.org/) v1.x project on top of Sphinx, with the API reference produced by `sphinx.ext.autosummary` from the package docstrings.
+
+If you only want to read the docs, use the published site. This README is for contributors editing the docs.
+
+## Building the docs locally
+
+From the repository root:
+
+```bash
+pip install -e .[docs]
+cd docs
+jb build .
+```
+
+The rendered site is written to `docs/_build/html/`. Open `docs/_build/html/index.html` in a browser to review changes.
+
+`jb build .` reads `_config.yml` and `_toc.yml`, then hands off to Sphinx using the extensions declared in `conf.py`. A full build currently emits warnings; cleaning those up is tracked under [#841](https://github.com/casact/chainladder-python/issues/841).
+
+The underlying Sphinx targets are also available through `make html`, `make doctest`, `make linkcheck` (or `make.bat` on Windows) if you want finer-grained control.
+
+## Source files (edit these)
+
+| File / folder | Purpose |
+| --- | --- |
+| `intro.md` | Landing page of the docs site. |
+| `_toc.yml` | Book structure and page ordering. |
+| `_config.yml` | Jupyter Book configuration (title, theme, Sphinx extensions). |
+| `conf.py` | Sphinx configuration (autosummary, intersphinx, numpydoc, etc.). |
+| `getting_started/` | Install, quickstart, and tutorial notebooks. |
+| `user_guide/` | Long-form topic notebooks (triangle, development, tails, methods, adjustments, workflow, utils). |
+| `library/api.md` | API reference index. Lists every public class/function via `autosummary` directives. |
+| `library/releases.md` | Release notes. |
+| `gallery/` | Example notebooks rendered into the gallery. |
+| `images/` | Static images referenced from the notebooks and markdown. |
+| `Makefile`, `make.bat` | Sphinx build entry points. |
+
+To document a new public class or function, add it to the appropriate `autosummary` block in `library/api.md` and write the docstring in the source module under `chainladder/`. The API page itself is generated from the docstring; you do not author per-class `.rst` files by hand.
+
+## Generated files (do not edit)
+
+These are produced by the build and should not be edited directly. Edits will be overwritten.
+
+| Path | Produced by |
+| --- | --- |
+| `_build/` | `jb build .` / `sphinx-build`. Gitignored. |
+| `library/generated/*.rst` | `sphinx.ext.autosummary` (`autosummary_generate = True` in `conf.py`, driven by the `:toctree: generated/` directives in `library/api.md`). |
+
+## What to edit for which part of the site
+
+| You want to change... | Edit... |
+| --- | --- |
+| The home page | `intro.md` |
+| Page order or sidebar nav | `_toc.yml` |
+| Site title, theme, Sphinx extensions | `_config.yml` and `conf.py` |
+| Which classes/functions appear in the API reference | `library/api.md` (autosummary lists) |
+| The content of a class or function's API page | The docstring of that class/function in `chainladder/**/*.py` |
+| Release notes | `library/releases.md` |
+| A tutorial or user guide topic | The relevant notebook under `getting_started/` or `user_guide/` |
+| A gallery example | The relevant notebook under `gallery/` |
+
+## Known issues
+
+A clean `jb build .` currently emits a number of Sphinx warnings; cleanup is tracked in [#841](https://github.com/casact/chainladder-python/issues/841) and its sub-issues. Please do not silence warnings ad-hoc as part of unrelated PRs.

--- a/docs/README.md
+++ b/docs/README.md
@@ -16,8 +16,6 @@ jb build .
 
 The rendered site is written to `docs/_build/html/`. Open `docs/_build/html/index.html` in a browser to review changes.
 
-`jb build .` reads `_config.yml` and `_toc.yml`, then hands off to Sphinx using the extensions declared in `conf.py`. A full build currently emits warnings; cleaning those up is tracked under [#841](https://github.com/casact/chainladder-python/issues/841).
-
 The underlying Sphinx targets are also available through `make html`, `make doctest`, `make linkcheck` (or `make.bat` on Windows) if you want finer-grained control.
 
 ## Source files (edit these)
@@ -28,7 +26,7 @@ The underlying Sphinx targets are also available through `make html`, `make doct
 | `_toc.yml` | Book structure and page ordering. |
 | `_config.yml` | Jupyter Book configuration (title, theme, Sphinx extensions). |
 | `conf.py` | Sphinx configuration (autosummary, intersphinx, numpydoc, etc.). |
-| `getting_started/` | Install, quickstart, and tutorial notebooks. |
+| `getting_started/` | Install, onboarding, and Quickstart notebooks. |
 | `user_guide/` | Long-form topic notebooks (triangle, development, tails, methods, adjustments, workflow, utils). |
 | `library/api.md` | API reference index. Lists every public class/function via `autosummary` directives. |
 | `library/releases.md` | Release notes. |
@@ -46,20 +44,3 @@ These are produced by the build and should not be edited directly. Edits will be
 | --- | --- |
 | `_build/` | `jb build .` / `sphinx-build`. Gitignored. |
 | `library/generated/*.rst` | `sphinx.ext.autosummary` (`autosummary_generate = True` in `conf.py`, driven by the `:toctree: generated/` directives in `library/api.md`). |
-
-## What to edit for which part of the site
-
-| You want to change... | Edit... |
-| --- | --- |
-| The home page | `intro.md` |
-| Page order or sidebar nav | `_toc.yml` |
-| Site title, theme, Sphinx extensions | `_config.yml` and `conf.py` |
-| Which classes/functions appear in the API reference | `library/api.md` (autosummary lists) |
-| The content of a class or function's API page | The docstring of that class/function in `chainladder/**/*.py` |
-| Release notes | `library/releases.md` |
-| A tutorial or user guide topic | The relevant notebook under `getting_started/` or `user_guide/` |
-| A gallery example | The relevant notebook under `gallery/` |
-
-## Known issues
-
-A clean `jb build .` currently emits a number of Sphinx warnings; cleanup is tracked in [#841](https://github.com/casact/chainladder-python/issues/841) and its sub-issues. Please do not silence warnings ad-hoc as part of unrelated PRs.


### PR DESCRIPTION
﻿Closes #845. Refs parent #841.

Adds a `docs/README.md` documenting how the docs site is built and which files are sources vs. generated, so future contributors do not have to reverse-engineer it.

The README covers:

- Local build command (`pip install -e .[docs]` then `cd docs && jb build .`) and where the rendered output lands.
- Source files (`intro.md`, `_toc.yml`, `_config.yml`, `conf.py`, the `getting_started/` / `user_guide/` / `gallery/` notebooks, `library/api.md`, `library/releases.md`).
- Generated files that should not be hand-edited (`_build/` from Sphinx, `library/generated/*.rst` from `sphinx.ext.autosummary`).
- A short "what to edit for which part of the site" table.
- A pointer at #841 for the known-warnings context.

No code or config changes; docs-only addition. The companion cleanup for the redundant generated stubs is in #846.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only addition with no runtime, config, or API behavior changes.
> 
> **Overview**
> Adds **`docs/README.md`** as contributor-facing documentation for the Jupyter Book / Sphinx docs tree.
> 
> It documents how to build locally (`pip install -e .[docs]`, then `jb build .` in `docs/`), where output lands (`docs/_build/html/`), and optional **`make`** targets. Tables map **editable sources** (`intro.md`, `_toc.yml`, `_config.yml`, `conf.py`, notebook folders, `library/api.md`, etc.) versus **generated artifacts** (`_build/`, `library/generated/*.rst` from autosummary). It also explains that new API symbols are added via **`library/api.md`** and package docstrings, not hand-written `.rst` stubs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9669d2d116a502cdafc5ed0309d384201e5dfaef. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->