### PR TITLE
Summary

### DIFF
--- a/chainladder/methods/base.py
+++ b/chainladder/methods/base.py
@@ -73,7 +73,7 @@ class MethodBase(BaseEstimator, EstimatorIO, Common):
         #columns for melt
         ids = X.key_labels + ['origin','development','valuation']
         #create dataframe for amount
-        amount = X.latest_diagonal.to_frame(implicit_axis=True,keepdims=True).reset_index().melt(id_vars=ids,var_name = 'column',value_name='actual')
+        amount = X.incr_to_cum().latest_diagonal.to_frame(implicit_axis=True,keepdims=True).reset_index().melt(id_vars=ids,var_name = 'column',value_name='actual')
         amount_index = X.key_labels + ['origin','column']
         amount = amount[amount_index + ['development','actual']]
         amount.set_index(amount_index,inplace=True)

--- a/chainladder/methods/base.py
+++ b/chainladder/methods/base.py
@@ -92,7 +92,7 @@ class MethodBase(BaseEstimator, EstimatorIO, Common):
         cdf.set_index(dev_factor_index,inplace=True)
         #assemble full summary. start from ultimate, as some methods (e.g. BF) return an ultimate without any actual amount
         output = ultimate.drop(columns=['development','valuation'])
-        output = output.join(amount,amount_index,how='left')
+        output = output.join(amount,on=amount_index,how='left')
         output = output.join(ldf,on=dev_factor_index,how='left')
         output = output.join(cdf,on=dev_factor_index,how='left')
         return output[X.key_labels + ['column','origin','development','actual','ldf','cdf','ultimate']]

--- a/chainladder/methods/base.py
+++ b/chainladder/methods/base.py
@@ -66,16 +66,16 @@ class MethodBase(BaseEstimator, EstimatorIO, Common):
             return self.X_.sum('development')
 
     @property
-    def summary(self):
+    def summary_(self):
         return self._get_summary(self.X_,self.ultimate_)
 
     def _get_summary(self,X,ult):
         #columns for melt
         ids = X.key_labels + ['origin','development','valuation']
         #create dataframe for amount
-        amount = X.incr_to_cum().latest_diagonal.to_frame(implicit_axis=True,keepdims=True).reset_index().melt(id_vars=ids,var_name = 'column',value_name='actual')
+        amount = X.incr_to_cum().latest_diagonal.to_frame(implicit_axis=True,keepdims=True).reset_index().melt(id_vars=ids,var_name = 'column',value_name='latest')
         amount_index = X.key_labels + ['origin','column']
-        amount = amount[amount_index + ['development','actual']]
+        amount = amount[amount_index + ['development','latest']]
         amount.set_index(amount_index,inplace=True)
         #create dataframe for ultimate
         ultimate = ult.to_frame(implicit_axis=True,keepdims=True).reset_index().melt(id_vars=ids,var_name = 'column',value_name='ultimate')
@@ -95,7 +95,7 @@ class MethodBase(BaseEstimator, EstimatorIO, Common):
         output = output.join(amount,on=amount_index,how='left')
         output = output.join(ldf,on=dev_factor_index,how='left')
         output = output.join(cdf,on=dev_factor_index,how='left')
-        return output[X.key_labels + ['column','origin','development','actual','ldf','cdf','ultimate']]
+        return output[X.key_labels + ['column','origin','development','latest','ldf','cdf','ultimate']]
 
     def fit(self, X, y=None, sample_weight=None):
         """Applies the chainladder technique to triangle **X**

--- a/chainladder/methods/base.py
+++ b/chainladder/methods/base.py
@@ -65,6 +65,38 @@ class MethodBase(BaseEstimator, EstimatorIO, Common):
         else:
             return self.X_.sum('development')
 
+    @property
+    def summary(self):
+        return self._get_summary(self.X_,self.ultimate_)
+
+    def _get_summary(self,X,ult):
+        #columns for melt
+        ids = X.key_labels + ['origin','development','valuation']
+        #create dataframe for amount
+        amount = X.latest_diagonal.to_frame(implicit_axis=True,keepdims=True).reset_index().melt(id_vars=ids,var_name = 'column',value_name='actual')
+        amount_index = X.key_labels + ['origin','column']
+        amount = amount[amount_index + ['development','actual']]
+        amount.set_index(amount_index,inplace=True)
+        #create dataframe for ultimate
+        ultimate = ult.to_frame(implicit_axis=True,keepdims=True).reset_index().melt(id_vars=ids,var_name = 'column',value_name='ultimate')
+        #columns for melt for dev factors
+        dev_ids = X.ldf_.key_labels + ['origin','development','valuation']
+        #create dataframe for ldf
+        ldf = X.ldf_.to_frame(implicit_axis=True,keepdims=True).reset_index().melt(id_vars=dev_ids,var_name = 'column',value_name='ldf')
+        dev_factor_index = X.ldf_.key_labels + ['development','column']
+        ldf = ldf[dev_factor_index + ['ldf']]
+        ldf.set_index(dev_factor_index,inplace=True)
+        #create dataframe for cdf
+        cdf = X.cdf_.to_frame(implicit_axis=True,keepdims=True).reset_index().melt(id_vars=dev_ids,var_name = 'column',value_name='cdf')
+        cdf = cdf[dev_factor_index + ['cdf']]
+        cdf.set_index(dev_factor_index,inplace=True)
+        #assemble full summary. start from ultimate, as some methods (e.g. BF) return an ultimate without any actual amount
+        output = ultimate.drop(columns=['development','valuation'])
+        output = output.join(amount,amount_index,how='left')
+        output = output.join(ldf,on=dev_factor_index,how='left')
+        output = output.join(cdf,on=dev_factor_index,how='left')
+        return output[X.key_labels + ['column','origin','development','actual','ldf','cdf','ultimate']]
+
     def fit(self, X, y=None, sample_weight=None):
         """Applies the chainladder technique to triangle **X**
 

--- a/chainladder/methods/benktander.py
+++ b/chainladder/methods/benktander.py
@@ -36,8 +36,8 @@ class Benktander(MethodBase):
         The ultimate losses per the method
     ibnr_: Triangle
         The IBNR per the method
-    summary: Pandas Dataframe
-        a summary exhibit that contains actual, ldf, cdf, and ultimate
+    summary_: Pandas Dataframe
+        a summary exhibit that contains latest, ldf, cdf, and ultimate
 
 
     Examples
@@ -251,7 +251,7 @@ class Benktander(MethodBase):
         X_new = super().predict(X, sample_weight)
         X_new.expectation_ = self._get_benktander_aprioris(X, sample_weight)
         X_new.ultimate_ = self._get_ultimate(X_new, X_new.expectation_)
-        X_new.summary = self._get_summary(X_new,X_new.ultimate_)
+        X_new.summary_ = self._get_summary(X_new,X_new.ultimate_)
         X_new.n_iters = self.n_iters
         X_new.apriori = self.apriori
         return X_new

--- a/chainladder/methods/benktander.py
+++ b/chainladder/methods/benktander.py
@@ -36,6 +36,9 @@ class Benktander(MethodBase):
         The ultimate losses per the method
     ibnr_: Triangle
         The IBNR per the method
+    summary: Pandas Dataframe
+        a summary exhibit that contains actual, ldf, cdf, and ultimate
+
 
     Examples
     --------
@@ -243,9 +246,12 @@ class Benktander(MethodBase):
             2012  15914.716737
             2013  17193.715555
         """
+        if sample_weight is None:
+            raise ValueError("sample_weight is required.")
         X_new = super().predict(X, sample_weight)
         X_new.expectation_ = self._get_benktander_aprioris(X, sample_weight)
         X_new.ultimate_ = self._get_ultimate(X_new, X_new.expectation_)
+        X_new.summary = self._get_summary(X_new,X_new.ultimate_)
         X_new.n_iters = self.n_iters
         X_new.apriori = self.apriori
         return X_new

--- a/chainladder/methods/bornferg.py
+++ b/chainladder/methods/bornferg.py
@@ -36,6 +36,8 @@ class BornhuetterFerguson(Benktander):
         The ultimate losses per the method
     ibnr_: Triangle
         The IBNR per the method
+    summary: Pandas Dataframe
+        a summary exhibit that contains actual, ldf, cdf, and ultimate
 
     Examples
     --------

--- a/chainladder/methods/bornferg.py
+++ b/chainladder/methods/bornferg.py
@@ -36,8 +36,8 @@ class BornhuetterFerguson(Benktander):
         The ultimate losses per the method
     ibnr_: Triangle
         The IBNR per the method
-    summary: Pandas Dataframe
-        a summary exhibit that contains actual, ldf, cdf, and ultimate
+    summary_: Pandas Dataframe
+        a summary exhibit that contains latest, ldf, cdf, and ultimate
 
     Examples
     --------

--- a/chainladder/methods/capecod.py
+++ b/chainladder/methods/capecod.py
@@ -54,6 +54,8 @@ class CapeCod(Benktander):
         The trended apriori vector developed by the Cape Cod Method
     detrended_apriori_:
         The detrended apriori vector developed by the Cape Cod Method
+    summary: Pandas Dataframe
+        a summary exhibit that contains actual, ldf, cdf, and ultimate
 
     Examples
     --------

--- a/chainladder/methods/capecod.py
+++ b/chainladder/methods/capecod.py
@@ -54,8 +54,8 @@ class CapeCod(Benktander):
         The trended apriori vector developed by the Cape Cod Method
     detrended_apriori_:
         The detrended apriori vector developed by the Cape Cod Method
-    summary: Pandas Dataframe
-        a summary exhibit that contains actual, ldf, cdf, and ultimate
+    summary_: Pandas Dataframe
+        a summary exhibit that contains latest, ldf, cdf, and ultimate
 
     Examples
     --------

--- a/chainladder/methods/chainladder.py
+++ b/chainladder/methods/chainladder.py
@@ -26,6 +26,8 @@ class Chainladder(MethodBase):
     full_triangle_:
         The ultimates back-filled to each development period in **X** retaining
         the known data
+    summary: Pandas Dataframe
+        a summary exhibit that contains actual, ldf, cdf, and ultimate
 
     Examples
     --------
@@ -188,6 +190,7 @@ class Chainladder(MethodBase):
         """
         X_new = super().predict(X, sample_weight)
         X_new.ultimate_ = self._get_ultimate(X_new, sample_weight)
+        X_new.summary = self._get_summary(X_new,X_new.ultimate_)
         return X_new
 
     def _get_ultimate(self, X, sample_weight=None):

--- a/chainladder/methods/chainladder.py
+++ b/chainladder/methods/chainladder.py
@@ -26,8 +26,8 @@ class Chainladder(MethodBase):
     full_triangle_:
         The ultimates back-filled to each development period in **X** retaining
         the known data
-    summary: Pandas Dataframe
-        a summary exhibit that contains actual, ldf, cdf, and ultimate
+    summary_: Pandas Dataframe
+        a summary exhibit that contains latest, ldf, cdf, and ultimate
 
     Examples
     --------
@@ -190,7 +190,7 @@ class Chainladder(MethodBase):
         """
         X_new = super().predict(X, sample_weight)
         X_new.ultimate_ = self._get_ultimate(X_new, sample_weight)
-        X_new.summary = self._get_summary(X_new,X_new.ultimate_)
+        X_new.summary_ = self._get_summary(X_new,X_new.ultimate_)
         return X_new
 
     def _get_ultimate(self, X, sample_weight=None):

--- a/chainladder/methods/expectedloss.py
+++ b/chainladder/methods/expectedloss.py
@@ -33,6 +33,8 @@ class ExpectedLoss(Benktander):
         The ultimate losses per the method
     ibnr_: Triangle
         The IBNR per the method
+    summary: Pandas Dataframe
+        a summary exhibit that contains actual, ldf, cdf, and ultimate
 
     Examples
     --------

--- a/chainladder/methods/expectedloss.py
+++ b/chainladder/methods/expectedloss.py
@@ -33,8 +33,8 @@ class ExpectedLoss(Benktander):
         The ultimate losses per the method
     ibnr_: Triangle
         The IBNR per the method
-    summary: Pandas Dataframe
-        a summary exhibit that contains actual, ldf, cdf, and ultimate
+    summary_: Pandas Dataframe
+        a summary exhibit that contains latest, ldf, cdf, and ultimate
 
     Examples
     --------

--- a/chainladder/methods/mack.py
+++ b/chainladder/methods/mack.py
@@ -27,8 +27,8 @@ class MackChainladder(Chainladder):
     full_triangle_:
         The ultimates back-filled to each development period in **X** retaining
         the known data
-    summary_:
-        summary of the model
+    mack_summary_:
+        summary of the mack model
     full_std_err_:
         The full standard error
     total_process_risk_:
@@ -39,6 +39,8 @@ class MackChainladder(Chainladder):
         The total prediction error by origin period
     total_mack_std_err_:
         The total prediction error across all origin periods
+    summary_: Pandas Dataframe
+        a summary exhibit that contains latest, ldf, cdf, and ultimate
 
     Examples
     --------
@@ -54,7 +56,7 @@ class MackChainladder(Chainladder):
 
         tr = cl.load_sample('ukmotor')
         model = cl.MackChainladder().fit(tr)
-        print(model.summary_)
+        print(model.mack_summary_)
 
     .. testoutput:
 
@@ -401,7 +403,7 @@ class MackChainladder(Chainladder):
         return pd.DataFrame(out, index=obj.index, columns=obj.columns)
 
     @property
-    def summary_(self):
+    def mack_summary_(self):
         """
         Headline Mack summary table by origin: latest diagonal, IBNR,
         ultimate, and Mack standard error.
@@ -423,7 +425,7 @@ class MackChainladder(Chainladder):
 
             tr = cl.load_sample('ukmotor')
             model = cl.MackChainladder().fit(tr)
-            print(model.summary_)
+            print(model.mack_summary_)
 
         .. testoutput::
 

--- a/chainladder/methods/tests/test_mack.py
+++ b/chainladder/methods/tests/test_mack.py
@@ -8,10 +8,10 @@ def test_mack_to_triangle():
                 cl.Development().fit_transform(cl.load_sample("ABC"))
             )
         )
-        .summary_
+        .mack_summary_
         == cl.MackChainladder()
         .fit(cl.Development().fit_transform(cl.load_sample("ABC")))
-        .summary_
+        .mack_summary_
     )
 
 

--- a/chainladder/methods/tests/test_predict.py
+++ b/chainladder/methods/tests/test_predict.py
@@ -23,12 +23,15 @@ def test_predict_and_weights(estimators,atol):
     est = estimators().fit(raa_1989, sample_weight=apriori_1989)
     pred = est.predict(raa, sample_weight=apriori)
     assert pred
-    assert np.all(abs(est.summary['actual'].values - raa_1989.latest_diagonal.values.reshape(-1)) < atol)
-    assert np.all(abs(pred.summary['actual'].values - raa.latest_diagonal.values.reshape(-1)) < atol)
-    assert np.all(abs(est.summary['ultimate'].values - est.ultimate_.values.reshape(-1)) < atol)
-    assert np.all(abs(pred.summary['ultimate'].values - pred.ultimate_.values.reshape(-1)) < atol)
+    assert np.all(abs(est.summary_['latest'].values - raa_1989.latest_diagonal.values.reshape(-1)) < atol)
+    assert np.all(abs(pred.summary_['latest'].values - raa.latest_diagonal.values.reshape(-1)) < atol)
+    assert np.all(abs(est.summary_['ultimate'].values - est.ultimate_.values.reshape(-1)) < atol)
+    assert np.all(abs(pred.summary_['ultimate'].values - pred.ultimate_.values.reshape(-1)) < atol)
     #Test validation of sample_weight requirement. Should raise a value error if no weight is supplied.
-    if estimators != cl.Chainladder:
+    if estimators == cl.Chainladder:
+        assert np.all(abs(est.summary_['ultimate'].values / est.summary_['latest'].values - est.summary_['cdf'].values) < atol)
+        assert np.all(abs(pred.summary_['ultimate'].values / pred.summary_['latest'].values - pred.summary_['cdf'].values) < atol)
+    else:
         with pytest.raises(ValueError):
             estimators().fit(raa_1989)
         with pytest.raises(ValueError):

--- a/chainladder/methods/tests/test_predict.py
+++ b/chainladder/methods/tests/test_predict.py
@@ -1,5 +1,6 @@
 import chainladder as cl
 import pandas as pd
+import numpy as np
 import pytest 
 
 raa = cl.load_sample("RAA")
@@ -8,37 +9,36 @@ cl_ult = cl.Chainladder().fit(raa).ultimate_  # Chainladder Ultimate
 apriori = cl_ult * 0 + (float(cl_ult.sum()) / 10)  # Mean Chainladder Ultimate
 apriori_1989 = apriori[apriori.origin < "1990"]
 
+@pytest.mark.parametrize(
+    "estimators",
+    [
+        cl.CapeCod,
+        cl.BornhuetterFerguson,
+        cl.ExpectedLoss,
+        cl.Benktander,
+        cl.Chainladder
+    ],
+)
+def test_predict_and_weights(estimators,atol):
+    est = estimators().fit(raa_1989, sample_weight=apriori_1989)
+    pred = est.predict(raa, sample_weight=apriori)
+    assert pred
+    assert np.all(abs(est.summary['actual'].values - raa_1989.latest_diagonal.values.reshape(-1)) < atol)
+    assert np.all(abs(pred.summary['actual'].values - raa.latest_diagonal.values.reshape(-1)) < atol)
+    assert np.all(abs(est.summary['ultimate'].values - est.ultimate_.values.reshape(-1)) < atol)
+    assert np.all(abs(pred.summary['ultimate'].values - pred.ultimate_.values.reshape(-1)) < atol)
+    #Test validation of sample_weight requirement. Should raise a value error if no weight is supplied.
+    if estimators != cl.Chainladder:
+        with pytest.raises(ValueError):
+            estimators().fit(raa_1989)
+        with pytest.raises(ValueError):
+            estimators().fit(raa_1989, sample_weight=apriori_1989).predict(raa)
 
-def test_cc_predict():
-    cc = cl.CapeCod().fit(raa_1989, sample_weight=apriori_1989)
-    assert cc.predict(raa, sample_weight=apriori)
-
-def test_bf_predict():
-    bf = cl.BornhuetterFerguson().fit(raa_1989, sample_weight=apriori_1989)
-    assert bf.predict(raa, sample_weight=apriori)
-
-def test_el_predict():
-    bf = cl.ExpectedLoss().fit(raa_1989, sample_weight=apriori_1989)
-    assert bf.predict(raa, sample_weight=apriori)
 
 def test_mack_predict():
     mack = cl.MackChainladder().fit(raa_1989)
     assert mack.predict(raa_1989)
 
-def test_capecod_fit_weight():
-    """
-    Test validation of sample_weight requirement. Should raise a value error if no weight is supplied.
-    """
-    with pytest.raises(ValueError):
-        cl.CapeCod().fit(raa_1989)
-
-def test_capecod_predict_weight():
-    """
-    Test validation of sample_weight requirement. Should raise a value error if no weight is supplied.
-    """
-    with pytest.raises(ValueError):
-        cc = cl.CapeCod().fit(raa_1989, sample_weight=apriori_1989)
-        cc.predict(raa)
 
 def test_bs_random_state_predict(clrd):
     tri = clrd.groupby("LOB").sum().loc["wkcomp", ["CumPaidLoss", "EarnedPremNet"]]


### PR DESCRIPTION
## Summary of Changes  


## Related GitHub Issue(s)  


## Additional Context for Reviewers  


- [ ] I passed tests locally for both code (`uv run pytest`) and documentation changes (`uv run jb build docs --builder=custom --custom-builder=doctest`)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Breaking API for code using `.summary`, `summary['actual']`, or `MackChainladder.summary_` for the Mack Triangle table; behavior is otherwise aligned with sklearn naming and clearer Mack vs generic summaries.
> 
> **Overview**
> Standardizes method **summary** APIs and renames the exhibit column from **`actual`** to **`latest`**.
> 
> **`summary_`** is now the shared fitted-attribute summary DataFrame on `MethodBase` (columns: `latest`, `ldf`, `cdf`, `ultimate`). **`predict`** on chainladder/Benktander sets **`summary_`** instead of **`summary`**. Docstrings across BF, Benktander, Cape Cod, Expected Loss, and Chainladder reflect the new name and column.
> 
> **`MackChainladder`**: the origin-level Triangle table (Latest / IBNR / Ultimate / Mack Std Err) moves from **`summary_`** to **`mack_summary_`**. Mack also documents **`summary_`** as the same pandas exhibit as other methods. Examples and **`test_mack.py`** use **`mack_summary_`**.
> 
> Tests in **`test_predict.py`** assert **`summary_['latest']`** and fix **`sample_weight`** validation so only non-**`Chainladder`** estimators must supply weights on fit/predict; **`Chainladder`** gets extra checks that ultimate/latest matches **`cdf`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f41736c05696e5a90061ff15975d9c302999892d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->