### PR TITLE
[REFACTOR]: Remove repetitive code. Remove dead Python 3.8 code. Add …

### DIFF
--- a/chainladder/__init__.py
+++ b/chainladder/__init__.py
@@ -1,37 +1,82 @@
 import numpy as np
 import pandas as pd
+from importlib.metadata import version
 from sklearn.utils import deprecated
 
 
-_DT64_DTYPE = pd.to_datetime(["2000-01-01"]).dtype
-_ULT_VAL: str = str(
-    pd.Timestamp("2262-01-01") - \
-    pd.Timedelta(1, unit=np.datetime_data(_DT64_DTYPE)[0])
-)
-
 class Options:
-    ARRAY_BACKEND = "numpy"
-    AUTO_SPARSE = True
-    ARRAY_PRIORITY = ["dask", "sparse", "cupy", "numpy"]
-    ULT_VAL: str = _ULT_VAL
-    DT64_UNIT: str = np.datetime_data(_DT64_DTYPE)[0]
-    DT64_DTYPE: str = str(_DT64_DTYPE)
+    """
+    Used to set defaults for array backend and datetime units.
 
-    @classmethod
-    def get_option(cls, option=None):
-        return getattr(cls, option)
+    Attributes
+    ----------
 
-    @classmethod
-    def set_option(cls, option, value):
-        setattr(cls, option, value)
+    ARRAY_BACKEND: str
+        The default array backend for chainladder.
+    AUTO_SPARSE: bool
 
-    def reset_option(self):
-        self.set_option('ARRAY_BACKEND', "numpy")
-        self.set_option('AUTO_SPARSE', True)
-        self.set_option('ARRAY_PRIORITY', ["dask", "sparse", "cupy", "numpy"])
-        self.set_option('ULT_VAL', _ULT_VAL)
-        self.set_option('DT64_UNIT', np.datetime_data(_DT64_DTYPE)[0])
-        self.set_option('DT64_DTYPE', str(_DT64_DTYPE))
+
+    """
+    def __init__(self):
+        self.ARRAY_BACKEND = "numpy"
+        self.AUTO_SPARSE = True
+        self.ARRAY_PRIORITY = ["dask", "sparse", "cupy", "numpy"]
+        self.DT64_DTYPE: str = pd.to_datetime(["2000-01-01"]).dtype.name
+        self.DT64_UNIT: str = np.datetime_data(self.DT64_DTYPE)[0]
+        self.ULT_VAL = str(
+            pd.Timestamp("2262-01-01") - \
+            pd.Timedelta(1, unit=self.DT64_UNIT)
+        )
+
+    def get_option(self, option: str) -> str | bool | list:
+        """
+        Get the option value for the specified option.
+
+        Parameters
+        ----------
+        option: str
+            The option you wish to get the values for.
+
+        Returns
+        -------
+        The option value.
+
+        """
+        return getattr(self, option)
+
+    def set_option(
+            self,
+            option: str,
+            value: str | bool | list
+    ) -> None:
+        """
+        Set the option value for the specified option.
+
+        Parameters
+        ----------
+        option: str
+            The option you wish to set the value for.
+        value: str | bool | list
+            The option value.
+
+        Returns
+        -------
+        None
+
+        """
+
+        setattr(self, option, value)
+
+    def reset_option(self) -> None:
+        """
+        Restores the default options.
+
+        Returns
+        -------
+        None
+
+        """
+        self.__init__()
 
     def describe_option(self):
         pass
@@ -55,10 +100,4 @@ from chainladder.tails import *  # noqa (API Import)
 from chainladder.methods import *  # noqa (API Import)
 from chainladder.workflow import *  # noqa (API Import)
 
-try:
-    from importlib.metadata import version
-    __version__ = version("chainladder")
-except ImportError:
-    # Fallback for Python < 3.8
-    from importlib_metadata import version
-    __version__ = version("chainladder")
+__version__ = version("chainladder")

--- a/chainladder/__init__.py
+++ b/chainladder/__init__.py
@@ -14,7 +14,14 @@ class Options:
     ARRAY_BACKEND: str
         The default array backend for chainladder.
     AUTO_SPARSE: bool
-
+        Controls whether chainladder automatically converts a triangle's backing array to a sparse representation
+        when it would be memory-efficient to do so.
+    DT64_DTYPE: str
+        The default datetime64 data type, extracted from Pandas installation.
+    DT64_UNIT: str
+        The default datetime64 precision, extracted from Pandas installation.
+    ULT_VAL: str
+        The default ultimate valuation datetime, precision set to default of Pandas installation.
 
     """
     def __init__(self):

--- a/chainladder/utils/tests/test_utilities.py
+++ b/chainladder/utils/tests/test_utilities.py
@@ -195,7 +195,6 @@ def test_reset_option() -> None:
     original_backend = cl.options.ARRAY_BACKEND
     original_auto_sparse = cl.options.AUTO_SPARSE
     original_array_priority = cl.options.ARRAY_PRIORITY
-    original_ult_val = cl.options.ULT_VAL
 
     try:
 
@@ -208,14 +207,12 @@ def test_reset_option() -> None:
         assert cl.options.ARRAY_BACKEND == original_backend
         assert cl.options.AUTO_SPARSE == original_auto_sparse
         assert cl.options.ARRAY_PRIORITY == original_array_priority
-        assert cl.options.ULT_VAL == original_ult_val
 
     finally:
     # Manual reset in case of test failure.
-        cl.options.ARRAY_BACKEND = original_backend
-        cl.options.AUTO_SPARSE = original_auto_sparse
-        cl.options.ARRAY_PRIORITY = original_array_priority
-        cl.options.ULT_VAL = original_ult_val
+        cl.options.set_option('ARRAY_BACKEND', original_backend)
+        cl.options.set_option('AUTO_SPARSE', original_auto_sparse)
+        cl.options.set_option('ARRAY_PRIORITY', original_array_priority)
 
 
 def test_options_defaults() -> None:

--- a/chainladder/utils/tests/test_utilities.py
+++ b/chainladder/utils/tests/test_utilities.py
@@ -197,16 +197,25 @@ def test_reset_option() -> None:
     original_array_priority = cl.options.ARRAY_PRIORITY
     original_ult_val = cl.options.ULT_VAL
 
-    cl.options.set_option('ARRAY_BACKEND', 'sparse')
-    cl.options.set_option('AUTO_SPARSE', False)
-    cl.options.set_option('ARRAY_PRIORITY', ['sparse', 'dask', 'numpy', 'cupy'])
+    try:
 
-    cl.options.reset_option()
+        cl.options.set_option('ARRAY_BACKEND', 'sparse')
+        cl.options.set_option('AUTO_SPARSE', False)
+        cl.options.set_option('ARRAY_PRIORITY', ['sparse', 'dask', 'numpy', 'cupy'])
 
-    assert cl.options.ARRAY_BACKEND == original_backend
-    assert cl.options.AUTO_SPARSE == original_auto_sparse
-    assert cl.options.ARRAY_PRIORITY == original_array_priority
-    assert cl.options.ULT_VAL == original_ult_val
+        cl.options.reset_option()
+
+        assert cl.options.ARRAY_BACKEND == original_backend
+        assert cl.options.AUTO_SPARSE == original_auto_sparse
+        assert cl.options.ARRAY_PRIORITY == original_array_priority
+        assert cl.options.ULT_VAL == original_ult_val
+
+    finally:
+    # Manual reset in case of test failure.
+        cl.options.ARRAY_BACKEND = original_backend
+        cl.options.AUTO_SPARSE = original_auto_sparse
+        cl.options.ARRAY_PRIORITY = original_array_priority
+        cl.options.ULT_VAL = original_ult_val
 
 
 def test_options_defaults() -> None:

--- a/chainladder/utils/tests/test_utilities.py
+++ b/chainladder/utils/tests/test_utilities.py
@@ -211,3 +211,94 @@ def test_reset_option() -> None:
     assert cl.options.ULT_VAL == original_ult_val
     assert cl.options.DT64_UNIT == original_dt64_unit
     assert cl.options.DT64_DTYPE == original_dt64_dtype
+
+
+def test_options_defaults() -> None:
+    """
+    When initialized, default options should be correct and accessible from the options variable.
+
+    Returns
+    -------
+    None
+
+    """
+    options = cl.Options()
+    assert options.ARRAY_BACKEND == "numpy"
+    assert options.AUTO_SPARSE == True
+    assert options.ARRAY_PRIORITY == ["dask", "sparse", "cupy", "numpy"]
+    assert isinstance(options.DT64_DTYPE, str)
+    assert isinstance(options.DT64_UNIT, str)
+    assert isinstance(options.ULT_VAL, str)
+
+
+def test_get_option() -> None:
+    """
+    get_option should return the appropriate attribute value.
+
+    Returns
+    -------
+    None
+
+    """
+    assert cl.options.get_option('ARRAY_BACKEND') == cl.options.ARRAY_BACKEND
+    assert cl.options.get_option('AUTO_SPARSE') == cl.options.AUTO_SPARSE
+    assert cl.options.get_option('ARRAY_PRIORITY') == cl.options.ARRAY_PRIORITY
+    assert cl.options.get_option('DT64_DTYPE') == cl.options.DT64_DTYPE
+    assert cl.options.get_option('DT64_UNIT') == cl.options.DT64_UNIT
+    assert cl.options.get_option('ULT_VAL') == cl.options.ULT_VAL
+
+
+def test_set_option_consistency() -> None:
+    """
+    When set_option changes an option value, get_option should return the new option value.
+
+    Returns
+    -------
+    None
+
+    """
+    original = cl.options.ARRAY_BACKEND
+    try:
+        cl.options.set_option('ARRAY_BACKEND', 'sparse')
+        assert cl.options.ARRAY_BACKEND == 'sparse'
+        assert cl.options.get_option('ARRAY_BACKEND') == 'sparse'
+    finally:
+        # Reset the options to default if the test fails.
+        cl.options.set_option('ARRAY_BACKEND', original)
+
+
+def test_deprecated_array_backend() -> None:
+    """
+    Trigger the deprecation warning on cl.array_backend()
+
+    Returns
+    -------
+    None
+
+    """
+    original = cl.options.ARRAY_BACKEND
+    try:
+        with pytest.warns(FutureWarning):
+            cl.array_backend('sparse')
+        assert cl.options.ARRAY_BACKEND == 'sparse'
+    finally:
+        # Reset the options to default if the test fails.
+        cl.options.set_option('ARRAY_BACKEND', original)
+
+
+def test_deprecated_auto_sparse() -> None:
+    """
+    Trigger the deprecation warning on cl.auto_sparse()
+
+    Returns
+    -------
+    None
+
+    """
+    original = cl.options.AUTO_SPARSE
+    try:
+        with pytest.warns(FutureWarning):
+            cl.auto_sparse(False)
+        assert cl.options.AUTO_SPARSE == False
+    finally:
+        cl.options.set_option('AUTO_SPARSE', original)

--- a/chainladder/utils/tests/test_utilities.py
+++ b/chainladder/utils/tests/test_utilities.py
@@ -184,7 +184,7 @@ def test_date_delta_adjustment() -> None:
 
 def test_reset_option() -> None:
     """
-    Tests cl.options.reset_option.
+    Change some of the options and then reset them. Values after reset should match the original values.
 
     Returns
     -------
@@ -192,25 +192,21 @@ def test_reset_option() -> None:
 
     """
 
+    original_backend = cl.options.ARRAY_BACKEND
+    original_auto_sparse = cl.options.AUTO_SPARSE
+    original_array_priority = cl.options.ARRAY_PRIORITY
     original_ult_val = cl.options.ULT_VAL
-    original_dt64_unit = cl.options.DT64_UNIT
-    original_dt64_dtype = cl.options.DT64_DTYPE
 
     cl.options.set_option('ARRAY_BACKEND', 'sparse')
     cl.options.set_option('AUTO_SPARSE', False)
-    cl.options.set_option('ARRAY_PRIORITY', ['numpy'])
-    cl.options.set_option('ULT_VAL', 'fake')
-    cl.options.set_option('DT64_UNIT', 'fake')
-    cl.options.set_option('DT64_DTYPE', 'fake')
+    cl.options.set_option('ARRAY_PRIORITY', ['sparse', 'dask', 'numpy', 'cupy'])
 
     cl.options.reset_option()
 
-    assert cl.options.ARRAY_BACKEND == 'numpy'
-    assert cl.options.AUTO_SPARSE == True
-    assert cl.options.ARRAY_PRIORITY == ['dask', 'sparse', 'cupy', 'numpy']
+    assert cl.options.ARRAY_BACKEND == original_backend
+    assert cl.options.AUTO_SPARSE == original_auto_sparse
+    assert cl.options.ARRAY_PRIORITY == original_array_priority
     assert cl.options.ULT_VAL == original_ult_val
-    assert cl.options.DT64_UNIT == original_dt64_unit
-    assert cl.options.DT64_DTYPE == original_dt64_dtype
 
 
 def test_options_defaults() -> None:

--- a/conftest.py
+++ b/conftest.py
@@ -27,7 +27,8 @@ def raa(request):
         cl.options.set_option("ARRAY_BACKEND", "sparse")
     else:
         cl.options.set_option("ARRAY_BACKEND", "numpy")
-    return cl.load_sample("raa")
+    yield cl.load_sample("raa")
+    cl.options.set_option("ARRAY_BACKEND", "numpy")
 
 
 @pytest.fixture
@@ -36,7 +37,8 @@ def qtr(request):
         cl.options.set_option("ARRAY_BACKEND", "sparse")
     else:
         cl.options.set_option("ARRAY_BACKEND", "numpy")
-    return cl.load_sample("quarterly")
+    yield cl.load_sample("quarterly")
+    cl.options.set_option("ARRAY_BACKEND", "numpy")
 
 
 @pytest.fixture
@@ -45,7 +47,8 @@ def clrd(request):
         cl.options.set_option("ARRAY_BACKEND", "sparse")
     else:
         cl.options.set_option("ARRAY_BACKEND", "numpy")
-    return cl.load_sample("clrd")
+    yield cl.load_sample("clrd")
+    cl.options.set_option("ARRAY_BACKEND", "numpy")
 
 
 @pytest.fixture
@@ -54,13 +57,15 @@ def genins(request):
         cl.options.set_option("ARRAY_BACKEND", "sparse")
     else:
         cl.options.set_option("ARRAY_BACKEND", "numpy")
-    return cl.load_sample("genins")
+    yield cl.load_sample("genins")
+    cl.options.set_option("ARRAY_BACKEND", "numpy")
 
 
 @pytest.fixture
 def prism(request):
     cl.options.set_option("ARRAY_BACKEND", "numpy")
-    return cl.load_sample("prism")
+    yield cl.load_sample("prism")
+    cl.options.set_option("ARRAY_BACKEND", "numpy")
 
 
 @pytest.fixture
@@ -69,7 +74,8 @@ def prism_dense(request):
         cl.options.set_option("ARRAY_BACKEND", "sparse")
     else:
         cl.options.set_option("ARRAY_BACKEND", "numpy")
-    return cl.load_sample("prism").sum()
+    yield cl.load_sample("prism").sum()
+    cl.options.set_option("ARRAY_BACKEND", "numpy")
 
 
 @pytest.fixture
@@ -78,7 +84,8 @@ def xyz(request):
         cl.options.set_option("ARRAY_BACKEND", "sparse")
     else:
         cl.options.set_option("ARRAY_BACKEND", "numpy")
-    return cl.load_sample("xyz")
+    yield cl.load_sample("xyz")
+    cl.options.set_option("ARRAY_BACKEND", "numpy")
 
 
 @pytest.fixture

--- a/conftest.py
+++ b/conftest.py
@@ -82,11 +82,6 @@ def clrd(request):
 
 
 @pytest.fixture
-def clrd(request):
-    yield from _sample_fixture(request, "clrd")
-
-
-@pytest.fixture
 def genins(request):
     yield from _sample_fixture(request, "genins")
 

--- a/conftest.py
+++ b/conftest.py
@@ -1,5 +1,17 @@
+from __future__ import annotations
+
 import pytest
 import chainladder as cl
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+    from chainladder import Triangle
+    from typing import (
+        Any,
+        Callable
+    )
 
 
 def pytest_generate_tests(metafunc):
@@ -21,71 +33,77 @@ def pytest_generate_tests(metafunc):
         metafunc.parametrize("xyz", ["normal_run", "sparse_only_run"], indirect=True)
 
 
+def _sample_fixture(
+        request: Any,
+        sample: str,
+        transform: Callable[[Triangle], Triangle] | None = None
+    ) -> Iterator[Triangle]:
+    """
+    Common template fixture for using sample data in unit tests.
+
+    Parameters
+    ----------
+    request:Any
+        The pytest request built-in.
+    sample: str
+        The name of the sample data set to be loaded, e.g., raa, clrd, etc.
+    transform: Callable[[Triangle], Triangle] | None
+        An optional transformation to be applied to the triangle supplied as a lambda function.
+
+    Yields
+    -------
+    A Triangle, with backend set according to request.param.
+
+    """
+
+    # Set the backend to sparse for a sparse-only-run.
+    cl.options.set_option("ARRAY_BACKEND", "sparse" if request.param == "sparse_only_run" else "numpy")
+    # Load the sample data.
+    tri = cl.load_sample(sample)
+    # Apply a transformation if supplied, then yield the triangle to the test.
+    yield transform(tri) if transform else tri
+    # After the test, reset the backend to default numpy.
+    cl.options.set_option("ARRAY_BACKEND", "numpy")
+
+
 @pytest.fixture
 def raa(request):
-    if request.param == "sparse_only_run":
-        cl.options.set_option("ARRAY_BACKEND", "sparse")
-    else:
-        cl.options.set_option("ARRAY_BACKEND", "numpy")
-    yield cl.load_sample("raa")
-    cl.options.set_option("ARRAY_BACKEND", "numpy")
+    yield from _sample_fixture(request, "raa")
 
 
 @pytest.fixture
 def qtr(request):
-    if request.param == "sparse_only_run":
-        cl.options.set_option("ARRAY_BACKEND", "sparse")
-    else:
-        cl.options.set_option("ARRAY_BACKEND", "numpy")
-    yield cl.load_sample("quarterly")
-    cl.options.set_option("ARRAY_BACKEND", "numpy")
+    yield from _sample_fixture(request, "quarterly")
 
 
 @pytest.fixture
 def clrd(request):
-    if request.param == "sparse_only_run":
-        cl.options.set_option("ARRAY_BACKEND", "sparse")
-    else:
-        cl.options.set_option("ARRAY_BACKEND", "numpy")
-    yield cl.load_sample("clrd")
-    cl.options.set_option("ARRAY_BACKEND", "numpy")
+    yield from _sample_fixture(request, "clrd")
+
+
+@pytest.fixture
+def clrd(request):
+    yield from _sample_fixture(request, "clrd")
 
 
 @pytest.fixture
 def genins(request):
-    if request.param == "sparse_only_run":
-        cl.options.set_option("ARRAY_BACKEND", "sparse")
-    else:
-        cl.options.set_option("ARRAY_BACKEND", "numpy")
-    yield cl.load_sample("genins")
-    cl.options.set_option("ARRAY_BACKEND", "numpy")
+    yield from _sample_fixture(request, "genins")
 
 
 @pytest.fixture
 def prism(request):
-    cl.options.set_option("ARRAY_BACKEND", "numpy")
-    yield cl.load_sample("prism")
-    cl.options.set_option("ARRAY_BACKEND", "numpy")
+    yield from _sample_fixture(request, "prism")
 
 
 @pytest.fixture
 def prism_dense(request):
-    if request.param == "sparse_only_run":
-        cl.options.set_option("ARRAY_BACKEND", "sparse")
-    else:
-        cl.options.set_option("ARRAY_BACKEND", "numpy")
-    yield cl.load_sample("prism").sum()
-    cl.options.set_option("ARRAY_BACKEND", "numpy")
+    yield from _sample_fixture(request, "prism", transform=lambda t: t.sum())
 
 
 @pytest.fixture
 def xyz(request):
-    if request.param == "sparse_only_run":
-        cl.options.set_option("ARRAY_BACKEND", "sparse")
-    else:
-        cl.options.set_option("ARRAY_BACKEND", "numpy")
-    yield cl.load_sample("xyz")
-    cl.options.set_option("ARRAY_BACKEND", "numpy")
+    yield from _sample_fixture(request, "xyz")
 
 
 @pytest.fixture


### PR DESCRIPTION
## Summary of Changes  

Remove repetitive code. Remove dead Python 3.8 code. Add missing unit tests.

Repetitive code would be variables like `_DT64_DTYPE` which then get assigned to something like `DT64_DTYPE`. Rewrite `reset_option` to remove copy-pasted code from initialization.

## Related GitHub Issue(s)  

Partially addresses #856 
Closes #862 

## Additional Context for Reviewers  


- [x] I passed tests locally for both code (`uv run pytest`) and documentation changes (`uv run jb build docs --builder=custom --custom-builder=doctest`)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> `DT64_DTYPE` now stores `.dtype.name` instead of `str(dtype)`, which could affect datetime casting in core triangle code if the string form differs from before; otherwise changes are mostly internal refactor and test infrastructure.
> 
> **Overview**
> Refactors **`Options`** from class-level defaults into instance initialization, documents **`get_option` / `set_option` / `reset_option`**, and makes **`reset_option`** call **`__init__()`** instead of duplicating default assignments. **`DT64_DTYPE`** is now derived via **`.dtype.name`** (dropping module-level **`_DT64_DTYPE`** / **`_ULT_VAL`**), and **`__version__`** always uses **`importlib.metadata`** (Python 3.8 **`importlib_metadata`** fallback removed).
> 
> **`conftest.py`** centralizes sample-triangle fixtures in **`_sample_fixture`**, yielding triangles with backend setup/teardown instead of repeating **`ARRAY_BACKEND`** logic per fixture.
> 
> **`test_utilities.py`** expands coverage for options defaults, get/set consistency, **`reset_option`** (with teardown), and deprecation warnings on **`array_backend`** / **`auto_sparse`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 70fe2a540608a8dad8f1a255e5b7b4a51f3a10ca. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->