### PR TITLE
[REFACTOR]: Continue work on cl.__init__.py refactor

### DIFF
--- a/chainladder/__init__.py
+++ b/chainladder/__init__.py
@@ -1,3 +1,17 @@
+"""
+The chainladder-python package was built to be able to handle all of your actuarial reserving needs in python.
+It consists of popular actuarial tools, such as triangle data manipulation, link ratios calculation, and
+IBNR estimates using both deterministic and stochastic models. We build this package so you no longer have to rely
+on outdated software and tools when performing actuarial pricing or reserving indications.
+
+This package strives to be minimalistic in needing its own API. The syntax mimics popular packages such as pandas for
+data manipulation and scikit-learn for model construction. An actuary that is already familiar with these tools will be
+able to pick up this package with ease. You will be able to save your mental energy for actual actuarial work.
+"""
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 import copy
 import numpy as np
 import pandas as pd

--- a/chainladder/__init__.py
+++ b/chainladder/__init__.py
@@ -1,3 +1,4 @@
+import copy
 import numpy as np
 import pandas as pd
 from importlib.metadata import version
@@ -37,7 +38,7 @@ class Options:
             pd.Timedelta(1, unit=__dt64_unit__)
         )
         # Store initial values as defaults.
-        self.defaults = {**vars(self)}
+        self.defaults = copy.deepcopy(vars(self))
 
     def get_option(self, option: str) -> str | bool | list:
         """

--- a/chainladder/__init__.py
+++ b/chainladder/__init__.py
@@ -1,6 +1,4 @@
 import copy
-from threading import settrace_all_threads
-
 import numpy as np
 import pandas as pd
 from importlib.metadata import version
@@ -95,7 +93,7 @@ class Options:
 
         if option is not None:
             self._validate_option(option)
-            setattr(self, option, self._defaults[option])
+            setattr(self, option, copy.deepcopy(self._defaults[option]))
         else:
             self.__init__()
 

--- a/chainladder/__init__.py
+++ b/chainladder/__init__.py
@@ -1,7 +1,12 @@
 import numpy as np
 import pandas as pd
 from importlib.metadata import version
-from sklearn.utils import deprecated
+
+
+# Get the default datetime64 data type and precision, extracted from Pandas installation.
+# Used for cross-version compatibility between Pandas 2 and Pandas 3.
+__dt64_dtype__: str = pd.to_datetime(["2000-01-01"]).dtype.name
+__dt64_unit__: str = np.datetime_data(__dt64_dtype__)[0]
 
 
 class Options:
@@ -16,10 +21,9 @@ class Options:
     AUTO_SPARSE: bool
         Controls whether chainladder automatically converts a triangle's backing array to a sparse representation
         when it would be memory-efficient to do so.
-    DT64_DTYPE: str
-        The default datetime64 data type, extracted from Pandas installation.
-    DT64_UNIT: str
-        The default datetime64 precision, extracted from Pandas installation.
+    ARRAY_PRIORITY: list
+        Determines which backend wins when two triangles with different backends interact, i.e.,
+        when comparing or concatenating them.
     ULT_VAL: str
         The default ultimate valuation datetime, precision set to default of Pandas installation.
 
@@ -28,12 +32,12 @@ class Options:
         self.ARRAY_BACKEND = "numpy"
         self.AUTO_SPARSE = True
         self.ARRAY_PRIORITY = ["dask", "sparse", "cupy", "numpy"]
-        self.DT64_DTYPE: str = pd.to_datetime(["2000-01-01"]).dtype.name
-        self.DT64_UNIT: str = np.datetime_data(self.DT64_DTYPE)[0]
         self.ULT_VAL = str(
             pd.Timestamp("2262-01-01") - \
-            pd.Timedelta(1, unit=self.DT64_UNIT)
+            pd.Timedelta(1, unit=__dt64_unit__)
         )
+        # Store initial values as defaults.
+        self.defaults = {**vars(self)}
 
     def get_option(self, option: str) -> str | bool | list:
         """
@@ -49,6 +53,7 @@ class Options:
         The option value.
 
         """
+        self._validate_option(option)
         return getattr(self, option)
 
     def set_option(
@@ -71,32 +76,35 @@ class Options:
         None
 
         """
-
+        self._validate_option(option)
         setattr(self, option, value)
 
-    def reset_option(self) -> None:
+    def reset_option(self, option: str | None = None) -> None:
         """
-        Restores the default options.
+        Restores the default value for the specified option. Restores default values for
+        all options if option is None.
 
         Returns
         -------
         None
 
         """
-        self.__init__()
 
-    def describe_option(self):
+        if option:
+            self._validate_option(option)
+            setattr(self, option, self.defaults[option])
+        else:
+            self.__init__()
+
+    def _validate_option(self, option: str) -> None:
+
+        if option not in self.defaults:
+            raise ValueError(f"Invalid option(s): {option}. Must be one of {list(self.defaults)}.")
+
+    def describe_option(self, option: str) -> str:
         pass
 
 options = Options()
-
-@deprecated("In an upcoming version of the package, this function will be deprecated. Use `chainladder.options.set_option('ARRAY_BACKEND', value)` to avoid breakage.")
-def array_backend(array_backend="numpy"):
-    options.set_option('ARRAY_BACKEND', array_backend)
-
-@deprecated("In an upcoming version of the package, this function will be deprecated. Use `chainladder.options.set_option('AUTO_SPARSE', value)` to avoid breakage.")
-def auto_sparse(auto_sparse=True):
-    options.set_option('AUTO_SPARSE', auto_sparse)
 
 
 from chainladder.utils import *  # noqa (API Import)

--- a/chainladder/__init__.py
+++ b/chainladder/__init__.py
@@ -1,4 +1,6 @@
 import copy
+from threading import settrace_all_threads
+
 import numpy as np
 import pandas as pd
 from importlib.metadata import version
@@ -38,7 +40,7 @@ class Options:
             pd.Timedelta(1, unit=__dt64_unit__)
         )
         # Store initial values as defaults.
-        self.defaults = copy.deepcopy(vars(self))
+        self._defaults = copy.deepcopy({k: v for k, v in vars(self).items() if not k.startswith('_')})
 
     def get_option(self, option: str) -> str | bool | list:
         """
@@ -91,16 +93,16 @@ class Options:
 
         """
 
-        if option:
+        if option is not None:
             self._validate_option(option)
-            setattr(self, option, self.defaults[option])
+            setattr(self, option, self._defaults[option])
         else:
             self.__init__()
 
     def _validate_option(self, option: str) -> None:
 
-        if option not in self.defaults:
-            raise ValueError(f"Invalid option(s): {option}. Must be one of {list(self.defaults)}.")
+        if option not in self._defaults:
+            raise ValueError(f"Invalid option(s): {option}. Must be one of {list(self._defaults)}.")
 
     def describe_option(self, option: str) -> str:
         pass

--- a/chainladder/__init__.py
+++ b/chainladder/__init__.py
@@ -7,6 +7,9 @@ on outdated software and tools when performing actuarial pricing or reserving in
 This package strives to be minimalistic in needing its own API. The syntax mimics popular packages such as pandas for
 data manipulation and scikit-learn for model construction. An actuary that is already familiar with these tools will be
 able to pick up this package with ease. You will be able to save your mental energy for actual actuarial work.
+
+The __init__.py file governs package configuration, including datetime datatypes and precision, backend and ultimate
+valuation defaults, as well as package metadata such as version number.
 """
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/chainladder/core/base.py
+++ b/chainladder/core/base.py
@@ -9,7 +9,11 @@ import warnings
 
 from abc import ABC, abstractmethod
 
-from chainladder import options
+from chainladder import (
+    __dt64_unit__,
+    __dt64_dtype__,
+    options
+)
 
 from chainladder.core.common import Common
 from chainladder.core.display import TriangleDisplay
@@ -534,12 +538,12 @@ class TriangleBase(
         ddim_arr = ddims - ddims[0]
         origin = np.minimum(self.odims, np.datetime64(self.valuation_date))
         val_array = origin.astype("datetime64[M]") + np.timedelta64(ddims[0], "M")
-        val_array = val_array.astype(options.DT64_DTYPE) - np.timedelta64(1, options.DT64_UNIT)
+        val_array = val_array.astype(__dt64_dtype__) - np.timedelta64(1, __dt64_unit__)
         val_array = val_array[:, None]
         s = slice(None, -1) if ddims[-1] == 9999 else slice(None, None)
         val_array = (
             val_array.astype("datetime64[M]") + ddim_arr[s][None, :] + 1
-        ).astype(options.DT64_DTYPE) - np.timedelta64(1, options.DT64_UNIT)
+        ).astype(__dt64_dtype__) - np.timedelta64(1, __dt64_unit__)
         if ddims[-1] == 9999:
             ult = np.repeat(np.datetime64(options.ULT_VAL), val_array.shape[0])[:, None]
             val_array = np.concatenate(

--- a/chainladder/core/pandas.py
+++ b/chainladder/core/pandas.py
@@ -6,7 +6,9 @@ from __future__ import annotations
 import numpy as np
 import pandas as pd
 
-from chainladder import options
+from chainladder import (
+    __dt64_dtype__
+)
 from chainladder.utils.utility_functions import num_to_nan
 from typing import TYPE_CHECKING
 
@@ -535,7 +537,7 @@ def add_triangle_agg_func(
         # If axis is development, set the ddims to be the valuation date.
         if axis == 3 and obj.values.shape[axis] == 1 and len(obj.ddims) > 1:
             obj.ddims = pd.DatetimeIndex(
-                [self.valuation_date], dtype=options.DT64_DTYPE, freq=None
+                [self.valuation_date], dtype=__dt64_dtype__, freq=None
             )
         obj._set_slicers()
         if auto_sparse:

--- a/chainladder/utils/tests/test_utilities.py
+++ b/chainladder/utils/tests/test_utilities.py
@@ -258,14 +258,13 @@ def test_set_option_consistency() -> None:
     None
 
     """
-    original = cl.options.ARRAY_BACKEND
     try:
         cl.options.set_option('ARRAY_BACKEND', 'sparse')
         assert cl.options.ARRAY_BACKEND == 'sparse'
         assert cl.options.get_option('ARRAY_BACKEND') == 'sparse'
     finally:
         # Reset the options to default if the test fails.
-        cl.options.set_option('ARRAY_BACKEND', original)
+        cl.options.reset_option('ARRAY_BACKEND')
 
 def test_reset_single_option() -> None:
     """

--- a/chainladder/utils/tests/test_utilities.py
+++ b/chainladder/utils/tests/test_utilities.py
@@ -4,6 +4,9 @@ import chainladder as cl
 import copy
 import numpy as np
 
+from chainladder import (
+    __dt64_unit__
+)
 from chainladder.utils.utility_functions import date_delta_adjustment
 from pathlib import Path
 
@@ -177,7 +180,7 @@ def test_date_delta_adjustment() -> None:
 
     expected = (
         "2025-10-31 23:59:59.999999999"
-        if cl.options.DT64_UNIT == "ns"
+        if __dt64_unit__ == "ns"
         else "2025-10-31 23:59:59.999999"
     )
     assert result == expected
@@ -228,8 +231,6 @@ def test_options_defaults() -> None:
     assert options.ARRAY_BACKEND == "numpy"
     assert options.AUTO_SPARSE == True
     assert options.ARRAY_PRIORITY == ["dask", "sparse", "cupy", "numpy"]
-    assert isinstance(options.DT64_DTYPE, str)
-    assert isinstance(options.DT64_UNIT, str)
     assert isinstance(options.ULT_VAL, str)
 
 
@@ -245,8 +246,6 @@ def test_get_option() -> None:
     assert cl.options.get_option('ARRAY_BACKEND') == cl.options.ARRAY_BACKEND
     assert cl.options.get_option('AUTO_SPARSE') == cl.options.AUTO_SPARSE
     assert cl.options.get_option('ARRAY_PRIORITY') == cl.options.ARRAY_PRIORITY
-    assert cl.options.get_option('DT64_DTYPE') == cl.options.DT64_DTYPE
-    assert cl.options.get_option('DT64_UNIT') == cl.options.DT64_UNIT
     assert cl.options.get_option('ULT_VAL') == cl.options.ULT_VAL
 
 
@@ -268,39 +267,29 @@ def test_set_option_consistency() -> None:
         # Reset the options to default if the test fails.
         cl.options.set_option('ARRAY_BACKEND', original)
 
-
-def test_deprecated_array_backend() -> None:
+def test_reset_single_option() -> None:
     """
-    Trigger the deprecation warning on cl.array_backend()
+    Set an option and check its value, then reset it and check its value.
 
     Returns
     -------
     None
 
     """
-    original = cl.options.ARRAY_BACKEND
-    try:
-        with pytest.warns(FutureWarning):
-            cl.array_backend('sparse')
-        assert cl.options.ARRAY_BACKEND == 'sparse'
-    finally:
-        # Reset the options to default if the test fails.
-        cl.options.set_option('ARRAY_BACKEND', original)
+    cl.options.set_option('ARRAY_BACKEND', 'sparse')
+    assert cl.options.ARRAY_BACKEND == 'sparse'
+    # Return backend to original state.
+    cl.options.reset_option('ARRAY_BACKEND')
+    assert cl.options.ARRAY_BACKEND == 'numpy'
 
 
-def test_deprecated_auto_sparse() -> None:
+def test_reset_option_invalid() -> None:
     """
-    Trigger the deprecation warning on cl.auto_sparse()
+    Supply in invalid option to cl.options.reset_option() and raise an error.
 
     Returns
     -------
     None
-
     """
-    original = cl.options.AUTO_SPARSE
-    try:
-        with pytest.warns(FutureWarning):
-            cl.auto_sparse(False)
-        assert cl.options.AUTO_SPARSE == False
-    finally:
-        cl.options.set_option('AUTO_SPARSE', original)
+    with pytest.raises(ValueError):
+        cl.options.reset_option('NOT_A_REAL_OPTION')

--- a/chainladder/utils/utility_functions.py
+++ b/chainladder/utils/utility_functions.py
@@ -10,7 +10,10 @@ import os
 import numpy as np
 import pandas as pd
 
-from chainladder import options
+from chainladder import (
+    __dt64_unit__,
+    __dt64_dtype__
+)
 from chainladder.utils.sparse import sp
 from io import StringIO
 from patsy import dmatrix  # noqa
@@ -648,7 +651,7 @@ def concat(
     if ignore_index and axis == 0:
         out.key_labels = ["Index"]
     out.valuation_date = pd.Series([obj.valuation_date for obj in objs]).max()
-    if out.ddims.dtype == options.DT64_DTYPE and type(out.ddims) == np.ndarray:
+    if out.ddims.dtype == __dt64_dtype__ and type(out.ddims) == np.ndarray:
         out.ddims = pd.DatetimeIndex(out.ddims)
     out._set_slicers()
     if sort:
@@ -931,7 +934,7 @@ def date_delta_adjustment(date: str) -> str:
 
     res: str = str(
         pd.Timestamp(date) - \
-        pd.Timedelta(1, unit=options.DT64_UNIT)
+        pd.Timedelta(1, unit=__dt64_unit__)
     )
 
     return res


### PR DESCRIPTION
## Summary of Changes  

-  Move datetime defaults out of Options. 
- Add validation to option getters and setters. 
- Enable resetting of single options.
- Deprecate cl.array_backend() and cl.auto_sparse()


## Related GitHub Issue(s)  

#861
#858
#860
#859 

## Additional Context for Reviewers  

It was hard to do this cleanly in multiple PRs, so I hope you can follow this. I found that aside from deprecating 2 functions, the other sub-items were intertwined.

- [x] I passed tests locally for both code (`uv run pytest`) and documentation changes (`uv run jb build docs --builder=custom --custom-builder=doctest`)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes affect global datetime handling and package-level configuration used across triangle valuation and utilities; removing deprecated helpers is a breaking API change for callers still using cl.array_backend() or cl.auto_sparse().
> 
> **Overview**
> This refactor tightens **package configuration** in `chainladder.__init__`: Pandas-derived datetime dtype/unit are now **module-level** `__dt64_dtype__` and `__dt64_unit__` (for Pandas 2/3 compatibility), not `Options` fields. **`Options`** gains **`_validate_option`** on get/set/reset, a **`_defaults`** snapshot, and **`reset_option(option)`** to restore one setting or all defaults. **`cl.array_backend()`** and **`cl.auto_sparse()`** are **removed** in favor of `chainladder.options.set_option`.
> 
> Triangle **valuation** and date helpers in `core/base.py`, `core/pandas.py`, and `utils/utility_functions.py` now use the module constants instead of `options.DT64_*`. Tests were updated accordingly (including single-option reset and invalid-option errors).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8030ac6c54b61f6a88a1e73565654481fea51ec8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->