### PR TITLE
Deprecate cupy array backend (#843)

### DIFF
--- a/chainladder/__init__.py
+++ b/chainladder/__init__.py
@@ -16,6 +16,7 @@ valuation defaults, as well as package metadata such as version number.
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 import copy
+import warnings
 import numpy as np
 import pandas as pd
 from importlib.metadata import version
@@ -95,6 +96,20 @@ class Options:
 
         """
         self._validate_option(option)
+        if option == "ARRAY_BACKEND" and value == "cupy":
+            warnings.warn(
+                "The 'cupy' array backend is deprecated and will be removed in a "
+                "future release. See https://github.com/casact/chainladder-python/issues/843.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+        elif option == "ARRAY_PRIORITY" and "cupy" in value:
+            warnings.warn(
+                "The 'cupy' array backend is deprecated and will be removed in a "
+                "future release. See https://github.com/casact/chainladder-python/issues/843.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
         setattr(self, option, value)
 
     def reset_option(self, option: str | None = None) -> None:

--- a/chainladder/__init__.py
+++ b/chainladder/__init__.py
@@ -104,12 +104,20 @@ class Options:
                 stacklevel=2,
             )
         elif option == "ARRAY_PRIORITY" and "cupy" in value:
-            warnings.warn(
-                "The 'cupy' array backend is deprecated and will be removed in a "
-                "future release. See https://github.com/casact/chainladder-python/issues/843.",
-                DeprecationWarning,
-                stacklevel=2,
-            )
+            # Only warn when 'cupy' is prioritized ahead of a non-deprecated
+            # backend ('numpy' or 'sparse'), i.e. cupy would actually be
+            # selected over a supported backend.
+            cupy_index = value.index("cupy")
+            if any(
+                backend in value and value.index(backend) > cupy_index
+                for backend in ("numpy", "sparse")
+            ):
+                warnings.warn(
+                    "The 'cupy' array backend is deprecated and will be removed in a "
+                    "future release. See https://github.com/casact/chainladder-python/issues/843.",
+                    DeprecationWarning,
+                    stacklevel=2,
+                )
         setattr(self, option, value)
 
     def reset_option(self, option: str | None = None) -> None:

--- a/chainladder/core/common.py
+++ b/chainladder/core/common.py
@@ -149,7 +149,7 @@ class Common:
         return func(self, *args, **kwargs)
 
     def set_backend(
-        self, backend: str, inplace: bool = False, deep: bool = False, **kwargs
+        self, backend: str, inplace: bool = False, deep: bool = False, _warn: bool = True, **kwargs
     ):
         """
         Converts triangle array_backend.
@@ -166,6 +166,16 @@ class Common:
         -------
             Triangle with updated array_backend
         """
+        # Warn once, at the public entry point, so stacklevel=2 points at the
+        # user's call site rather than an internal recursive call. The _warn
+        # flag suppresses duplicate warnings from internal recursion below.
+        if _warn and backend == "cupy":
+            warnings.warn(
+                "The 'cupy' array backend is deprecated and will be removed in a "
+                "future release. See https://github.com/casact/chainladder-python/issues/843.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
         if hasattr(self, "array_backend"):
             old_backend: str = self.array_backend
         else:
@@ -174,13 +184,6 @@ class Common:
             else:
                 raise ValueError("Unable to determine array backend.")
         if inplace:
-            if backend == "cupy":
-                warnings.warn(
-                    "The 'cupy' array backend is deprecated and will be removed in a "
-                    "future release. See https://github.com/casact/chainladder-python/issues/843.",
-                    DeprecationWarning,
-                    stacklevel=2,
-                )
             # Coming from dask - compute and then recall this method
             # going to dask  -
             if old_backend == "dask" and backend != "dask":
@@ -214,7 +217,7 @@ class Common:
                 if deep:
                     for k, v in vars(self).items():
                         if isinstance(v, Common):
-                            v.set_backend(backend, inplace=True, deep=True)
+                            v.set_backend(backend, inplace=True, deep=True, _warn=False)
                 if hasattr(self, "array_backend"):
                     self.array_backend = backend
             else:
@@ -222,7 +225,7 @@ class Common:
             return self
         else:
             obj = self.copy()
-            return obj.set_backend(backend=backend, inplace=True, deep=deep, **kwargs)
+            return obj.set_backend(backend=backend, inplace=True, deep=deep, _warn=False, **kwargs)
 
     @staticmethod
     def _validate_assumption(

--- a/chainladder/core/common.py
+++ b/chainladder/core/common.py
@@ -3,6 +3,8 @@
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 from __future__ import annotations
 
+import warnings
+
 import numpy as np
 import pandas as pd
 
@@ -172,6 +174,13 @@ class Common:
             else:
                 raise ValueError("Unable to determine array backend.")
         if inplace:
+            if backend == "cupy":
+                warnings.warn(
+                    "The 'cupy' array backend is deprecated and will be removed in a "
+                    "future release. See https://github.com/casact/chainladder-python/issues/843.",
+                    DeprecationWarning,
+                    stacklevel=2,
+                )
             # Coming from dask - compute and then recall this method
             # going to dask  -
             if old_backend == "dask" and backend != "dask":

--- a/chainladder/core/common.py
+++ b/chainladder/core/common.py
@@ -161,6 +161,13 @@ class Common:
         inplace : bool
             Whether to mutate the existing Triangle instance or return a new
             one.
+        deep : bool
+            Whether to also convert the backend of nested Triangle-like
+            attributes (e.g. fitted estimator components).
+        _warn : bool
+            Internal flag controlling whether a deprecation warning is emitted.
+            Set to ``False`` on internal recursive calls so the warning fires
+            only once, at the user's call site. Not part of the public API.
 
         Returns
         -------

--- a/chainladder/utils/tests/test_utilities.py
+++ b/chainladder/utils/tests/test_utilities.py
@@ -292,3 +292,63 @@ def test_reset_option_invalid() -> None:
     """
     with pytest.raises(ValueError):
         cl.options.reset_option('NOT_A_REAL_OPTION')
+
+
+def test_set_option_cupy_backend_deprecated() -> None:
+    """
+    Setting ARRAY_BACKEND to 'cupy' should emit a DeprecationWarning. See issue #843.
+
+    Returns
+    -------
+    None
+    """
+    try:
+        with pytest.warns(DeprecationWarning, match="cupy"):
+            cl.options.set_option('ARRAY_BACKEND', 'cupy')
+    finally:
+        cl.options.reset_option('ARRAY_BACKEND')
+
+
+def test_set_option_cupy_priority_deprecated() -> None:
+    """
+    Setting ARRAY_PRIORITY to a list containing 'cupy' should emit a
+    DeprecationWarning. See issue #843.
+
+    Returns
+    -------
+    None
+    """
+    try:
+        with pytest.warns(DeprecationWarning, match="cupy"):
+            cl.options.set_option('ARRAY_PRIORITY', ['dask', 'sparse', 'cupy', 'numpy'])
+    finally:
+        cl.options.reset_option('ARRAY_PRIORITY')
+
+
+def test_set_option_non_cupy_no_warning(recwarn) -> None:
+    """
+    Setting backends other than 'cupy' should not emit a DeprecationWarning.
+
+    Returns
+    -------
+    None
+    """
+    try:
+        cl.options.set_option('ARRAY_BACKEND', 'sparse')
+        cl.options.set_option('ARRAY_PRIORITY', ['dask', 'sparse', 'numpy'])
+        assert not [w for w in recwarn if issubclass(w.category, DeprecationWarning)]
+    finally:
+        cl.options.reset_option('ARRAY_BACKEND')
+        cl.options.reset_option('ARRAY_PRIORITY')
+
+
+def test_set_backend_cupy_deprecated(clrd) -> None:
+    """
+    Triangle.set_backend('cupy') should emit a DeprecationWarning. See issue #843.
+
+    Returns
+    -------
+    None
+    """
+    with pytest.warns(DeprecationWarning, match="cupy"):
+        clrd.set_backend('cupy')

--- a/chainladder/utils/tests/test_utilities.py
+++ b/chainladder/utils/tests/test_utilities.py
@@ -311,8 +311,8 @@ def test_set_option_cupy_backend_deprecated() -> None:
 
 def test_set_option_cupy_priority_deprecated() -> None:
     """
-    Setting ARRAY_PRIORITY to a list containing 'cupy' should emit a
-    DeprecationWarning. See issue #843.
+    Setting ARRAY_PRIORITY with 'cupy' ahead of a non-deprecated backend
+    ('numpy' or 'sparse') should emit a DeprecationWarning. See issue #843.
 
     Returns
     -------
@@ -320,7 +320,24 @@ def test_set_option_cupy_priority_deprecated() -> None:
     """
     try:
         with pytest.warns(DeprecationWarning, match="cupy"):
-            cl.options.set_option('ARRAY_PRIORITY', ['dask', 'sparse', 'cupy', 'numpy'])
+            cl.options.set_option('ARRAY_PRIORITY', ['cupy', 'dask', 'sparse', 'numpy'])
+    finally:
+        cl.options.reset_option('ARRAY_PRIORITY')
+
+
+def test_set_option_cupy_priority_last_no_warning(recwarn) -> None:
+    """
+    Setting ARRAY_PRIORITY with 'cupy' ranked below every non-deprecated
+    backend should not warn, since cupy would never be selected over a
+    supported backend. See issue #843.
+
+    Returns
+    -------
+    None
+    """
+    try:
+        cl.options.set_option('ARRAY_PRIORITY', ['dask', 'sparse', 'numpy', 'cupy'])
+        assert not [w for w in recwarn if issubclass(w.category, DeprecationWarning)]
     finally:
         cl.options.reset_option('ARRAY_PRIORITY')
 

--- a/chainladder/utils/tests/test_utilities.py
+++ b/chainladder/utils/tests/test_utilities.py
@@ -344,11 +344,20 @@ def test_set_option_non_cupy_no_warning(recwarn) -> None:
 
 def test_set_backend_cupy_deprecated(clrd) -> None:
     """
-    Triangle.set_backend('cupy') should emit a DeprecationWarning. See issue #843.
+    Triangle.set_backend('cupy') should emit exactly one DeprecationWarning,
+    pointing at the caller. See issue #843.
 
     Returns
     -------
     None
     """
-    with pytest.warns(DeprecationWarning, match="cupy"):
-        clrd.set_backend('cupy')
+    with pytest.warns(DeprecationWarning, match="cupy") as record:
+        clrd.set_backend('cupy', deep=True)
+    cupy_warnings = [
+        w for w in record
+        if issubclass(w.category, DeprecationWarning) and "cupy" in str(w.message)
+    ]
+    # A single warning should fire at the user's call site, not once per
+    # internal recursive / deep child conversion.
+    assert len(cupy_warnings) == 1
+    assert cupy_warnings[0].filename == __file__


### PR DESCRIPTION
## Summary of Changes

Emits a `DeprecationWarning` when the cupy array backend is selected, without removing any functionality. cupy is elective and not well maintained, so it's slated for removal in a future release (#601). This warns users now so they can migrate before it's gone.

Three entry points warn:

- `set_option("ARRAY_BACKEND", "cupy")` warns
- `set_option("ARRAY_PRIORITY", ...)` warns only when cupy is ranked ahead of numpy or sparse, so valid priority lists don't get noisy
- `Triangle.set_backend("cupy")` warns once at the user's call site, even with `deep=True`. Internal recursive calls are suppressed via a private `_warn` flag.

Also documented the `_warn` and `deep` params on `set_backend`.

Added tests in `chainladder/utils/tests/test_utilities.py` covering each warning path plus the no-warn cases (non-cupy backends, and cupy ranked last in priority).

## Related GitHub Issue(s)

Closes #843.

Per @henrydingliu's call on the issue, this only deprecates (warns) and does not remove cupy. Removal can follow later under #601.

## Additional Context for Reviewers

The current default priority `["dask", "sparse", "cupy", "numpy"]` has cupy ahead of numpy, so explicitly re-setting that default would warn. Happy to switch the check to only fire when cupy leads both numpy and sparse if you'd prefer the default never warns.

- `uv run --extra dev pytest -k "deprecat or cupy"` passed, 6 tests
- `uv run jb build docs --builder=custom --custom-builder=doctest` clean

- [x] I passed tests locally for both code (`uv run pytest`) and documentation changes (`uv run jb build docs --builder=custom --custom-builder=doctest`)