### PR TITLE
DOCS: Render API methods inline via custom autosummary templates (#847)

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -43,6 +43,8 @@ sphinx:
     linkcode: _ext
   config:
     autosummary_generate: True
+    templates_path: ['_templates']
+    numpydoc_show_class_members: False
     bibtex_reference_style: author_year
 
 parse:

--- a/docs/_ext/linkcode.py
+++ b/docs/_ext/linkcode.py
@@ -53,11 +53,21 @@ def linkcode_resolve(domain: str, info: dict) -> str | None:
     for part in info["fullname"].split("."):
         obj: type = getattr(obj, part)
 
+    # Resolve properties to their underlying getter function.
+    if isinstance(obj, property):
+        obj = obj.fget
+        if obj is None:
+            return None
+
     # Unwrap any decorators.
     obj: type = inspect.unwrap(obj)
 
-    # Get the path of the source file.
-    source_file: str = inspect.getsourcefile(obj)
+    # Get the path of the source file. Some objects (e.g. C-level callables or
+    # dynamically created members) are not introspectable; skip linking those.
+    try:
+        source_file: str = inspect.getsourcefile(obj)
+    except TypeError:
+        return None
 
     # If the source file cannot be found, return the URL pointing to a .py file named after the module.
     if source_file is None:
@@ -65,7 +75,11 @@ def linkcode_resolve(domain: str, info: dict) -> str | None:
         return url_base + "%s.py" % filename
 
     # Extract the lines and locate the starting line position.
-    source_lines, start_line = inspect.getsourcelines(obj)
+    try:
+        source_lines, start_line = inspect.getsourcelines(obj)
+    except (TypeError, OSError):
+        filename: str = info["module"].replace(".", "/")
+        return url_base + "%s.py" % filename
 
     # Get the root path.
     root_path: str = os.path.abspath(os.path.join(cl.__file__, "..", ".."))

--- a/docs/_templates/autosummary/class.rst
+++ b/docs/_templates/autosummary/class.rst
@@ -1,0 +1,8 @@
+{{ fullname | escape | underline }}
+
+.. currentmodule:: {{ module }}
+
+.. autoclass:: {{ objname }}
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/_templates/autosummary/class_inherited.rst
+++ b/docs/_templates/autosummary/class_inherited.rst
@@ -1,0 +1,9 @@
+{{ fullname | escape | underline }}
+
+.. currentmodule:: {{ module }}
+
+.. autoclass:: {{ objname }}
+   :members:
+   :undoc-members:
+   :inherited-members:
+   :show-inheritance:

--- a/docs/_templates/autosummary/function.rst
+++ b/docs/_templates/autosummary/function.rst
@@ -1,0 +1,5 @@
+{{ fullname | escape | underline }}
+
+.. currentmodule:: {{ module }}
+
+.. autofunction:: {{ objname }}

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -40,5 +40,7 @@ nb_output_stderr = 'show'
 numfig = True
 pygments_style = 'sphinx'
 suppress_warnings = ['myst.domains']
+templates_path = ['_templates']
+numpydoc_show_class_members = False
 use_jupyterbook_latex = True
 use_multitoc_numbering = True

--- a/docs/library/api.md
+++ b/docs/library/api.md
@@ -20,7 +20,7 @@ Classes
 
 .. autosummary::
   :toctree: generated/
-  :template: class_inherited.rst
+  :template: class_inherited
 
   Triangle
   DevelopmentCorrelation
@@ -43,7 +43,7 @@ Classes
 
 .. autosummary::
   :toctree: generated/
-  :template: class.rst
+  :template: class
 
   Development
   DevelopmentConstant
@@ -72,7 +72,7 @@ Classes
 
 .. autosummary::
   :toctree: generated/
-  :template: class.rst
+  :template: class
 
   TailConstant
   TailCurve
@@ -96,7 +96,7 @@ Classes
 
 .. autosummary::
    :toctree: generated/
-   :template: class.rst
+   :template: class
 
    Chainladder
    MackChainladder
@@ -119,7 +119,7 @@ Classes
 
 .. autosummary::
  :toctree: generated/
- :template: class.rst
+ :template: class
 
  BootstrapODPSample
  BerquistSherman
@@ -140,7 +140,7 @@ Classes
 
 .. autosummary::
   :toctree: generated/
-  :template: class.rst
+  :template: class
 
   Pipeline
   VotingChainladder
@@ -162,7 +162,7 @@ Functions
 
 .. autosummary::
    :toctree: generated/
-   :template: function.rst
+   :template: function
 
    load_sample
    read_pickle
@@ -178,7 +178,7 @@ Classes
 
 .. autosummary::
  :toctree: generated/
- :template: class.rst
+ :template: class
 
  PatsyFormula
 


### PR DESCRIPTION
## Summary of Changes
- Adds custom `sphinx.ext.autosummary` templates under `docs/_templates/autosummary/`: `class.rst`, `class_inherited.rst`, `function.rst`.
- API class pages now list methods and properties **inline** instead of a summary table that links to a separate page per method.
- Fixes the `:template:` names in `docs/library/api.md` to drop `.rst` (`:template: class.rst` → `:template: class`).
- Sets `numpydoc_show_class_members = False` and `templates_path = ['_templates']` in `docs/_config.yml` (and the generated `docs/conf.py`).
- Guards `docs/_ext/linkcode.py` against `property` objects so inline members don't crash the build.

Three issues fixed along the way:

1. **`:template: class.rst` never worked.** Sphinx appends `.rst`, so it looked for `autosummary/class.rst.rst` and fell back to the base template. Names now omit the extension.
2. **numpydoc duplicate table.** `numpydoc_show_class_members = False` stops numpydoc emitting its own members table next to the inline members.
3. **`linkcode_resolve` crash.** Inline members pass `property` objects to the resolver, where `inspect.getsourcefile(property)` raises `TypeError` and aborts `jb build`. Fixed by unwrapping properties to `fget` and guarding `getsourcefile` / `getsourcelines`.

## Related GitHub Issue(s)
- Closes #847
- Based on `experimental`; builds on merged #879.

## Additional Context for Reviewers
- `conf.py` is regenerated from `_config.yml` by Jupyter Book; both updated to stay in sync.
- `jb build .` succeeds (warnings all pre-existing). HTML spot checks:

  | Page | Inline methods | Inline properties | numpydoc table |
  |------|---------------|-------------------|----------------|
  | `Development` (`class`) | 3 | 0 | none |
  | `Triangle` (`class_inherited`) | 64 | 24 | none |
  | `load_sample` (`function`) | function block | – | – |

One thing to decide: with `:inherited-members:` on, `Triangle` shows 64 methods and 24 properties, including sklearn ones it inherits like `get_params`, `set_output`, `set_fit_request`, `get_metadata_routing`. Do you want all of those shown, or should I hide the sklearn ones (or just drop inherited members entirely)? Let me know which you prefer and I'll adjust.

- [x] Verified documentation changes locally with `jb build .` (HTML builder).