### PR TITLE
fix(sparse): floor() returns a copy instead of mutating its input (#740)

### DIFF
--- a/chainladder/utils/sparse.py
+++ b/chainladder/utils/sparse.py
@@ -67,6 +67,7 @@ def cumprod(a, axis=None, dtype=None, out=None):
 
 
 def floor(x):
+    x = x.copy()
     x.data = np.floor(x.data)
     return x
 

--- a/chainladder/utils/sparse.py
+++ b/chainladder/utils/sparse.py
@@ -66,7 +66,7 @@ def cumprod(a, axis=None, dtype=None, out=None):
     return array(np.cumprod(a.todense(), axis=axis, dtype=dtype, out=out))
 
 
-def floor(x):
+def floor(x: COO) -> COO:
     x = x.copy()
     x.data = np.floor(x.data)
     return x

--- a/chainladder/utils/tests/test_sparse.py
+++ b/chainladder/utils/tests/test_sparse.py
@@ -97,9 +97,10 @@ def test_floor_rounds_down() -> None:
     np.testing.assert_array_equal(result.todense(), [1.0, 2.0, -1.0])
 
 
-def test_floor_mutates_in_place() -> None:
+def test_floor_returns_copy() -> None:
     """
-    Checks in-place mutation of floor function.
+    Checks that floor returns a copy and does not mutate its input,
+    mirroring np.floor (see issue #740).
 
     Returns
     -------
@@ -107,4 +108,6 @@ def test_floor_mutates_in_place() -> None:
     """
     a = array([1.2, 2.7, -0.3])
     result: COO = floor(a)
-    assert result is a
+    assert result is not a
+    np.testing.assert_array_equal(result.todense(), [1.0, 2.0, -1.0])
+    np.testing.assert_array_equal(a.todense(), [1.2, 2.7, -0.3])


### PR DESCRIPTION
Closes #740.

`chainladder.utils.sparse.floor(x)` reassigned `x.data` in place, mutating the caller's COO array as a side effect:

```python
def floor(x):
    x.data = np.floor(x.data)
    return x
```

Since `np.floor()` returns a copy, this makes `floor()` match that contract by copying before flooring, using the same `.copy()` idiom already present in `nan_to_num()` in the same module:

```python
def floor(x):
    x = x.copy()
    x.data = np.floor(x.data)
    return x
```

Behavior now matches the issue's expectation:

```python
a = array([1.2, 2.7, -0.3])
floor(a)
a.todense()        # array([ 1.2,  2.7, -0.3])  (unchanged)

a = floor(a)
a.todense()        # array([ 1.,  2., -1.])
```

The only internal caller (`chainladder/core/correlation.py`) already consumes the return value (`m = xp.floor((n - 1) / 2)`), so the change is behavior-preserving there.

Updated `test_floor_mutates_in_place` (which asserted `result is a`) to `test_floor_returns_copy`, asserting the result is a new object and the input is left unmodified. `test_sparse.py` and `test_correlation.py` pass (12 passed).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized utility fix; the only in-repo caller already uses the return value, so behavior there is unchanged aside from avoiding accidental input mutation.
> 
> **Overview**
> **`chainladder.utils.sparse.floor`** no longer mutates the input COO array. It now **`copy()`**s first (same pattern as **`nan_to_num`** in that module), then floors **`x.data`**, aligning with **`np.floor`**’s copy semantics (issue #740). Type hints **`COO` → `COO`** were added on **`floor`**.
> 
> The test that expected **`result is a`** was renamed to **`test_floor_returns_copy`** and now checks the input values stay unchanged while the returned array is floored.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 876211ff6f573eff6381c5bd59a087c5b96ff756. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->