### PR TITLE
docs: fix lowercase option names after options refactor (#889)

### DIFF
--- a/docs/user_guide/triangle.ipynb
+++ b/docs/user_guide/triangle.ipynb
@@ -430,7 +430,7 @@
     }
    ],
    "source": [
-    "cl.options.set_option('auto_sparse', False)\n",
+    "cl.options.set_option('AUTO_SPARSE', False)\n",
     "prism = cl.load_sample('prism', array_backend='sparse')\n",
     "prism.array_backend"
    ]

--- a/docs/user_guide/triangle.ipynb
+++ b/docs/user_guide/triangle.ipynb
@@ -414,24 +414,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
    "id": "bc2151fc",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "'sparse'"
-      ]
-     },
-     "execution_count": 7,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "cl.options.set_option('AUTO_SPARSE', False)\n",
     "prism = cl.load_sample('prism', array_backend='sparse')\n",
+    "cl.options.reset_option('AUTO_SPARSE')\n",
     "prism.array_backend"
    ]
   },


### PR DESCRIPTION
Closes #889.

The options refactor on `experimental` added `Options._validate_option()`, which checks the option name against the uppercase attribute keys (`ARRAY_BACKEND`, `AUTO_SPARSE`, `ARRAY_PRIORITY`, `ULT_VAL`). Two code cells in `docs/user_guide/triangle.ipynb` (the "Other Parameters" / Backends section linked in the issue) still passed the old lowercase names, so they now raise:

```
ValueError: Invalid option(s): array_backend. Must be one of
['ARRAY_BACKEND', 'AUTO_SPARSE', 'ARRAY_PRIORITY', 'ULT_VAL'].
```

Fix:

- `cl.options.set_option('array_backend', 'cupy')` -> `'ARRAY_BACKEND'`
- `cl.options.set_option('auto_sparse', False)` -> `'AUTO_SPARSE'`

I grepped the whole `docs/` tree for `cl.options.*_option(` calls — these two were the only stale ones; `methods.ipynb` already uses the correct uppercase `'ULT_VAL'`. Notebook JSON validates after the edit.

Targeting `experimental` since that's where the refactor and the rendered docs in the issue live.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only notebook edits; no runtime or library code changes.
> 
> **Overview**
> Updates the **Backends** section in `docs/user_guide/triangle.ipynb` so `cl.options.set_option` / `reset_option` use the uppercase keys required by `Options._validate_option()` on `experimental` (e.g. `'AUTO_SPARSE'` instead of `'auto_sparse'`). Without this, those cells raise `ValueError: Invalid option(s)`.
> 
> The **auto_sparse** demo cell also calls `cl.options.reset_option('AUTO_SPARSE')` after loading the prism sample so global options are restored, and stored outputs are cleared (`execution_count` set to null).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5299fb34ec2fee4dcba57738b9c616a1f0b5d973. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->