### PR TITLE
docs: fix DevelopmentConstant patterns dict in friedland chapter_8

### DIFF
--- a/docs/friedland/chapter_8.ipynb
+++ b/docs/friedland/chapter_8.ipynb
@@ -825,7 +825,7 @@
       "metadata": {},
       "outputs": [],
       "source": [
-        "cl.DevelopmentConstant(patterns=patterns, style='cdf').fit(auto_bi[\"Paid Claims\"]).ldf_"
+        "cl.DevelopmentConstant(patterns=patterns['paid'], style='cdf').fit(auto_bi[\"Paid Claims\"]).ldf_"
       ]
     }
   ],


### PR DESCRIPTION
### What

The final code cell of `docs/friedland/chapter_8.ipynb` errors during the docs build, failing the Doctest CI job:

```python
cl.DevelopmentConstant(patterns=patterns, style='cdf').fit(auto_bi["Paid Claims"]).ldf_
```

```
KeyError: 12
  File chainladder/development/constant.py:78, in DevelopmentConstant.fit
    ldf = xp.array([float(self.patterns[item]) for item in obj.ddims])
```

### Why

`patterns` is defined as a **nested** dict:

```python
patterns = {
    'reported': {12: 4.0, 24: 2.9, ...},
    'paid':     {12: 90.0, 24: 15.0, ...},
}
```

But the non-callable `patterns` path in `DevelopmentConstant.fit` (and the docstring: *"A dictionary key:value representation of age(in months):value"*) expects a **flat** `{age: value}` dict. `fit` indexes `self.patterns[item]` for each `item` in `obj.ddims` (`[12, 24, ...]`), so with the nested dict it looks up `patterns[12]` and raises `KeyError`.

### Fix

Pass the `'paid'` sub-dict in the fit cell, since it fits `auto_bi["Paid Claims"]`. The nested `patterns` definition is left intact for the preceding cell (which shows the full reported+paid pattern set). One-line change to the notebook source.

### Verification

Executed the notebook end-to-end locally (`jupyter nbconvert --execute`, 120s timeout) — it now completes with no `CellExecutionError`, and the fit cell produces a clean `execute_result` with the expected LDFs (`12-24: 6.0`, `24-36: 3.0`, ... matching the Friedland exhibit).

The bug is present on both `main` and `experimental`; targeting `main`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only notebook one-liner; no library or production code paths change.
> 
> **Overview**
> Fixes a **docs notebook** cell that broke **Doctest / nbconvert** execution: the Friedland chapter 8 example passed the full nested `patterns` dict into `DevelopmentConstant.fit` on **Paid Claims**, but the non-callable `patterns` path indexes **`{age_in_months: value}`** directly (`self.patterns[item]` for each `obj.ddims` entry), which raised **`KeyError: 12`**.
> 
> The change passes **`patterns['paid']`** so the fit uses the paid CDF pattern that matches **`auto_bi["Paid Claims"]`**, while the earlier cell can still display the nested reported+paid pattern set.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit de9b0dcec7da3f4fcb901e83862458b34e57b6f5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->