### PR TITLE
maint: remove numba as a direct dependency (#483)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,6 @@ keywords = ["actuarial", "reserving", "insurance", "chainladder", "IBNR"]
 dependencies = [
     "pandas >=2.3.3",
     "scikit-learn>1.4.2",
-    "numba>0.54",
     "sparse>=0.9",
     "numpy",
     "matplotlib",  # Required for TriangleDisplay.heatmap()


### PR DESCRIPTION
Closes #483.

`numba` is listed in `[project.dependencies]` (`numba>0.54`) but is not imported anywhere in the package — a grep of the `chainladder/` tree returns no `import numba` / `from numba`.

As @jbogaardt noted on the issue, numba is a hard dependency of `sparse`, which chainladder depends on directly. I confirmed this against the current pin: `sparse 0.17.0` declares `numba>=0.49`, so numba is still installed transitively after removing the direct entry. @genedan's 2026-05-18 comment proposed exactly this for 0.9.3.

Removing the direct pin also stops chainladder from constraining numba independently of sparse, which is what was causing the numpy-compatibility friction reported earlier in the thread (the chainladder-pinned numba lagging numpy).

**Verification**

- With `numba>0.54` removed from `[project.dependencies]`, `uv pip install -e ".[dev]"` re-resolves the environment and numba is still present: `numba 0.63.1` (pulled via `sparse`).
- Full suite: **717 passed, 12 xfailed** (the xfails and warnings are pre-existing, unchanged from a clean run).

Single-line change to `pyproject.toml`. Happy to adjust if you'd prefer to also set a numba floor somewhere explicit, but since it's transitive-only now I left it to sparse to constrain.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line dependency metadata change; numba remains via sparse and the suite was verified unchanged.
> 
> **Overview**
> Removes **`numba>0.54`** from **`pyproject.toml`** `[project.dependencies]`. The package does not import numba directly; it remains available **transitively** via **`sparse`**, so install graphs still include numba without chainladder imposing its own pin.
> 
> That avoids an extra, package-level numba constraint that could drift from **`sparse`**’s requirements and contribute to numpy/numba compatibility friction.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 899d808e9e8536b19eb4e9d2ddd80b7d9d7a2983. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->