### PR TITLE
uv: set minimum numpy version to 2.0 (#810)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ dependencies = [
     "scikit-learn>1.4.2",
     "numba>0.54",
     "sparse>=0.9",
-    "numpy",
+    "numpy>=2.0",
     "matplotlib",  # Required for TriangleDisplay.heatmap()
     "dill",
     "patsy",


### PR DESCRIPTION
Closes #810.

Running the suite on numpy 1.x breaks the unit tests, so the floor should be numpy 2.x. The existing dependency set already implies a 2.x-compatible window — `numba` caps numpy at `<2.4`, and `pandas>=2.3.3` needs `numpy>=1.26` on py3.12+ — but nothing pinned a 2.x floor explicitly. This sets it.

**Change:** `"numpy"` → `"numpy>=2.0"` in `[project.dependencies]`.

**Why 2.0 and not higher:** 2.0 is the lowest numpy 2.x, it satisfies every transitive constraint in the dep tree (pandas, scikit-learn, sparse, numba, matplotlib all resolve against it), and `requires-python>=3.10` is compatible with numpy 2.0+. Going higher would over-constrain without cause.

**Verification (the "uv solves AND passes tests" check from the issue):** I built an isolated env and pinned numpy to the floor (`numpy==2.0.2`). uv resolved the full environment cleanly, and at that floor the suite passes:

```
716 passed, 1 skipped, 12 xfailed in 133.41s
```

(At the floor the resolver also pulled pandas 3.0.3 / sparse 0.18 / numba 0.65.1, so the floor holds even against the newest pandas — not just the currently-pinned 2.3.3.)

I left `uv.lock` out of the diff so it regenerates in CI; happy to commit a refreshed lock if you'd prefer it in the PR.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Packaging-only constraint change; no runtime or library code is modified.
> 
> **Overview**
> Pins **NumPy 2.x** as the minimum runtime dependency by changing `numpy` to **`numpy>=2.0`** in `[project.dependencies]` in `pyproject.toml`.
> 
> This aligns declared requirements with the stack the project already expects (tests fail on NumPy 1.x) without changing application code.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a822accf84a56bfde3922434e3692abf8c04c43c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->