### PR TITLE
DOCS: Bring autosummary templates to parity (#847)

### DIFF
--- a/docs/_ext/linkcode.py
+++ b/docs/_ext/linkcode.py
@@ -49,9 +49,14 @@ def linkcode_resolve(domain: str, info: dict) -> str | None:
     mod: ModuleType = importlib.import_module(info["module"])
 
     obj: ModuleType = mod
-    # Extract the part.
+    # Extract the part. Some documented members (e.g. instance attributes pulled
+    # in via :inherited-members:) are not accessible on the object itself; skip
+    # linking those rather than crashing the build.
     for part in info["fullname"].split("."):
-        obj: type = getattr(obj, part)
+        try:
+            obj: type = getattr(obj, part)
+        except AttributeError:
+            return None
 
     # Resolve properties to their underlying getter function.
     if isinstance(obj, property):

--- a/docs/_templates/autosummary/class.rst
+++ b/docs/_templates/autosummary/class.rst
@@ -5,4 +5,4 @@
 .. autoclass:: {{ objname }}
    :members:
    :undoc-members:
-   :show-inheritance:
+   :inherited-members:

--- a/docs/_templates/autosummary/class_inherited.rst
+++ b/docs/_templates/autosummary/class_inherited.rst
@@ -6,4 +6,3 @@
    :members:
    :undoc-members:
    :inherited-members:
-   :show-inheritance:


### PR DESCRIPTION
Follow-up to #885, addressing Henry's two parity edits from #847.

## Summary of Changes
- Drop `:show-inheritance:` from the class templates so internal base classes (e.g. `MethodBase` behind `Chainladder`) are no longer listed.
- Add `:inherited-members:` to the plain `class` template so useful inherited methods like `to_pickle` now show up on pages such as `Development`.
- Guard `linkcode_resolve` against members not accessible on the class object. Adding `:inherited-members:` surfaces members like `Pipeline.steps` (present on instances, not on the class), which made linkcode's `getattr` walk raise `AttributeError` and abort the build; those members are now skipped.

After these edits `class.rst` and `class_inherited.rst` are identical; kept as two files to stay minimal and avoid touching `api.md`. Exclusions for sklearn boilerplate are intentionally punted to a future enhancement per the discussion on #847.

## Verification
`jb build .` succeeds (189 warnings, all pre-existing). HTML spot check of `Development`: `to_pickle` now present, no "Bases:" line, 12 inline method blocks; `Pipeline` page builds without the linkcode crash.

## Related GitHub Issue(s)
- Refs #847

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and Sphinx extension behavior only; no runtime library or security impact.
> 
> **Overview**
> Brings the Sphinx **autosummary** class templates in line: both drop **`:show-inheritance:`** (so internal bases like `MethodBase` no longer clutter class pages) and enable **`:inherited-members:`** on the default `class` template so inherited API members (e.g. `to_pickle` on `Development`) appear in generated docs.
> 
> **`linkcode_resolve`** now catches **`AttributeError`** while walking dotted names, so inherited or synthetic members that cannot be resolved for GitHub source links no longer break the doc build—they simply omit the link.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7f066fff6d411aae600f5f9d4e9655a80a102f9f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->