### PR TITLE
Test experimental

### DIFF
--- a/chainladder/development/development.py
+++ b/chainladder/development/development.py
@@ -79,7 +79,7 @@ class Development(DevelopmentBase):
         of estimating patterns.  If omitted, each level of the triangle
         index will receive its own patterns.
 
-    .. notes ::
+    .. note ::
 
         (Order of Drop Operations)
         

--- a/docs/_templates/autosummary/class.rst
+++ b/docs/_templates/autosummary/class.rst
@@ -5,7 +5,7 @@
 .. autoclass:: {{ objname }}
    :members:
    :undoc-members:
-   :exclude-members: set_fit_request, set_score_request, set_transform_request, {{ attributes | join(', ') }}
+   :exclude-members: set_fit_request, set_predict_request, set_score_request, set_transform_request, {{ attributes | join(', ') }}
 
 {% set inherited = [] %}
 {% for method in methods %}

--- a/docs/_templates/autosummary/class_inherited.rst
+++ b/docs/_templates/autosummary/class_inherited.rst
@@ -5,7 +5,7 @@
 .. autoclass:: {{ objname }}
    :members:
    :undoc-members:
-   :exclude-members: set_fit_request, set_score_request, set_transform_request, {{ attributes | join(', ') }}
+   :exclude-members: set_fit_request, set_predict_request, set_score_request, set_transform_request, {{ attributes | join(', ') }}
 
 {% set inherited = [] %}
 {% for method in methods %}

--- a/docs/_toc.yml
+++ b/docs/_toc.yml
@@ -38,7 +38,7 @@ parts:
   - chapters:
     - file: gallery/index.md
   - chapters:
-    - file: library/api.rst    
+    - file: library/api.md    
   - chapters:
     - file: library/about.md
       sections:

--- a/docs/getting_started/index.md
+++ b/docs/getting_started/index.md
@@ -1,4 +1,4 @@
-## {octicon}`rocket` Getting Started
+# {octicon}`rocket` Getting Started
 
 We recommend that you try the sandbox tutorial before installing the package on your machine. There's also the more in-depth onboarding tutorial to give you a slightly more comprehensive view of what the package can do.
 


### PR DESCRIPTION
## Summary of Changes  


## Related GitHub Issue(s)  


## Additional Context for Reviewers  


- [ ] I passed tests locally for both code (`uv run pytest`) and documentation changes (`uv run jb build docs --builder=custom --custom-builder=doctest`)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and docstring markup only; no changes to estimation or core package behavior.
> 
> **Overview**
> This PR is mostly **documentation build and presentation** tweaks, with no runtime library logic changes.
> 
> The `Development` class docstring fixes a Sphinx typo: `.. notes ::` becomes `.. note ::` so the “Order of Drop Operations” block renders correctly. Autosummary class templates now also exclude `set_predict_request` (along with other sklearn request setters) so those helpers don’t clutter generated API pages.
> 
> The book TOC now links the API section to `library/api.md` instead of `library/api.rst`, matching the markdown-based API index. The Getting Started landing page heading is normalized to a single `#` title instead of the previous `##` line.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fefc903619cbbb56ba4a855b9c9e02a7c115021a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->