### PR TITLE
refactor: make API exports explicit (#876)

### DIFF
--- a/chainladder/__init__.py
+++ b/chainladder/__init__.py
@@ -125,12 +125,67 @@ class Options:
 options = Options()
 
 
-from chainladder.utils import *  # noqa (API Import)
-from chainladder.core import *  # noqa (API Import)
-from chainladder.development import *  # noqa (API Import)
-from chainladder.adjustments import *  # noqa (API Import)
-from chainladder.tails import *  # noqa (API Import)
-from chainladder.methods import *  # noqa (API Import)
-from chainladder.workflow import *  # noqa (API Import)
+from chainladder.utils import (  # noqa (API import)
+    WeightedRegression,
+    parallelogram_olf,
+    read_csv,
+    read_pickle,
+    read_json,
+    concat,
+    load_sample,
+    list_samples,
+    minimum,
+    maximum,
+    PatsyFormula,
+    model_diagnostics,
+    cp,
+    sp,
+    dp,
+)
+from chainladder.core import (  # noqa (API import)
+    Triangle,
+    DevelopmentCorrelation,
+    ValuationCorrelation,
+)
+from chainladder.development import (  # noqa (API import)
+    DevelopmentBase,
+    Development,
+    MunichAdjustment,
+    IncrementalAdditive,
+    DevelopmentConstant,
+    ClarkLDF,
+    CaseOutstanding,
+    DevelopmentML,
+    TweedieGLM,
+    BarnettZehnwirth,
+)
+from chainladder.adjustments import (  # noqa (API import)
+    BootstrapODPSample,
+    BerquistSherman,
+    ParallelogramOLF,
+    Trend,
+    TrendConstant,
+)
+from chainladder.tails import (  # noqa (API import)
+    TailBase,
+    TailConstant,
+    TailCurve,
+    TailBondy,
+    TailClark,
+)
+from chainladder.methods import (  # noqa (API import)
+    MethodBase,
+    Chainladder,
+    MackChainladder,
+    Benktander,
+    BornhuetterFerguson,
+    CapeCod,
+    ExpectedLoss,
+)
+from chainladder.workflow import (  # noqa (API import)
+    GridSearch,
+    Pipeline,
+    VotingChainladder,
+)
 
 __version__ = version("chainladder")

--- a/chainladder/adjustments/__init__.py
+++ b/chainladder/adjustments/__init__.py
@@ -3,3 +3,11 @@ from chainladder.adjustments.berqsherm import BerquistSherman  # noqa (API impor
 from chainladder.adjustments.parallelogram import ParallelogramOLF  # noqa (API import)
 from chainladder.adjustments.trend import Trend  # noqa (API import)
 from chainladder.adjustments.trend import TrendConstant  # noqa (API import)
+
+__all__ = [
+    "BootstrapODPSample",
+    "BerquistSherman",
+    "ParallelogramOLF",
+    "Trend",
+    "TrendConstant",
+]

--- a/chainladder/core/__init__.py
+++ b/chainladder/core/__init__.py
@@ -3,3 +3,9 @@ from chainladder.core.correlation import (
     DevelopmentCorrelation,
     ValuationCorrelation,
 )  # noqa (API import)
+
+__all__ = [
+    "Triangle",
+    "DevelopmentCorrelation",
+    "ValuationCorrelation",
+]

--- a/chainladder/development/__init__.py
+++ b/chainladder/development/__init__.py
@@ -8,3 +8,16 @@ from chainladder.development.outstanding import CaseOutstanding  # noqa (API imp
 from chainladder.development.learning import DevelopmentML  # noqa (API import)
 from chainladder.development.glm import TweedieGLM  # noqa (API import)
 from chainladder.development.barnzehn import BarnettZehnwirth  # noqa (API import)
+
+__all__ = [
+    "DevelopmentBase",
+    "Development",
+    "MunichAdjustment",
+    "IncrementalAdditive",
+    "DevelopmentConstant",
+    "ClarkLDF",
+    "CaseOutstanding",
+    "DevelopmentML",
+    "TweedieGLM",
+    "BarnettZehnwirth",
+]

--- a/chainladder/methods/__init__.py
+++ b/chainladder/methods/__init__.py
@@ -5,3 +5,13 @@ from chainladder.methods.benktander import Benktander  # noqa (API import)
 from chainladder.methods.bornferg import BornhuetterFerguson  # noqa (API import)
 from chainladder.methods.capecod import CapeCod  # noqa (API import)
 from chainladder.methods.expectedloss import ExpectedLoss  # noqa (API import)
+
+__all__ = [
+    "MethodBase",
+    "Chainladder",
+    "MackChainladder",
+    "Benktander",
+    "BornhuetterFerguson",
+    "CapeCod",
+    "ExpectedLoss",
+]

--- a/chainladder/tails/__init__.py
+++ b/chainladder/tails/__init__.py
@@ -5,3 +5,11 @@ from chainladder.tails.constant import TailConstant  # noqa (API import)
 from chainladder.tails.curve import TailCurve  # noqa (API import)
 from chainladder.tails.bondy import TailBondy  # noqa (API import)
 from chainladder.tails.clark import TailClark  # noqa (API import)
+
+__all__ = [
+    "TailBase",
+    "TailConstant",
+    "TailCurve",
+    "TailBondy",
+    "TailClark",
+]

--- a/chainladder/tests/test_public_api.py
+++ b/chainladder/tests/test_public_api.py
@@ -1,0 +1,156 @@
+"""Tests that guard the explicit public API of ``chainladder``.
+
+The top-level package exposes a curated set of names via explicit imports
+(see ``chainladder/__init__.py`` and each submodule's ``__all__``). These
+tests pin that public surface so the refactor away from wildcard imports
+cannot silently add or drop a public name, and so submodule names no longer
+leak into the package namespace.
+"""
+
+from __future__ import annotations
+
+import types
+
+import chainladder as cl
+
+
+# The intended public API of the top-level ``chainladder`` package. This is the
+# union of every submodule ``__all__`` plus the package-level objects defined
+# directly in ``chainladder/__init__.py``.
+EXPECTED_PUBLIC_API = {
+    # core
+    "Triangle",
+    "DevelopmentCorrelation",
+    "ValuationCorrelation",
+    # utils
+    "WeightedRegression",
+    "parallelogram_olf",
+    "read_csv",
+    "read_pickle",
+    "read_json",
+    "concat",
+    "load_sample",
+    "list_samples",
+    "minimum",
+    "maximum",
+    "PatsyFormula",
+    "model_diagnostics",
+    "cp",
+    "sp",
+    "dp",
+    # development
+    "DevelopmentBase",
+    "Development",
+    "MunichAdjustment",
+    "IncrementalAdditive",
+    "DevelopmentConstant",
+    "ClarkLDF",
+    "CaseOutstanding",
+    "DevelopmentML",
+    "TweedieGLM",
+    "BarnettZehnwirth",
+    # adjustments
+    "BootstrapODPSample",
+    "BerquistSherman",
+    "ParallelogramOLF",
+    "Trend",
+    "TrendConstant",
+    # tails
+    "TailBase",
+    "TailConstant",
+    "TailCurve",
+    "TailBondy",
+    "TailClark",
+    # methods
+    "MethodBase",
+    "Chainladder",
+    "MackChainladder",
+    "Benktander",
+    "BornhuetterFerguson",
+    "CapeCod",
+    "ExpectedLoss",
+    # workflow
+    "GridSearch",
+    "Pipeline",
+    "VotingChainladder",
+    # package-level objects
+    "Options",
+    "options",
+    "version",
+}
+
+
+def test_public_api_present() -> None:
+    """Every expected public name is importable from ``chainladder``."""
+    missing = {name for name in EXPECTED_PUBLIC_API if not hasattr(cl, name)}
+    assert not missing, f"Missing public names: {sorted(missing)}"
+
+
+def test_no_submodule_leakage() -> None:
+    """Implementation submodules no longer leak into the public namespace.
+
+    Wildcard imports previously exposed leaf module names (e.g. ``clark``,
+    ``bondy``, ``mack``, ``glm``) on the top-level package. After switching to
+    explicit imports, only the subpackages themselves (bound by importing them)
+    and a small set of intentionally retained helpers remain as modules.
+    """
+    # Leaf implementation modules that used to leak via ``import *``.
+    leaked_leaf_modules = {
+        "barnzehn",
+        "base",
+        "benktander",
+        "berqsherm",
+        "bondy",
+        "bootstrap",
+        "bornferg",
+        "capecod",
+        "chainladder",
+        "clark",
+        "common",
+        "constant",
+        "correlation",
+        "curve",
+        "display",
+        "dunders",
+        "expectedloss",
+        "glm",
+        "gridsearch",
+        "incremental",
+        "io",
+        "learning",
+        "mack",
+        "munich",
+        "outstanding",
+        "pandas",
+        "parallelogram",
+        "slice",
+        "triangle",
+        "trend",
+        "utility_functions",
+        "voting",
+        "weighted_regression",
+    }
+    still_leaked = {name for name in leaked_leaf_modules if hasattr(cl, name)}
+    assert not still_leaked, (
+        f"Implementation submodules leaked into the public namespace: "
+        f"{sorted(still_leaked)}"
+    )
+
+
+def test_estimators_match_expected() -> None:
+    """The public estimator/util names exactly match the expected set.
+
+    Allows the package to also expose a few standard helper imports
+    (``numpy``, ``pandas``, ``copy``) without failing, while ensuring the
+    curated API itself does not drift.
+    """
+    public_non_modules = {
+        name
+        for name in dir(cl)
+        if not name.startswith("_")
+        and not isinstance(getattr(cl, name), types.ModuleType)
+    }
+    # Standard third-party/stdlib helpers that may remain visible.
+    allowed_extra = {"np", "pd", "copy"}
+    unexpected = public_non_modules - EXPECTED_PUBLIC_API - allowed_extra
+    assert not unexpected, f"Unexpected public names: {sorted(unexpected)}"

--- a/chainladder/utils/__init__.py
+++ b/chainladder/utils/__init__.py
@@ -21,3 +21,21 @@ from chainladder.utils.utility_functions import (  # noqa (API import)
 from chainladder.utils.cupy import cp
 from chainladder.utils.sparse import sp
 from chainladder.utils.dask import dp
+
+__all__ = [
+    "WeightedRegression",
+    "parallelogram_olf",
+    "read_csv",
+    "read_pickle",
+    "read_json",
+    "concat",
+    "load_sample",
+    "list_samples",
+    "minimum",
+    "maximum",
+    "PatsyFormula",
+    "model_diagnostics",
+    "cp",
+    "sp",
+    "dp",
+]

--- a/chainladder/workflow/__init__.py
+++ b/chainladder/workflow/__init__.py
@@ -1,2 +1,8 @@
 from chainladder.workflow.gridsearch import GridSearch, Pipeline  # noqa (API import)
 from chainladder.workflow.voting import VotingChainladder  # noqa (API import)
+
+__all__ = [
+    "GridSearch",
+    "Pipeline",
+    "VotingChainladder",
+]


### PR DESCRIPTION
## Summary of Changes

Swaps the wildcard imports in the top-level `__init__.py` for explicit ones, and adds `__all__` to each of the 7 submodules (core, utils, development, adjustments, tails, methods, workflow). Modeled on pandas' `__init__.py`.

No behavior change. All 48 public names stay the same. The only difference is that implementation modules like `barnzehn`, `bondy`, `clark`, `mack`, `glm` no longer leak into `chainladder.*`.

Kept `cp`/`sp`/`dp` in `utils.__all__` since they were already public. `np`, `pd`, `copy`, `version` are still visible since they're direct imports, not from the wildcards. Could clean those up in a follow-up if wanted.

Added `chainladder/tests/test_public_api.py` with a few tests to pin the public surface and make sure the leaked modules stay gone.

## Related GitHub Issue(s)

Closes #876

## Additional Context for Reviewers

Before: 48 public names plus a bunch of leaked module names. After: same 48, leaked modules gone.

- [x] I passed tests locally for both code (`uv run pytest`) and documentation changes (`uv run jb build docs --builder=custom --custom-builder=doctest`)