### PR TITLE
fix and enhance utils.model_diagnostics (#913)

### DIFF
--- a/chainladder/core/tests/test_triangle.py
+++ b/chainladder/core/tests/test_triangle.py
@@ -49,6 +49,9 @@ def test_link_ratio(raa, atol):
         raa.link_ratio * raa.iloc[:, :, :-1, :-1].values - raa.values[:, :, :-1, 1:]
     ).sum().sum() < atol
 
+def test_align_pattern(raa, atol):
+    with pytest.raises(ValueError):
+        raa.align_pattern(raa)
 
 def test_incr_to_cum(clrd):
     clrd.cum_to_incr().incr_to_cum() == clrd

--- a/chainladder/core/triangle.py
+++ b/chainladder/core/triangle.py
@@ -914,6 +914,40 @@ class Triangle(TriangleBase):
         """
         return self._pattern
 
+    def align_pattern(self, X:Triangle, sample_weight:Triangle|None=None) -> Triangle:
+        """ 
+        Vertically align a selected pattern to origin period latest diagonal. Triangle must be a selected pattern.
+
+        Parameters
+        ----------
+        X: Triangle
+        The target triangle to align to
+        
+        sample_weight:  Triangle, option (default=None)
+        Exposure triangle
+
+        Returns
+        -------
+        Triangle
+            Triangle of selected pattern across origin periods
+
+        """
+        if not self._pattern:
+            raise ValueError("Triangle is not a selected pattern, such as .ldf_ or .cdf_")
+        valuation = X.valuation_date
+        pattern = self.iloc[..., : X.shape[-1]]
+        a = X.iloc[0, 0] * 0
+        a = a + a.nan_triangle
+        if X.array_backend == "sparse":
+            a = a - a[a.valuation < a.valuation_date]
+        if sample_weight:
+            X = X * a + sample_weight * a
+        else:
+            X = X * a
+        pattern = X / X * pattern
+        pattern.valuation_date = valuation
+        return pattern.latest_diagonal
+
     @is_pattern.setter
     def is_pattern(self, pattern: bool):
         self._pattern = pattern

--- a/chainladder/methods/base.py
+++ b/chainladder/methods/base.py
@@ -25,19 +25,7 @@ class MethodBase(BaseEstimator, EstimatorIO, Common):
 
     def _align_cdf(self, X, sample_weight=None):
         """ Vertically align CDF to origin period latest diagonal. """
-        valuation = X.valuation_date
-        cdf = X.cdf_.iloc[..., : X.shape[-1]]
-        a = X.iloc[0, 0] * 0
-        a = a + a.nan_triangle
-        if X.array_backend == "sparse":
-            a = a - a[a.valuation < a.valuation_date]
-        if sample_weight:
-            X = X * a + sample_weight * a
-        else:
-            X = X * a
-        cdf = X / X * cdf
-        cdf.valuation_date = valuation
-        return cdf.latest_diagonal
+        return X.cdf_.align_pattern(X,sample_weight)
 
     def _set_ult_attr(self, ultimate):
         """ Ultimate scaffolding """

--- a/chainladder/methods/benktander.py
+++ b/chainladder/methods/benktander.py
@@ -243,6 +243,8 @@ class Benktander(MethodBase):
             2012  15914.716737
             2013  17193.715555
         """
+        if sample_weight is None:
+            raise ValueError("sample_weight is required.")
         X_new = super().predict(X, sample_weight)
         X_new.expectation_ = self._get_benktander_aprioris(X, sample_weight)
         X_new.ultimate_ = self._get_ultimate(X_new, X_new.expectation_)

--- a/chainladder/methods/tests/test_predict.py
+++ b/chainladder/methods/tests/test_predict.py
@@ -1,4 +1,5 @@
 import chainladder as cl
+import numpy as np
 import pandas as pd
 import pytest 
 
@@ -8,37 +9,34 @@ cl_ult = cl.Chainladder().fit(raa).ultimate_  # Chainladder Ultimate
 apriori = cl_ult * 0 + (float(cl_ult.sum()) / 10)  # Mean Chainladder Ultimate
 apriori_1989 = apriori[apriori.origin < "1990"]
 
-
-def test_cc_predict():
-    cc = cl.CapeCod().fit(raa_1989, sample_weight=apriori_1989)
-    assert cc.predict(raa, sample_weight=apriori)
-
-def test_bf_predict():
-    bf = cl.BornhuetterFerguson().fit(raa_1989, sample_weight=apriori_1989)
-    assert bf.predict(raa, sample_weight=apriori)
-
-def test_el_predict():
-    bf = cl.ExpectedLoss().fit(raa_1989, sample_weight=apriori_1989)
-    assert bf.predict(raa, sample_weight=apriori)
+@pytest.mark.parametrize(
+    "estimators",
+    [
+        cl.CapeCod,
+        cl.BornhuetterFerguson,
+        cl.ExpectedLoss,
+        cl.Benktander,
+        cl.Chainladder
+    ],
+)
+def test_predict_and_weights(estimators,atol):
+    est = estimators().fit(raa_1989, sample_weight=apriori_1989)
+    pred = est.predict(raa, sample_weight=apriori)
+    assert pred
+    assert np.allclose(raa_1989.latest_diagonal.values.swapaxes(0,1).reshape(cl.model_diagnostics(est)['Latest'].values.shape),cl.model_diagnostics(est)['Latest'].values,atol=atol,equal_nan=True)
+    assert np.allclose(raa.latest_diagonal.values.swapaxes(0,1).reshape(cl.model_diagnostics(pred)['Latest'].values.shape),cl.model_diagnostics(pred)['Latest'].values,atol=atol,equal_nan=True)
+    assert np.allclose(est.ultimate_.values.swapaxes(0,1).reshape(cl.model_diagnostics(est)['Ultimate'].values.shape),cl.model_diagnostics(est)['Ultimate'].values,atol=atol,equal_nan=True)
+    assert np.allclose(pred.ultimate_.values.swapaxes(0,1).reshape(cl.model_diagnostics(pred)['Ultimate'].values.shape),cl.model_diagnostics(pred)['Ultimate'].values,atol=atol,equal_nan=True)
+    #Test validation of sample_weight requirement. Should raise a value error if no weight is supplied.
+    if estimators != cl.Chainladder:
+        with pytest.raises(ValueError):
+            estimators().fit(raa_1989)
+        with pytest.raises(ValueError):
+            estimators().fit(raa_1989, sample_weight=apriori_1989).predict(raa)
 
 def test_mack_predict():
     mack = cl.MackChainladder().fit(raa_1989)
     assert mack.predict(raa_1989)
-
-def test_capecod_fit_weight():
-    """
-    Test validation of sample_weight requirement. Should raise a value error if no weight is supplied.
-    """
-    with pytest.raises(ValueError):
-        cl.CapeCod().fit(raa_1989)
-
-def test_capecod_predict_weight():
-    """
-    Test validation of sample_weight requirement. Should raise a value error if no weight is supplied.
-    """
-    with pytest.raises(ValueError):
-        cc = cl.CapeCod().fit(raa_1989, sample_weight=apriori_1989)
-        cc.predict(raa)
 
 def test_bs_random_state_predict(clrd):
     tri = clrd.groupby("LOB").sum().loc["wkcomp", ["CumPaidLoss", "EarnedPremNet"]]

--- a/chainladder/utils/tests/test_utilities.py
+++ b/chainladder/utils/tests/test_utilities.py
@@ -112,6 +112,16 @@ def test_concat(clrd):
 def test_model_diagnostics(qtr):
     cl.model_diagnostics(cl.Chainladder().fit(qtr))
 
+def test_model_diagnostics_erorr(raa):
+    with pytest.raises(ValueError):
+        cl.model_diagnostics(raa)
+
+def test_model_diagnostics_groupby(prism,atol):
+    dev = cl.Development().fit(prism["Incurred"].sum())
+    est = cl.Chainladder().fit(dev.transform(prism["Incurred"]))
+    lhs = cl.model_diagnostics(est,groupby=['Line'])['Ultimate']
+    rhs = cl.model_diagnostics(cl.Chainladder().fit(dev.transform(prism["Incurred"].groupby('Line').sum())))['Ultimate']
+    assert np.allclose(lhs.values,rhs.values,atol=atol,equal_nan=True)
 
 def test_concat_immutability(raa):
     u = cl.Chainladder().fit(raa).ultimate_

--- a/chainladder/utils/utility_functions.py
+++ b/chainladder/utils/utility_functions.py
@@ -23,7 +23,7 @@ from sklearn.base import BaseEstimator, TransformerMixin
 from typing import Iterable, Union, Optional, TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from chainladder import Triangle
+    from chainladder import Triangle, MethodBase
     from numpy.typing import ArrayLike
     from pandas import DataFrame
     from sparse import COO
@@ -689,43 +689,51 @@ class PatsyFormula(BaseEstimator, TransformerMixin):
         return dmatrix(self.design_info_, X)
 
 
-def model_diagnostics(model, name=None, groupby=None):
+def model_diagnostics(
+        model:Triangle|MethodBase|Pipeline, 
+        name:str|None=None, 
+        groupby:str|list(str)|None=None) -> Triangle:
     """A helper function that summarizes various vectors of an
     IBNR model as columns of a Triangle
 
     Parameters
     ----------
-    model:
-        A chainladder IBNR estimator or Pipeline
-    name:
+    model: Triangle|MethodBase|Pipeline
+        A predicted Triangle, chainladder IBNR estimator or Pipeline
+    name: str, optional (default=None)
         An alias to give the model. This will be added to the index of the return
         triangle.
-    groupby:
-        The index level at which the model should be summarized
+    groupby: str|list(str), optional (default=None)
+        The index level at which the model should be summarized. No development pattern will be included if groupby is used
 
     Returns
     -------
-    Triangle up select origin vectors, IBNR, ultimate, Latest diagonal, etc.
+    Triangle up select origin vectors, IBNR, ultimate, Latest diagonal, LDF, CDF, etc.
     """
-    from chainladder import Pipeline
+    from chainladder import Pipeline, Triangle
 
     if isinstance(model, Pipeline):
         obj = copy.deepcopy(model.steps[-1][-1])
     else:
         obj = copy.deepcopy(model)
+    if not (hasattr(obj,"ultimate_") & hasattr(obj,"ibnr_") & hasattr(obj,"ldf_")):
+        raise ValueError("model does not have ultimate_/ibnr_/ldf_")
+    if isinstance(model, Triangle):
+        tri = obj
+    else:
+        tri = obj.X_
     if groupby is not None:
-        obj.X_ = obj.X_.groupby(groupby).sum().cum_to_incr()
+        tri = tri.groupby(groupby).sum()
         obj.ultimate_ = obj.ultimate_.groupby(groupby).sum()
         if hasattr(obj, "expectation_"):
             obj.expectation_ = obj.expectation_.groupby(groupby).sum()
-    else:
-        obj.X_ = obj.X_.incr_to_cum()
-    val = obj.X_.valuation
-    latest = obj.X_.sum("development")
+    tri = tri.cum_to_incr()
+    val = tri.valuation
+    latest = tri.sum("development")
     run_off = obj.full_expectation_.iloc[..., :-1].dev_to_val().cum_to_incr()
-    run_off = run_off[run_off.development > str(obj.X_.valuation_date)]
+    run_off = run_off[run_off.development > str(tri.valuation_date)]
     run_off = run_off.iloc[
-        ..., : {"M": 12, "S": 6, "Q": 4, "Y": 1}[obj.X_.development_grain]
+        ..., : {"M": 12, "S": 6, "Q": 4, "Y": 1}[tri.development_grain]
     ]
 
     triangles = []
@@ -735,18 +743,18 @@ def model_diagnostics(model, name=None, groupby=None):
         idx["Model"] = obj.__class__.__name__ if name is None else name
         idx = idx[list(idx.columns[-2:]) + list(idx.columns[:-2])]
         out = latest[col].rename("columns", ["Latest"])
-        if obj.X_.development_grain in ["M"]:
-            out["Month Incremental"] = obj.X_[col][val == obj.X_.valuation_date].sum(
+        if tri.development_grain in ["M"]:
+            out["Month Incremental"] = tri[col][val == tri.valuation_date].sum(
                 "development"
             )
         if (
-            obj.X_.development_grain in ["M", "Q"]
+            tri.development_grain in ["M", "Q"]
             and pd.Period(out.valuation_date, freq="Q").to_timestamp(how="s")
             > val.min()
         ):
             out["Quarter Incremental"] = (
-                obj.X_
-                - obj.X_[
+                tri
+                - tri[
                     val
                     < pd.Period(out.valuation_date, freq="Q")
                     .to_timestamp(how="s")
@@ -757,11 +765,17 @@ def model_diagnostics(model, name=None, groupby=None):
             out["Quarter Incremental"] = 0
         if pd.Period(out.valuation_date, freq="Y").to_timestamp(how="s") > val.min():
             out["Year Incremental"] = (
-                obj.X_ - obj.X_[val < str(obj.X_.valuation_date.year)]
+                tri - tri[val < str(tri.valuation_date.year)]
             ).sum("development")[col]
         else:
             out["Year Incremental"] = 0
-        out["IBNR"] = obj.ibnr_[col]
+        if groupby is None:
+            out["LDF"] = obj.ldf_.align_pattern(tri.incr_to_cum(),sample_weight = obj.ultimate_[col])[col]
+            out["CDF"] = obj.cdf_.align_pattern(tri.incr_to_cum(),sample_weight = obj.ultimate_[col])[col]
+        if groupby is not None:
+            out["IBNR"] = obj.ibnr_[col].groupby(groupby).sum()
+        else:
+            out["IBNR"] = obj.ibnr_[col]
         out["Ultimate"] = obj.ultimate_[col]
         for i in range(run_off.shape[-1]):
             out["Run Off " + str(i + 1)] = run_off[col].iloc[..., i]


### PR DESCRIPTION
## Summary of Changes  
As we work our way through Friedland, the community agreed that we need a way to easily assemble exhibits together. Fortunately, John already created a `model_diagnostics` utility function. 

- fixed a bug where latest is the sum of cumulative values
- added support for predicted triangles
- fixed a bug where ibnr_ doesn't work on when groupby is specified
- added ldf and cdf to output
    - to do this more seamlessly, migrated `_align_cdf` function from `MethodBase` to `Triangle`. `_align_cdf` did not need any information from the IBNR estimator and actually made more sense to be a triangle method
- added tests and streamlined some existing tests
    - added error handling around missing sample_weight to benktander 

## Related GitHub Issue(s)  
closes #839 

## Additional Context for Reviewers  


- [X] I passed tests locally for both code (`uv run pytest`) and documentation changes (`uv run jb build docs --builder=custom --custom-builder=doctest`)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes affect a shared reporting helper and refactor CDF alignment used by several IBNR methods; fixes are behavior-changing for Latest/groupby outputs but are covered by new tests.
> 
> **Overview**
> **`model_diagnostics`** is reworked so exhibit-style summaries are more accurate and flexible: **Latest** is built from incremental development (fixing cumulative sums), **predicted `Triangle`** inputs are supported, **`groupby`** no longer breaks **IBNR**, and **LDF** / **CDF** columns are added when not grouping (via pattern alignment).
> 
> The CDF alignment logic moves from **`MethodBase._align_cdf`** to **`Triangle.align_pattern`**, which **`_align_cdf`** now delegates to; non-pattern triangles raise **`ValueError`**.
> 
> **Benktander** **`predict`** now requires **`sample_weight`**, matching **`fit`**. Tests are consolidated (parametrized predict/weights) and extended for diagnostics, **`align_pattern`**, and groupby consistency.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bcb9d6b275f573d478b2cd1cf91a64b3f1388954. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->