### PR TITLE
adding support for multi_index

### DIFF
--- a/chainladder/adjustments/bootstrap.py
+++ b/chainladder/adjustments/bootstrap.py
@@ -233,12 +233,16 @@ class BootstrapODPSample(DevelopmentBase):
         resampled_residual = xp.concatenate(tuple(resampled_residual), 0).reshape(
             self.n_sims, exp_incr_triangle.shape[0], exp_incr_triangle.shape[1]
         )
-        resampled_residual = resampled_residual
         b = xp.repeat(exp_incr_triangle[None, ...], self.n_sims, 0)
         resampled_triangles = (resampled_residual * xp.sqrt(abs(b)) + b).cumsum(2)
         resampled_triangles = xp.swapaxes(resampled_triangles[None, ...], 0, 1)
         obj = X.copy()
-        obj.kdims = np.arange(self.n_sims)
+        if X.key_labels == ['Total']:
+            obj.kdims = np.arange(self.n_sims)
+            obj.key_labels = ['Simulation_#']
+        else:
+            obj.kdims = np.concat([np.tile(X.kdims,(self.n_sims,1)),np.arange(self.n_sims).reshape(-1,1)],axis=1)
+            obj.key_labels = X.key_labels + ['Simulation_#']
         obj.values = resampled_triangles
         obj._set_slicers()
         return obj, scale_phi

--- a/chainladder/adjustments/tests/test_bootstrap.py
+++ b/chainladder/adjustments/tests/test_bootstrap.py
@@ -15,3 +15,9 @@ def test_bs_sample(raa):
 def test_bs_multiple_cols():
     assert cl.BootstrapODPSample().fit_transform(
         cl.load_sample('berqsherm').iloc[0]).shape == (1000, 4, 8, 8)
+
+def test_multi_index(clrd):
+    tri = clrd['CumPaidLoss'].sum()
+    resampled_triangles = cl.BootstrapODPSample().fit(clrd).resampled_triangles_
+    resampled_triangles.index
+    assert np.all(resampled_triangles.index == pd.DataFrame(np.concat((np.array([['(All)','(All)']] * 1000),np.arange(1000).reshape(-1,1)),axis=1),columns=['GRNAME','LOB','Simulation_#']))

--- a/chainladder/adjustments/tests/test_bootstrap.py
+++ b/chainladder/adjustments/tests/test_bootstrap.py
@@ -1,5 +1,6 @@
 import chainladder as cl
 import numpy as np
+import pandas as pd
 
 
 def test_bs_sample(raa):
@@ -18,6 +19,6 @@ def test_bs_multiple_cols():
 
 def test_multi_index(clrd):
     tri = clrd['CumPaidLoss'].sum()
-    resampled_triangles = cl.BootstrapODPSample().fit(clrd).resampled_triangles_
+    resampled_triangles = cl.BootstrapODPSample().fit(tri).resampled_triangles_
     resampled_triangles.index
     assert np.all(resampled_triangles.index == pd.DataFrame(np.concat((np.array([['(All)','(All)']] * 1000),np.arange(1000).reshape(-1,1)),axis=1),columns=['GRNAME','LOB','Simulation_#']))


### PR DESCRIPTION
## Summary of Changes  


## Related GitHub Issue(s)  


## Additional Context for Reviewers  


- [ ] I passed tests locally for both code (`uv run pytest`) and documentation changes (`uv run jb build docs --builder=custom --custom-builder=doctest`)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized index labeling in bootstrap simulation output; fit constraints unchanged and covered by a new test.
> 
> **Overview**
> **Bootstrap ODP** now labels simulated triangles with a proper index when the input triangle has multiple key dimensions (not only the aggregated `Total` case).
> 
> In `_get_simulation`, resampled output keeps the original `key_labels` and repeats each key row for every simulation, appending a **`Simulation_#`** column. Single-total triangles still use only simulation numbers as the index. A redundant no-op assignment on `resampled_residual` was removed.
> 
> A regression test on **`clrd`** checks that a summed multi-key triangle produces the expected **`GRNAME` / `LOB` / `Simulation_#`** index after bootstrap.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 79510ef2a731613791b3d778ac765be454f61130. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->