### PR TITLE
adding support for multi_index (#916)

### DIFF
--- a/chainladder/adjustments/bootstrap.py
+++ b/chainladder/adjustments/bootstrap.py
@@ -233,12 +233,16 @@ class BootstrapODPSample(DevelopmentBase):
         resampled_residual = xp.concatenate(tuple(resampled_residual), 0).reshape(
             self.n_sims, exp_incr_triangle.shape[0], exp_incr_triangle.shape[1]
         )
-        resampled_residual = resampled_residual
         b = xp.repeat(exp_incr_triangle[None, ...], self.n_sims, 0)
         resampled_triangles = (resampled_residual * xp.sqrt(abs(b)) + b).cumsum(2)
         resampled_triangles = xp.swapaxes(resampled_triangles[None, ...], 0, 1)
         obj = X.copy()
-        obj.kdims = np.arange(self.n_sims)
+        if X.key_labels == ['Total']:
+            obj.kdims = np.arange(self.n_sims)
+            obj.key_labels = ['Simulation_#']
+        else:
+            obj.kdims = np.concat([np.tile(X.kdims,(self.n_sims,1)),np.arange(self.n_sims).reshape(-1,1)],axis=1)
+            obj.key_labels = X.key_labels + ['Simulation_#']
         obj.values = resampled_triangles
         obj._set_slicers()
         return obj, scale_phi

--- a/chainladder/adjustments/tests/test_bootstrap.py
+++ b/chainladder/adjustments/tests/test_bootstrap.py
@@ -1,5 +1,6 @@
 import chainladder as cl
 import numpy as np
+import pandas as pd
 
 
 def test_bs_sample(raa):
@@ -15,3 +16,9 @@ def test_bs_sample(raa):
 def test_bs_multiple_cols():
     assert cl.BootstrapODPSample().fit_transform(
         cl.load_sample('berqsherm').iloc[0]).shape == (1000, 4, 8, 8)
+
+def test_multi_index(clrd):
+    tri = clrd['CumPaidLoss'].sum()
+    resampled_triangles = cl.BootstrapODPSample().fit(tri).resampled_triangles_
+    resampled_triangles.index
+    assert np.all(resampled_triangles.index == pd.DataFrame(np.concat((np.array([['(All)','(All)']] * 1000),np.arange(1000).reshape(-1,1)),axis=1),columns=['GRNAME','LOB','Simulation_#']))


### PR DESCRIPTION
## Summary of Changes  
added logic to bootstrap to preserve original index

## Related GitHub Issue(s)  
closes #425

## Additional Context for Reviewers  


- [X] I passed tests locally for both code (`uv run pytest`) and documentation changes (`uv run jb build docs --builder=custom --custom-builder=doctest`)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Indexing and metadata only; bootstrap sampling math is unchanged aside from a no-op line removal.
> 
> **Overview**
> **Bootstrap ODP output** now labels each simulation correctly on `resampled_triangles_` instead of always using a bare simulation index.
> 
> For triangles whose only key is **`Total`**, the result keeps a single **`Simulation_#`** index (same as before, with an explicit label). For **multi-level indices** (e.g. after summing CLRD by group), each simulation repeats the input’s key dimensions and appends **`Simulation_#`**, so the pandas index matches expectations like `GRNAME`, `LOB`, `Simulation_#`.
> 
> A redundant assignment in `_get_simulation` was removed. **`test_multi_index`** asserts the aggregated CLRD triangle’s resampled index shape and column names.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7a52f8cb06957af2cf4d8ab994b265b96c861524. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->