### PR TITLE
#919  friedland gl self insurer grain

### DIFF
--- a/chainladder/utils/data/_manifest.py
+++ b/chainladder/utils/data/_manifest.py
@@ -27,6 +27,8 @@ case) to the keyword arguments passed to ``Triangle``:
     Measure column name(s) loaded into the Triangle.
 ``cumulative``
     ``True`` if the measures are cumulative, ``False`` if incremental.
+``development_format``
+    Optional. Passed to ``Triangle`` by :func:`chainladder.load_sample`.
 """
 
 SAMPLES: dict = {
@@ -157,6 +159,7 @@ SAMPLES: dict = {
             "Paid Claims",
         ],
         "cumulative": True,
+        "development_format": "%Y-12-31",
     },
     "friedland_med_mal": {
         "origin": "Accident Year",
@@ -169,6 +172,7 @@ SAMPLES: dict = {
             "Open Claim Counts",
         ],
         "cumulative": True,
+        "development_format": "%Y",
     },
     "friedland_qs": {
         "origin": "Accident Year",

--- a/chainladder/utils/data/_manifest.py
+++ b/chainladder/utils/data/_manifest.py
@@ -172,7 +172,6 @@ SAMPLES: dict = {
             "Open Claim Counts",
         ],
         "cumulative": True,
-        "development_format": "%Y",
     },
     "friedland_qs": {
         "origin": "Accident Year",

--- a/chainladder/utils/utility_functions.py
+++ b/chainladder/utils/utility_functions.py
@@ -10,10 +10,7 @@ import os
 import numpy as np
 import pandas as pd
 
-from chainladder import (
-    __dt64_unit__,
-    __dt64_dtype__
-)
+from chainladder import __dt64_unit__, __dt64_dtype__
 from chainladder.utils.sparse import sp
 from chainladder.utils.data._manifest import SAMPLES
 from io import StringIO
@@ -117,6 +114,8 @@ def load_sample(key: str, *args, **kwargs) -> Triangle:
     columns = config["columns"]
     cumulative = config["cumulative"]
 
+    development_format = config.get("development_format", None)
+
     df = pd.read_csv(filepath_or_buffer=dataset_path)
 
     return Triangle(
@@ -126,6 +125,7 @@ def load_sample(key: str, *args, **kwargs) -> Triangle:
         index=index,
         columns=columns,
         cumulative=cumulative,
+        development_format=development_format,
         *args,
         **kwargs,
     )
@@ -818,6 +818,7 @@ def PTF_formula(
         return "+".join(formula_parts)
     return ""
 
+
 def date_delta_adjustment(date: str) -> str:
     """
     Subtracts the default pandas datetime delta from a date in "YYYY-MM-DD" string format.
@@ -855,10 +856,6 @@ def date_delta_adjustment(date: str) -> str:
         '2025-10-31 23:59:59.999999'
     """
 
-
-    res: str = str(
-        pd.Timestamp(date) - \
-        pd.Timedelta(1, unit=__dt64_unit__)
-    )
+    res: str = str(pd.Timestamp(date) - pd.Timedelta(1, unit=__dt64_unit__))
 
     return res


### PR DESCRIPTION
## Summary of Changes  
Now the valuation date format is explicit

## Related GitHub Issue(s)  
Fixes #919 

## Additional Context for Reviewers  
N/A

- [x] I passed tests locally for both code (`uv run pytest`) and documentation changes (`uv run jb build docs --builder=custom --custom-builder=doctest`)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized sample-loader and manifest metadata change; only one bundled dataset gets a new format string, with no auth or core algorithm changes.
> 
> **Overview**
> Fixes incorrect development/valuation grain for the **friedland_gl_self_insurer** sample by wiring optional **`development_format`** through the sample manifest into **`load_sample`** → **`Triangle`**.
> 
> The manifest gains an optional **`development_format`** field (documented in `_manifest.py`). Only **friedland_gl_self_insurer** sets it to **`%Y-12-31`**, so calendar-year development columns are parsed as explicit year-end dates instead of being inferred ambiguously. **`load_sample`** reads `config.get("development_format")` and passes it when constructing the triangle.
> 
> Minor cleanup in **`utility_functions`**: import formatting and a small simplification of **`date_delta_adjustment`** (no behavior change intended).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3993b4a8f3459780d2986b51281d953329b87ab0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->