### PR TITLE
#928 quarterly warning

### DIFF
--- a/chainladder/core/base.py
+++ b/chainladder/core/base.py
@@ -409,17 +409,17 @@ class TriangleBase(
                     try:
                         datetime_values = cast(DatetimeIndex, pd.to_datetime(**date_inference))
                         break
-                    except ValueError:
+                    except (ValueError, UserWarning):
                         pass
-                    # Quarterly edge case.
-                    except UserWarning:
-                        datetime_values = pd.PeriodIndex(datetime_arg, freq='Q').to_timestamp(how=start_end)
-                        break
 
             if datetime_values is None:
-                raise ValueError(
-                    "Unable to infer datetime for field(s): " + str(fields) +
-                    ". Please check the underlying data or any supplied format arguments."
+                # Quarterly edge case.
+                try:
+                    datetime_values: DatetimeIndex = pd.PeriodIndex(datetime_arg, freq='Q').to_timestamp(how=start_end)
+                except ValueError:
+                    raise ValueError(
+                        "Unable to infer datetime for field(s): " + str(fields) +
+                        ". Please check the underlying data or any supplied format arguments."
                     )
             datetime_mapping = dict(zip(datetime_arg, datetime_values))
             target: Series = target_field.map(arg=datetime_mapping)

--- a/chainladder/core/base.py
+++ b/chainladder/core/base.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import pandas as pd
 import numpy as np
+import re
 import warnings
 
 from abc import ABC, abstractmethod
@@ -379,13 +380,16 @@ class TriangleBase(
         else:
             target_field: Series = data[fields].iloc[:, 0]
 
+        # Used for specifying start/end of a period when constructing timestamps.
+        # period_end is a boolean that if true, means that the timestamp should be the end of the period.
+        start_end: str = {1: "e", 0: "s"}[period_end]
+
         if hasattr(target_field, "dt"):
             # If the target field is already a non-period datetime, no conversion is needed.
             target: Series = target_field
-            # If the target field is a period, convert to timestamp. period_end is a boolean that if true,
-            # means that the timestamp should be the end of the period.
+            # If the target field is a period, convert to timestamp.
             if type(target.iloc[0]) == pd.Period:
-                return target.dt.to_timestamp(how={1: "e", 0: "s"}[period_end])
+                return target.dt.to_timestamp(how=start_end)
         else:
             datetime_arg: np.ndarray = target_field.unique()
             date_format = [{"arg": datetime_arg, "format": date_format}] if date_format else []
@@ -404,6 +408,9 @@ class TriangleBase(
                     break
                 except ValueError:
                     pass
+                # Quarterly edge case.
+                except UserWarning:
+                    datetime_mapping = dict(zip(datetime_arg, pd.PeriodIndex(datetime_arg, freq='Q').to_timestamp(how={1: "e", 0: "s"}[period_end])))
 
             if datetime_mapping is None:
                 raise ValueError(

--- a/chainladder/core/base.py
+++ b/chainladder/core/base.py
@@ -29,7 +29,8 @@ from chainladder.utils.sparse import sp
 
 from typing import (
     Optional,
-    TYPE_CHECKING
+    TYPE_CHECKING,
+    cast
 )
 
 if TYPE_CHECKING:
@@ -401,22 +402,24 @@ class TriangleBase(
                 {"arg": datetime_arg},
             ]
 
-            datetime_mapping: None | dict = None
+            datetime_values: DatetimeIndex | None = None
             for date_inference in date_inference_list:
                 try:
-                    datetime_mapping = dict(zip(datetime_arg, pd.to_datetime(**date_inference)))
+                    datetime_values = cast(DatetimeIndex, pd.to_datetime(**date_inference))
                     break
                 except ValueError:
                     pass
                 # Quarterly edge case.
                 except UserWarning:
-                    datetime_mapping = dict(zip(datetime_arg, pd.PeriodIndex(datetime_arg, freq='Q').to_timestamp(how={1: "e", 0: "s"}[period_end])))
+                    datetime_values: DatetimeIndex = pd.PeriodIndex(datetime_arg, freq='Q').to_timestamp(how=start_end)
+                    break
 
-            if datetime_mapping is None:
+            if datetime_values is None:
                 raise ValueError(
                     "Unable to infer datetime for field(s): " + str(fields) +
                     ". Please check the underlying data or any supplied format arguments."
                     )
+            datetime_mapping = dict(zip(datetime_arg, datetime_values))
             target: Series = target_field.map(arg=datetime_mapping)
 
         return target

--- a/chainladder/core/base.py
+++ b/chainladder/core/base.py
@@ -403,16 +403,17 @@ class TriangleBase(
             ]
 
             datetime_values: DatetimeIndex | None = None
-            for date_inference in date_inference_list:
-                try:
-                    datetime_values = cast(DatetimeIndex, pd.to_datetime(**date_inference))
-                    break
-                except ValueError:
-                    pass
-                # Quarterly edge case.
-                except UserWarning:
-                    datetime_values: DatetimeIndex = pd.PeriodIndex(datetime_arg, freq='Q').to_timestamp(how=start_end)
-                    break
+            with warnings.catch_warnings():
+                warnings.filterwarnings('error', category=UserWarning)
+                for date_inference in date_inference_list:
+                    try:
+                        datetime_values = cast(DatetimeIndex, pd.to_datetime(**date_inference))
+                        break
+                    except ValueError:
+                        pass
+                    except UserWarning:
+                        datetime_values = pd.PeriodIndex(datetime_arg, freq='Q').to_timestamp(how=start_end)
+                        break
 
             if datetime_values is None:
                 raise ValueError(

--- a/chainladder/core/base.py
+++ b/chainladder/core/base.py
@@ -403,7 +403,7 @@ class TriangleBase(
             ]
 
             datetime_values: DatetimeIndex | None = None
-            with warnings.catch_warnings():
+            with warnings.catch_warnings(record=False):
                 warnings.filterwarnings('error', category=UserWarning)
                 for date_inference in date_inference_list:
                     try:
@@ -411,6 +411,7 @@ class TriangleBase(
                         break
                     except ValueError:
                         pass
+                    # Quarterly edge case.
                     except UserWarning:
                         datetime_values = pd.PeriodIndex(datetime_arg, freq='Q').to_timestamp(how=start_end)
                         break

--- a/chainladder/core/base.py
+++ b/chainladder/core/base.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 
 import pandas as pd
 import numpy as np
-import re
 import warnings
 
 from abc import ABC, abstractmethod
@@ -27,6 +26,8 @@ from chainladder.utils.cupy import cp
 from chainladder.utils.dask import dp
 from chainladder.utils.sparse import sp
 
+from pandas import DatetimeIndex
+
 from typing import (
     Optional,
     TYPE_CHECKING,
@@ -39,7 +40,6 @@ if TYPE_CHECKING:
         Series
     )
     from numpy.typing import ArrayLike
-    from pandas.core.indexes.datetimes import DatetimeIndex
     from pandas.core.interchange.dataframe_protocol import DataFrame as DataFrameXchg
     from pandas._libs.tslibs.timestamps import Timestamp
     from types import ModuleType

--- a/chainladder/core/tests/test_triangle.py
+++ b/chainladder/core/tests/test_triangle.py
@@ -1061,3 +1061,23 @@ def test_xs(clrd):
     assert clrd.xs('comauto',level=1).index.equals(clrd.xs('comauto',level='LOB').index)
 
 
+def test_to_datetime_uninferrable_format_raises() -> None:
+    """
+    Initialize a triangle with incorrect date format on the origin axis. Should raise a ValueError.
+
+    Returns
+    -------
+    None
+
+    """
+    with pytest.raises(ValueError, match="Unable to infer datetime"):
+        cl.Triangle(
+            data={
+                'origin': ['1995/Q1', '1996/Q1'],
+                'development': ['1995Q1', '1996Q1'],
+                'value': [1.0, 2.0]},
+            origin='origin',
+            development='development',
+            columns='value',
+            cumulative=True
+        )

--- a/chainladder/core/triangle.py
+++ b/chainladder/core/triangle.py
@@ -34,7 +34,7 @@ class Triangle(TriangleBase):
 
     Parameters
     ----------
-    data: DataFrame or DataFrameXchg, or dict
+    data: DataFrame | DataFrameXchg |dict
         A single dataframe that contains columns representing all other
         arguments to the Triangle constructor. One may supply a DataFrame-like
         object (referred to as DataFrameXchg) supporting the __dataframe__


### PR DESCRIPTION
## Summary of Changes  

Handles quarterly edge case when conducting datetime inference. Python doesn't have a native datetime format string for quarterly dates, so I decided to intercept the UserWarning and handle the quarterly case separately.

Reduces the number of warnings from 1112 to 1080.

## Related GitHub Issue(s)  

#840
#928 

## Additional Context for Reviewers  


- [x] I passed tests locally for both code (`uv run pytest`) and documentation changes (`uv run jb build docs --builder=custom --custom-builder=doctest`)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core Triangle date parsing used at construction; quarterly fallback could affect edge-case origin/development labels, though behavior for known formats should stay the same.
> 
> **Overview**
> **`TriangleBase._to_datetime`** now treats **`UserWarning`** from **`pd.to_datetime`** as a failed inference attempt (via **`warnings.filterwarnings('error')`**) instead of letting quarterly strings warn and still partially parse. When the usual format list fails, it falls back to **`pd.PeriodIndex(..., freq='Q').to_timestamp`**, honoring **`period_end`** through a shared **`start_end`** flag for period timestamps.
> 
> A regression test asserts **`Triangle`** still raises **`ValueError`** with *"Unable to infer datetime"* when origin/development strings use incompatible formats (e.g. **`1995/Q1`** vs **`1995Q1`**). **`Triangle`** docs only clarify the **`data`** type as **`DataFrame | DataFrameXchg | dict`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 99682fe9c93db90aa3587d9363e00118250a7e30. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->