### PR TITLE
base.py unit tests

### DIFF
--- a/chainladder/core/base.py
+++ b/chainladder/core/base.py
@@ -105,7 +105,7 @@ class TriangleBase(
         columns = str_to_list(columns)
         origin = str_to_list(origin)
         development = str_to_list(development)
-        if not all(pd.api.types.is_numeric_dtype(data[col]) for col in columns):
+        if not all(pd.api.types.is_numeric_dtype(dt) for dt in data[columns].dtypes):
             raise TypeError("column attribute must be numeric.")
         if data[columns].shape[1] != len(columns):
             raise AttributeError("Columns are required to have unique names")

--- a/chainladder/core/base.py
+++ b/chainladder/core/base.py
@@ -105,7 +105,7 @@ class TriangleBase(
         columns = str_to_list(columns)
         origin = str_to_list(origin)
         development = str_to_list(development)
-        if "object" in data[columns].dtypes:
+        if (data[columns].dtypes == "object").any():
             raise TypeError("column attribute must be numeric.")
         if data[columns].shape[1] != len(columns):
             raise AttributeError("Columns are required to have unique names")

--- a/chainladder/core/base.py
+++ b/chainladder/core/base.py
@@ -105,7 +105,7 @@ class TriangleBase(
         columns = str_to_list(columns)
         origin = str_to_list(origin)
         development = str_to_list(development)
-        if (data[columns].dtypes == "object").any():
+        if not all(pd.api.types.is_numeric_dtype(data[col]) for col in columns):
             raise TypeError("column attribute must be numeric.")
         if data[columns].shape[1] != len(columns):
             raise AttributeError("Columns are required to have unique names")

--- a/chainladder/core/tests/test_triangle.py
+++ b/chainladder/core/tests/test_triangle.py
@@ -1061,6 +1061,171 @@ def test_xs(clrd):
     assert clrd.xs('comauto',level=1).index.equals(clrd.xs('comauto',level='LOB').index)
 
 
+def test_get_array_module_with_explicit_arr(raa: Triangle) -> None:
+    """
+    Supply a ndarray to Triangle.get_array_module(), which should be np (numpy).
+
+    Parameters
+    ----------
+    raa: Triangle
+        The raa sample data set.
+
+    Returns
+    -------
+    None
+
+    """
+    assert raa.get_array_module(np.array([1.0])) is np
+
+
+def test_get_array_module_invalid_backend_raises(raa: Triangle) -> None:
+    """
+    Simulate typo in setting array backend, should raise an exception.
+
+    Parameters
+    ----------
+    raa: Triangle
+        The raa sample data set.
+
+    Returns
+    -------
+    None
+
+    """
+    tri = raa.copy()
+    tri.array_backend = 'mumpy'
+    with pytest.raises(Exception, match="Array backend is invalid or not properly set"):
+        tri.get_array_module()
+
+
+def test_set_development_no_development_column() -> None:
+    """
+    Initialize a triangle without a development dimension specified. Development will default to being
+    a single period set to the latest origin period.
+
+    Returns
+    -------
+    None
+
+    """
+    df = pd.DataFrame(
+        {
+            'origin': [1995, 1996, 1997],
+            'reported': [1.0, 2.0, 3.0]
+        }
+    )
+    tri = cl.Triangle(
+        data=df,
+        origin='origin',
+        columns='reported',
+        cumulative=True
+    )
+    assert tri.shape[-1] == 1
+    assert tri.development[0] == str(tri.origin[-1])
+
+
+def test_set_development_age_instead_of_date_raises() -> None:
+    """
+    Initialize a triangle with incorrect development periods specified. Should raise a ValueError.
+
+    Returns
+    -------
+    None
+
+    """
+    df = pd.DataFrame(
+        {
+            'origin': [1995, 1996],
+            'development': [12, 24],
+            'reported': [1.0, 2.0]
+        }
+    )
+    with pytest.raises(ValueError, match="Development lags could not be determined"):
+        cl.Triangle(
+            data=df,
+            origin='origin',
+            development='development',
+            columns='reported',
+            cumulative=True
+        )
+
+
+def test_input_validation_non_numeric_columns_raises() -> None:
+    """
+    Initialize a triangle with reported losses as an invalid string data type. Should raise a TypeError.
+
+    Returns
+    -------
+    None
+
+    """
+    df = pd.DataFrame({
+        'origin': [1995, 1996],
+        'dev': [1995, 1996],
+        'reported': ['1000', '2000'],
+    })
+    with pytest.raises(TypeError, match="column attribute must be numeric"):
+        cl.Triangle(
+            data=df,
+            origin='origin',
+            development='development',
+            columns='reported',
+            cumulative=True
+        )
+
+
+def test_input_validation_duplicate_columns_raises() -> None:
+    """
+    Initialize a triangle with duplicate column names. Raise an AttributeError.
+
+    Returns
+    -------
+    None
+
+    """
+    df = pd.DataFrame(
+        [[1995, 1995, 1.0, 2.0], [1996, 1996, 3.0, 4.0]],
+        columns=pd.Index(['origin', 'development', 'reported', 'reported'])
+    )
+    with pytest.raises(AttributeError, match="Columns are required to have unique names"):
+        cl.Triangle(
+            data=df,
+            origin='origin',
+            development='development',
+            columns='reported',
+            cumulative=True
+        )
+
+
+def test_get_axis_value(raa) -> None:
+    """
+    Extract the Triangle axes using integer indices and string specifications.
+
+    Parameters
+    ----------
+    raa: Triangle
+        The raa sample data set.
+
+    Returns
+    -------
+    None
+
+    """
+    assert raa._get_axis_value(0).equals(raa.index)
+    assert raa._get_axis_value("index").equals(raa.index)
+    assert raa._get_axis_value(1).equals(raa.columns)
+    assert raa._get_axis_value("columns").equals(raa.columns)
+    assert raa._get_axis_value(2).equals(raa.origin)
+    assert raa._get_axis_value("origin").equals(raa.origin)
+    assert raa._get_axis_value(3).equals(raa.development)
+    assert raa._get_axis_value("development").equals(raa.development)
+    # Negative index support in TrianglePandas().get_axis()
+    assert raa._get_axis_value(-4).equals(raa.index)
+    assert raa._get_axis_value(-1).equals(raa.development)
+    with pytest.raises(ValueError):
+        raa._get_axis_value("dev")
+
+
 def test_to_datetime_uninferrable_format_raises() -> None:
     """
     Initialize a triangle with incorrect date format on the origin axis. Should raise a ValueError.

--- a/chainladder/core/tests/test_triangle.py
+++ b/chainladder/core/tests/test_triangle.py
@@ -1161,7 +1161,7 @@ def test_input_validation_non_numeric_columns_raises() -> None:
     """
     df = pd.DataFrame({
         'origin': [1995, 1996],
-        'dev': [1995, 1996],
+        'development': [1995, 1996],
         'reported': ['1000', '2000'],
     })
     with pytest.raises(TypeError, match="column attribute must be numeric"):


### PR DESCRIPTION
## Summary of Changes  

Adding some unit tests for lines missing coverage in `base.py`. Also fixes a bug in `base.py`, it was checking for "object" in the column names rather than the data types of the columns.

## Related GitHub Issue(s)  


## Additional Context for Reviewers  

- [x] I passed tests locally for both code (`uv run pytest`) and documentation changes (`uv run jb build docs --builder=custom --custom-builder=doctest`)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small validation fix plus tests; behavior change only tightens rejecting non-numeric measure columns that may have slipped through before.
> 
> **Overview**
> Fixes **Triangle** input validation so numeric measure columns are checked via `pd.api.types.is_numeric_dtype` on each column dtype, instead of the broken `"object" in data[columns].dtypes` check (which did not reliably reject non-numeric data).
> 
> Adds **pytest** coverage in `test_triangle.py` for `base.py` paths: `get_array_module` (explicit ndarray and invalid backend), default development when no development field is given, development-as-age `ValueError`, non-numeric and duplicate-column validation errors, and `_get_axis_value` (including invalid axis).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1284204355f0df15f8d569f55af07da611b68473. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->