### PR TITLE
feat: deprecate dask array backend (#842)

### DIFF
--- a/chainladder/__init__.py
+++ b/chainladder/__init__.py
@@ -49,6 +49,23 @@ _option_warning: str = (
     "The parameter 'option' is deprecated and will be removed in a future release. Use 'pat' instead."
 )
 
+# Array backends slated for removal, mapped to the issue tracking each one.
+# Selecting one of these (via set_option, ARRAY_PRIORITY, or set_backend, or by
+# passing a Dask dataframe to the Triangle constructor) emits a
+# DeprecationWarning.
+_DEPRECATED_BACKENDS: dict[str, str] = {
+    "cupy": "https://github.com/casact/chainladder-python/issues/843",
+    "dask": "https://github.com/casact/chainladder-python/issues/842",
+}
+
+
+def _deprecated_backend_message(backend: str) -> str:
+    """Build the deprecation message for a soon-to-be-removed array backend."""
+    return (
+        f"The '{backend}' array backend is deprecated and will be removed in a "
+        f"future release. See {_DEPRECATED_BACKENDS[backend]}."
+    )
+
 
 @overload
 def _resolve_pat(pat: str | None, option: str | None, required: Literal[True] = ...) -> str: ...
@@ -189,28 +206,30 @@ class Options:
         self._validate_option(pat)
         if value is _UNSET:
             raise TypeError("set_option() missing required argument: 'value'.")
-        if pat == "ARRAY_BACKEND" and value == "cupy":
+        if pat == "ARRAY_BACKEND" and value in _DEPRECATED_BACKENDS:
             warnings.warn(
-                "The 'cupy' array backend is deprecated and will be removed in a "
-                "future release. See https://github.com/casact/chainladder-python/issues/843.",
+                _deprecated_backend_message(value),
                 DeprecationWarning,
                 stacklevel=2,
             )
-        elif pat == "ARRAY_PRIORITY" and isinstance(value, list) and "cupy" in value:
-            # Only warn when 'cupy' is prioritized ahead of a non-deprecated
-            # backend ('numpy' or 'sparse'), i.e. cupy would actually be
-            # selected over a supported backend.
-            cupy_index = value.index("cupy")
-            if any(
-                backend in value and value.index(backend) > cupy_index
-                for backend in ("numpy", "sparse")
-            ):
-                warnings.warn(
-                    "The 'cupy' array backend is deprecated and will be removed in a "
-                    "future release. See https://github.com/casact/chainladder-python/issues/843.",
-                    DeprecationWarning,
-                    stacklevel=2,
-                )
+        elif pat == "ARRAY_PRIORITY" and isinstance(value, list):
+            # Only warn when a deprecated backend ('cupy' or 'dask') is
+            # prioritized ahead of a non-deprecated backend ('numpy' or
+            # 'sparse'), i.e. it would actually be selected over a supported
+            # backend. The position in the list determines precedence.
+            for backend in _DEPRECATED_BACKENDS:
+                if backend not in value:
+                    continue
+                backend_index = value.index(backend)
+                if any(
+                    supported in value and value.index(supported) > backend_index
+                    for supported in ("numpy", "sparse")
+                ):
+                    warnings.warn(
+                        _deprecated_backend_message(backend),
+                        DeprecationWarning,
+                        stacklevel=2,
+                    )
         setattr(self, pat, value)
 
     def reset_option(

--- a/chainladder/core/base.py
+++ b/chainladder/core/base.py
@@ -12,7 +12,8 @@ from abc import ABC, abstractmethod
 from chainladder import (
     __dt64_unit__,
     __dt64_dtype__,
-    options
+    options,
+    _deprecated_backend_message
 )
 
 from chainladder.core.common import Common
@@ -162,6 +163,14 @@ class TriangleBase(
     ):
         """Summarize dataframe to the level specified in axes"""
         if type(data) != pd.DataFrame:
+            # A non-pandas input here is a Dask dataframe. stacklevel=3 points
+            # the warning at the user's Triangle(...) call (warn -> this
+            # method -> Triangle.__init__ -> user).
+            warnings.warn(
+                _deprecated_backend_message("dask"),
+                DeprecationWarning,
+                stacklevel=3,
+            )
             # Dask dataframes are mutated.
             data["__origin__"] = origin_date
             data["__development__"] = development_date

--- a/chainladder/core/base.py
+++ b/chainladder/core/base.py
@@ -163,14 +163,18 @@ class TriangleBase(
     ):
         """Summarize dataframe to the level specified in axes"""
         if type(data) != pd.DataFrame:
-            # A non-pandas input here is a Dask dataframe. stacklevel=3 points
-            # the warning at the user's Triangle(...) call (warn -> this
-            # method -> Triangle.__init__ -> user).
-            warnings.warn(
-                _deprecated_backend_message("dask"),
-                DeprecationWarning,
-                stacklevel=3,
-            )
+            # A non-pandas input that reaches this branch is a Dask dataframe.
+            # Only the Dask backend is deprecated, so gate the warning on the
+            # data's module rather than warning for every pandas subclass that
+            # also takes this path. stacklevel=3 points the warning at the
+            # user's Triangle(...) call (warn -> this method ->
+            # Triangle.__init__ -> user).
+            if type(data).__module__.split(".")[0] == "dask":
+                warnings.warn(
+                    _deprecated_backend_message("dask"),
+                    DeprecationWarning,
+                    stacklevel=3,
+                )
             # Dask dataframes are mutated.
             data["__origin__"] = origin_date
             data["__development__"] = development_date

--- a/chainladder/core/common.py
+++ b/chainladder/core/common.py
@@ -9,6 +9,7 @@ import numpy as np
 import pandas as pd
 
 from chainladder import options
+from chainladder import _DEPRECATED_BACKENDS, _deprecated_backend_message
 from chainladder.utils.cupy import cp
 from chainladder.utils.dask import dp
 from chainladder.utils.sparse import sp
@@ -180,10 +181,9 @@ class Common:
         # Warn once, at the public entry point, so stacklevel=2 points at the
         # user's call site rather than an internal recursive call. The _warn
         # flag suppresses duplicate warnings from internal recursion below.
-        if _warn and backend == "cupy":
+        if _warn and backend in _DEPRECATED_BACKENDS:
             warnings.warn(
-                "The 'cupy' array backend is deprecated and will be removed in a "
-                "future release. See https://github.com/casact/chainladder-python/issues/843.",
+                _deprecated_backend_message(backend),
                 DeprecationWarning,
                 stacklevel=2,
             )

--- a/chainladder/utils/tests/test_utilities.py
+++ b/chainladder/utils/tests/test_utilities.py
@@ -4,6 +4,7 @@ import pytest
 import chainladder as cl
 import copy
 import numpy as np
+import pandas as pd
 
 from chainladder import (
     __dt64_unit__
@@ -390,6 +391,21 @@ def test_set_option_cupy_backend_deprecated() -> None:
         cl.options.reset_option('ARRAY_BACKEND')
 
 
+def test_set_option_dask_backend_deprecated() -> None:
+    """
+    Setting ARRAY_BACKEND to 'dask' should emit a DeprecationWarning. See issue #842.
+
+    Returns
+    -------
+    None
+    """
+    try:
+        with pytest.warns(DeprecationWarning, match="dask"):
+            cl.options.set_option('ARRAY_BACKEND', 'dask')
+    finally:
+        cl.options.reset_option('ARRAY_BACKEND')
+
+
 def test_set_option_cupy_priority_deprecated() -> None:
     """
     Setting ARRAY_PRIORITY with 'cupy' ahead of a non-deprecated backend
@@ -401,31 +417,49 @@ def test_set_option_cupy_priority_deprecated() -> None:
     """
     try:
         with pytest.warns(DeprecationWarning, match="cupy"):
-            cl.options.set_option('ARRAY_PRIORITY', ['cupy', 'dask', 'sparse', 'numpy'])
+            cl.options.set_option('ARRAY_PRIORITY', ['cupy', 'numpy', 'sparse', 'dask'])
     finally:
         cl.options.reset_option('ARRAY_PRIORITY')
 
 
-def test_set_option_cupy_priority_last_no_warning(recwarn) -> None:
+def test_set_option_dask_priority_deprecated() -> None:
     """
-    Setting ARRAY_PRIORITY with 'cupy' ranked below every non-deprecated
-    backend should not warn, since cupy would never be selected over a
-    supported backend. See issue #843.
+    Setting ARRAY_PRIORITY with 'dask' ahead of a non-deprecated backend
+    ('numpy' or 'sparse') should emit a DeprecationWarning. See issue #842.
 
     Returns
     -------
     None
     """
     try:
-        cl.options.set_option('ARRAY_PRIORITY', ['dask', 'sparse', 'numpy', 'cupy'])
+        with pytest.warns(DeprecationWarning, match="dask"):
+            cl.options.set_option('ARRAY_PRIORITY', ['dask', 'numpy', 'sparse', 'cupy'])
+    finally:
+        cl.options.reset_option('ARRAY_PRIORITY')
+
+
+def test_set_option_deprecated_priority_last_no_warning(recwarn) -> None:
+    """
+    Setting ARRAY_PRIORITY with the deprecated backends ('cupy' and 'dask')
+    ranked below every non-deprecated backend should not warn, since neither
+    would ever be selected over a supported backend. See issues #842 and #843.
+
+    Returns
+    -------
+    None
+    """
+    try:
+        cl.options.set_option('ARRAY_PRIORITY', ['numpy', 'sparse', 'dask', 'cupy'])
         assert not [w for w in recwarn if issubclass(w.category, DeprecationWarning)]
     finally:
         cl.options.reset_option('ARRAY_PRIORITY')
 
 
-def test_set_option_non_cupy_no_warning(recwarn) -> None:
+def test_set_option_supported_backend_no_warning(recwarn) -> None:
     """
-    Setting backends other than 'cupy' should not emit a DeprecationWarning.
+    Setting a non-deprecated backend ('sparse'), and a priority list where no
+    deprecated backend precedes a supported one, should not emit a
+    DeprecationWarning.
 
     Returns
     -------
@@ -433,7 +467,7 @@ def test_set_option_non_cupy_no_warning(recwarn) -> None:
     """
     try:
         cl.options.set_option('ARRAY_BACKEND', 'sparse')
-        cl.options.set_option('ARRAY_PRIORITY', ['dask', 'sparse', 'numpy'])
+        cl.options.set_option('ARRAY_PRIORITY', ['sparse', 'numpy'])
         assert not [w for w in recwarn if issubclass(w.category, DeprecationWarning)]
     finally:
         cl.options.reset_option('ARRAY_BACKEND')
@@ -459,6 +493,67 @@ def test_set_backend_cupy_deprecated(clrd) -> None:
     # internal recursive / deep child conversion.
     assert len(cupy_warnings) == 1
     assert cupy_warnings[0].filename == __file__
+
+
+def test_set_backend_dask_deprecated(clrd) -> None:
+    """
+    Triangle.set_backend('dask') should emit exactly one DeprecationWarning,
+    pointing at the caller. See issue #842.
+
+    Returns
+    -------
+    None
+    """
+    with pytest.warns(DeprecationWarning, match="dask") as record:
+        try:
+            clrd.set_backend('dask', deep=True)
+        except Exception:
+            # The actual conversion can fail when the optional 'dask'
+            # dependency is not installed; we only care that the deprecation
+            # warning fired at the public entry point.
+            pass
+    dask_warnings = [
+        w for w in record
+        if issubclass(w.category, DeprecationWarning) and "dask" in str(w.message)
+    ]
+    assert len(dask_warnings) == 1
+    assert dask_warnings[0].filename == __file__
+
+
+def test_triangle_dask_input_deprecated() -> None:
+    """
+    Passing a non-pandas (Dask) dataframe to the Triangle constructor should
+    emit a DeprecationWarning. The 'dask' dependency is optional and not
+    installed in the test environment, so a pandas subclass is used to take
+    the same non-pandas code path in ``_aggregate_data``. See issue #842.
+
+    Returns
+    -------
+    None
+    """
+    class _NonPandasFrame(pd.DataFrame):
+        @property
+        def _constructor(self):
+            return _NonPandasFrame
+
+    data = _NonPandasFrame({
+        "origin": [2020, 2020, 2021],
+        "development": [2020, 2021, 2021],
+        "values": [100.0, 150.0, 200.0],
+    })
+    with pytest.warns(DeprecationWarning, match="dask") as record:
+        cl.Triangle(
+            data,
+            origin="origin",
+            development="development",
+            columns="values",
+        )
+    dask_warnings = [
+        w for w in record
+        if issubclass(w.category, DeprecationWarning) and "dask" in str(w.message)
+    ]
+    assert len(dask_warnings) == 1
+    assert dask_warnings[0].filename == __file__
 
 
 def test_describe_option(capsys: CaptureFixture[str]) -> None:

--- a/chainladder/utils/tests/test_utilities.py
+++ b/chainladder/utils/tests/test_utilities.py
@@ -522,21 +522,27 @@ def test_set_backend_dask_deprecated(clrd) -> None:
 
 def test_triangle_dask_input_deprecated() -> None:
     """
-    Passing a non-pandas (Dask) dataframe to the Triangle constructor should
-    emit a DeprecationWarning. The 'dask' dependency is optional and not
-    installed in the test environment, so a pandas subclass is used to take
-    the same non-pandas code path in ``_aggregate_data``. See issue #842.
+    Passing a Dask dataframe to the Triangle constructor should emit a
+    DeprecationWarning. The 'dask' dependency is optional and not installed in
+    the test environment, so a pandas subclass whose module is spoofed to
+    'dask' is used to take the same non-pandas code path in ``_aggregate_data``
+    while still supporting the pandas operations performed there. See issue
+    #842.
 
     Returns
     -------
     None
     """
-    class _NonPandasFrame(pd.DataFrame):
+    class _FakeDaskFrame(pd.DataFrame):
         @property
         def _constructor(self):
-            return _NonPandasFrame
+            return _FakeDaskFrame
 
-    data = _NonPandasFrame({
+    # The warning is gated on the data's top-level module being 'dask', so the
+    # detection mirrors a real dask dataframe (e.g. dask.dataframe.core).
+    _FakeDaskFrame.__module__ = "dask.dataframe.core"
+
+    data = _FakeDaskFrame({
         "origin": [2020, 2020, 2021],
         "development": [2020, 2021, 2021],
         "values": [100.0, 150.0, 200.0],
@@ -554,6 +560,40 @@ def test_triangle_dask_input_deprecated() -> None:
     ]
     assert len(dask_warnings) == 1
     assert dask_warnings[0].filename == __file__
+
+
+def test_triangle_pandas_subclass_no_dask_warning(recwarn) -> None:
+    """
+    Passing a pandas subclass (not a Dask dataframe) to the Triangle
+    constructor should not emit the dask DeprecationWarning, even though such
+    inputs take the same non-pandas code path in ``_aggregate_data``. See
+    issue #842.
+
+    Returns
+    -------
+    None
+    """
+    class _PandasSubclass(pd.DataFrame):
+        @property
+        def _constructor(self):
+            return _PandasSubclass
+
+    data = _PandasSubclass({
+        "origin": [2020, 2020, 2021],
+        "development": [2020, 2021, 2021],
+        "values": [100.0, 150.0, 200.0],
+    })
+    cl.Triangle(
+        data,
+        origin="origin",
+        development="development",
+        columns="values",
+    )
+    dask_warnings = [
+        w for w in recwarn
+        if issubclass(w.category, DeprecationWarning) and "dask" in str(w.message)
+    ]
+    assert dask_warnings == []
 
 
 def test_describe_option(capsys: CaptureFixture[str]) -> None:


### PR DESCRIPTION
## Summary of Changes

Emits a `DeprecationWarning` when the dask array backend is selected, without removing any functionality, mirroring the cupy deprecation in #881. dask is elective and not well maintained, so it's slated for removal in a future release (#601).

Unlike cupy, dask has an extra entry point: a dask dataframe passed directly to the `Triangle` constructor. So this warns at four points:

- `set_option("ARRAY_BACKEND", "dask")`
- `set_option("ARRAY_PRIORITY", ...)` when dask is ranked ahead of numpy or sparse
- `Triangle.set_backend("dask")` (once, at the user's call site)
- `Triangle(data=...)` when `data` is a dask dataframe (the `_aggregate_data` path @genedan flagged on the issue)

Refactored the cupy warning into two small shared helpers in `__init__.py` (`_DEPRECATED_BACKENDS` mapping + `_deprecated_backend_message`) so cupy and dask share one code path and message format instead of duplicated blocks.

Added tests for each dask warning path and the no-warn cases. The dask constructor test uses a pandas subclass to exercise the non-pandas branch, since dask is an optional dependency not installed in the test environment.

## Related GitHub Issue(s)

Closes #842.

Deprecation only (warnings), no removal, consistent with #843/#881 and @henrydingliu's note on not taking functionality away before 1.0.

## Additional Context for Reviewers

@genedan thanks for flagging `_aggregate_data` - that's the constructor entry point covered by the fourth warning above.

The default priority `["dask", "sparse", "cupy", "numpy"]` has dask ahead of numpy/sparse, so explicitly re-setting that default would warn. Same caveat as cupy; happy to adjust if you'd rather the default never warns.

- `uv run --extra dev pytest -k "deprecat or dask or cupy"` passed, 13 tests
- `uv run --extra dev pytest chainladder/core/tests/` passed, 350 passed / 11 xfailed
- `uv run jb build docs --builder=custom --custom-builder=doctest` passed, 111 tests, 0 failures

- [x] I passed tests locally for both code (`uv run pytest`) and documentation changes (`uv run jb build docs --builder=custom --custom-builder=doctest`)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Warnings-only change with no removal of functionality; behavior is limited to when DeprecationWarnings are emitted and shared message formatting.
> 
> **Overview**
> **Deprecates the dask array backend** with `DeprecationWarning`s (no behavior removal), aligned with the existing cupy deprecation (#843).
> 
> Shared helpers `_DEPRECATED_BACKENDS` and `_deprecated_backend_message` in `chainladder/__init__.py` replace cupy-only warning text. `set_option` now warns for **cupy or dask** on `ARRAY_BACKEND`, and on `ARRAY_PRIORITY` when either deprecated backend ranks ahead of `numpy` or `sparse`. `Triangle.set_backend` uses the same map for both backends.
> 
> A new warning fires when `Triangle(...)` receives input whose top-level module is `dask` in `_aggregate_data` (non-pandas path), without warning ordinary pandas subclasses on that path.
> 
> Tests cover dask paths for options, `set_backend`, constructor input (via a module-spoofed fake dask frame), no-warn cases, and renamed/generalized cupy tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4caefb73f672f1136a52de0a726f3050b489ac07. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->