### PR TITLE
Util weight

### DIFF
--- a/chainladder/__init__.py
+++ b/chainladder/__init__.py
@@ -387,6 +387,7 @@ options = Options()
 
 from chainladder.utils import (  # noqa (API import)
     WeightedRegression,
+    TriangleWeight,
     parallelogram_olf,
     read_csv,
     read_pickle,

--- a/chainladder/development/tests/test_development.py
+++ b/chainladder/development/tests/test_development.py
@@ -221,7 +221,6 @@ def test_drophighlow_inequal(prism,atol):
     no_drop = dev0.fit_transform(tri).cdf_.to_frame().values
     drop_high = dev1.fit_transform(tri).cdf_.to_frame().values
     drop_low = dev2.fit_transform(tri).cdf_.to_frame().values
-    print(_FutureDevelopment(dev2).fit(tri).ldf_)
     assert (drop_low >= no_drop).all()
     assert (no_drop >= drop_high).all()
     assert (_FutureDevelopment(dev2).fit(tri).ldf_.values >= _FutureDevelopment(dev0).fit(tri).ldf_.values).all()
@@ -305,7 +304,6 @@ def test_drop_valuation_2(qtr):
     dev2 = cl.Development(drop_valuation="1995-03-31")
     dev3 = cl.Development(drop_valuation="1995-06-30")
     dev4 = cl.Development(drop_valuation="1995-09-30")
-
     assert (
         dev1.fit_transform(qtr["incurred"]).cdf_
         != dev2.fit_transform(qtr["incurred"]).cdf_

--- a/chainladder/development/tests/test_development.py
+++ b/chainladder/development/tests/test_development.py
@@ -2,78 +2,156 @@ import numpy as np
 import chainladder as cl
 import pytest
 
-
-def test_full_slice():
+class _FutureDevelopment(cl.TriangleWeight):
+    '''
+    An internal class to assist with the testing of the TriangleWeight utility class
+    '''
+    def __init__(self,dev):
+        super().__init__(
+            n_periods=dev.n_periods,
+            drop=dev.drop,
+            drop_high=dev.drop_high,
+            drop_low=dev.drop_low,
+            preserve=dev.preserve,
+            drop_valuation=dev.drop_valuation,
+            drop_above=dev.drop_above,
+            drop_below=dev.drop_below
+        )    
+        self.average = dev.average
+        self.dev = dev
+    
+    def fit(self, X, y: None = None, sample_weight: None = None):
+        if hasattr(X,'age_to_age'):
+            super().fit(X.incr_to_cum().age_to_age)
+            xp = X.get_array_module()
+            indices = X.values.shape[0]
+            columns = X.values.shape[1]
+            origins = X.age_to_age.values.shape[2]
+            reg_x = X.incr_to_cum().values[...,:origins,:-1]
+            reg_y = X.incr_to_cum().values[...,:origins,1:]
+            dev_len = reg_x.shape[3]
+            average_param = self._cascade_param(dev_len, self.average, "volume")
+            average_param = np.tile(average_param,(indices,columns,1,1))
+            params = cl.WeightedRegression(axis=2, thru_orig=True, xp=xp).fit(
+                reg_x, reg_y, self.w_.values, average_param
+            )
+            self.ldf_ = self.dev._param_property(X, xp.swapaxes(params.slope_, 2, 3), 0)
+        return self
+    
+def test_full_slice(genins):
+    dev1 = cl.Development()
+    dev2 = cl.Development(n_periods=1000)
     assert (
-        cl.Development().fit_transform(cl.load_sample("GenIns")).ldf_
-        == cl.Development(n_periods=1000).fit_transform(cl.load_sample("GenIns")).ldf_
+        dev1.fit_transform(genins).ldf_
+        == dev2.fit_transform(genins).ldf_
+    )
+    assert (
+        dev1.fit_transform(genins).ldf_
+        == _FutureDevelopment(dev1).fit(genins).ldf_
+    )
+    assert (
+        _FutureDevelopment(dev1).fit(genins).ldf_
+        == _FutureDevelopment(dev2).fit(genins).ldf_
     )
 
-
-def test_full_slice2():
+def test_full_slice2(genins):
+    dev1 = cl.Development()
+    dev2 = cl.Development(n_periods=[1000] * (genins.shape[3] - 1))
     assert (
-        cl.Development().fit_transform(cl.load_sample("GenIns")).ldf_
-        == cl.Development(n_periods=[1000] * (cl.load_sample("GenIns").shape[3] - 1))
-        .fit_transform(cl.load_sample("GenIns"))
-        .ldf_
+        dev1.fit_transform(genins).ldf_
+        == dev2.fit_transform(genins).ldf_
     )
-
+    assert (
+        dev1.fit_transform(genins).ldf_
+        == _FutureDevelopment(dev1).fit(genins).ldf_
+    )
+    assert (
+        _FutureDevelopment(dev1).fit(genins).ldf_
+        == _FutureDevelopment(dev2).fit(genins).ldf_
+    )
 
 def test_drop1(raa):
+    dev1 = cl.Development(drop=("1982", 12))
+    dev2 = cl.Development(drop_high=[True] + [False] * 8)
     assert (
-        cl.Development(drop=("1982", 12)).fit(raa).ldf_.values[0, 0, 0, 0]
-        == cl.Development(drop_high=[True] + [False] * 8)
-        .fit(raa)
-        .ldf_.values[0, 0, 0, 0]
+        dev1.fit(raa).ldf_.values[0, 0, 0, 0]
+        == dev2.fit(raa).ldf_.values[0, 0, 0, 0]
+    )
+    assert (
+        dev1.fit_transform(raa).ldf_.values[0, 0, 0, 0]
+        == _FutureDevelopment(dev1).fit(raa).ldf_.values[0, 0, 0, 0]
+    )
+    assert (
+        _FutureDevelopment(dev1).fit(raa).ldf_.values[0, 0, 0, 0]
+        == _FutureDevelopment(dev2).fit(raa).ldf_.values[0, 0, 0, 0]
     )
 
-
 def test_drop2(raa):
+    dev1 = cl.Development(drop_valuation="1981")
+    dev2 = cl.Development(drop_low=[True] + [False] * 8)
     assert (
-        cl.Development(drop_valuation="1981").fit(raa).ldf_.values[0, 0, 0, 0]
-        == cl.Development(drop_low=[True] + [False] * 8)
-        .fit(raa)
-        .ldf_.values[0, 0, 0, 0]
+        dev1.fit(raa).ldf_.values[0, 0, 0, 0]
+        == dev2.fit(raa).ldf_.values[0, 0, 0, 0]
+    )
+    assert (
+        dev1.fit_transform(raa).ldf_.values[0, 0, 0, 0]
+        == _FutureDevelopment(dev1).fit(raa).ldf_.values[0, 0, 0, 0]
+    )
+    assert (
+        _FutureDevelopment(dev1).fit(raa).ldf_.values[0, 0, 0, 0]
+        == _FutureDevelopment(dev2).fit(raa).ldf_.values[0, 0, 0, 0]
     )
 
 
 def test_n_periods():
     d = cl.load_sample("usauto")["incurred"]
     xp = np if d.array_backend == "sparse" else d.get_array_module()
+    dev = cl.Development(n_periods=3, average="volume")
     assert xp.all(
         xp.around(
             xp.unique(
-                cl.Development(n_periods=3, average="volume").fit(d).ldf_.values,
+                dev.fit(d).ldf_.values,
                 axis=-2,
             ),
             3,
         ).flatten()
         == xp.array([1.164, 1.056, 1.027, 1.012, 1.005, 1.003, 1.002, 1.001, 1.0])
     )
+    assert (
+        dev.fit_transform(d).ldf_
+        == _FutureDevelopment(dev).fit(d).ldf_
+    )
 
-
-def test_drophighlow():
-    raa = cl.load_sample("raa")
-
-    lhs = np.round(cl.Development(drop_high=0).fit(raa).cdf_.values, 4).flatten()
+def test_drophighlow(raa):
+    dev = cl.Development(drop_high=0)
+    lhs = np.round(dev.fit(raa).cdf_.values, 4).flatten()
     rhs = np.array(
         [8.9202, 2.974, 1.8318, 1.4414, 1.2302, 1.1049, 1.0604, 1.0263, 1.0092]
     )
     assert np.all(lhs == rhs)
+    assert (
+        dev.fit_transform(raa).ldf_
+        == _FutureDevelopment(dev).fit(raa).ldf_
+    )
 
-    lhs = np.round(
-        cl.Development(drop_high=[True, False, True, False]).fit(raa).cdf_.values, 4
-    ).flatten()
+    dev = cl.Development(drop_high=[True, False, True, False])
+    lhs = np.round(dev.fit(raa).cdf_.values, 4).flatten()
     rhs = np.array(
         [8.0595, 2.8613, 1.7624, 1.4414, 1.2302, 1.1049, 1.0604, 1.0263, 1.0092]
     )
     assert np.all(lhs == rhs)
+    assert (
+        dev.fit_transform(raa).ldf_
+        == _FutureDevelopment(dev).fit(raa).ldf_
+    )
 
-    with pytest.warns(UserWarning, match="exclusions have been ignored"):
-        dev = cl.Development(
+    dev = cl.Development(
             drop_high=[2, 3, 3, 3], drop_low=[0, 1, 0], preserve=2
-        ).fit(raa)
-    lhs = np.round(dev.cdf_.values, 4).flatten()
+        )
+    with pytest.warns(UserWarning, match="exclusions have been ignored"):
+        tr = dev.fit_transform(raa)
+        tw = _FutureDevelopment(dev).fit(raa)
+    lhs = np.round(tr.cdf_.values, 4).flatten()
     rhs = np.array(
         [
             5.7403,
@@ -88,146 +166,195 @@ def test_drophighlow():
         ]
     )
     assert np.all(lhs == rhs)
+    assert tr.ldf_ == tw.ldf_
 
+    dev = cl.Development(drop_high=1)
     with pytest.warns(UserWarning, match="exclusions have been ignored"):
-        dev = cl.Development(drop_high=1).fit(raa)
-    lhs = np.round(dev.cdf_.values, 4).flatten()
+        tr = dev.fit_transform(raa)
+        tw = _FutureDevelopment(dev).fit(raa)
+    lhs = np.round(tr.cdf_.values, 4).flatten()
     rhs = np.array(
         [7.2190, 2.5629, 1.6592, 1.3570, 1.1734, 1.0669, 1.0419, 1.0121, 1.0092]
     )
     assert np.all(lhs == rhs)
+    assert tr.ldf_ == tw.ldf_
 
+    dev = cl.Development(drop_high=1, drop_low=1)
     with pytest.warns(UserWarning, match="exclusions have been ignored"):
-        dev = cl.Development(drop_high=1, drop_low=1).fit(raa)
-    lhs = np.round(dev.cdf_.values, 4).flatten()
+        tr = dev.fit_transform(raa)
+        tw = _FutureDevelopment(dev).fit(raa)
+    lhs = np.round(tr.cdf_.values, 4).flatten()
     rhs = np.array(
         [9.0982, 2.8731, 1.8320, 1.4713, 1.2522, 1.0963, 1.0604, 1.0263, 1.0092]
     )
     assert np.all(lhs == rhs)
+    assert tr.ldf_ == tw.ldf_
 
+    dev = cl.Development(drop_high=[2, 1, 1], drop_low=1)
     with pytest.warns(UserWarning, match="exclusions have been ignored"):
-        dev = cl.Development(drop_high=[2, 1, 1], drop_low=1).fit(raa)
-    lhs = np.round(dev.cdf_.values, 4).flatten()
+        tr = dev.fit_transform(raa)
+        tw = _FutureDevelopment(dev).fit(raa)
+    lhs = np.round(tr.cdf_.values, 4).flatten()
     rhs = np.array(
         [8.4905, 3.0589, 1.9504, 1.5664, 1.3142, 1.1403, 1.0822, 1.0426, 1.0092]
     )
     assert np.all(lhs == rhs)
+    assert tr.ldf_ == tw.ldf_
 
+    dev = cl.Development(drop_high=1, drop_low=1, n_periods=5)
     with pytest.warns(UserWarning, match="exclusions have been ignored"):
-        dev = cl.Development(drop_high=1, drop_low=1, n_periods=5).fit(raa)
-    lhs = np.round(dev.cdf_.values, 4).flatten()
+        tr = dev.fit_transform(raa)
+        tw = _FutureDevelopment(dev).fit(raa)
+    lhs = np.round(tr.cdf_.values, 4).flatten()
     rhs = np.array(
         [16.3338, 3.2092, 1.8124, 1.4793, 1.2522, 1.0963, 1.0604, 1.0263, 1.0092]
     )
     assert np.all(lhs == rhs)
+    assert tr.ldf_ == tw.ldf_
 
-    tri = cl.load_sample("prism")["Paid"].sum().grain("OYDQ")
-    no_drop = cl.Development().fit_transform(tri).cdf_.to_frame().values
-    drop_high = cl.Development(drop_high=True).fit_transform(tri).cdf_.to_frame().values
-    drop_low = cl.Development(drop_low=True).fit_transform(tri).cdf_.to_frame().values
+
+def test_drophighlow_inequal(prism,atol):
+    tri = prism["Paid"].sum().grain("OYDQ")
+    dev0 = cl.Development()
+    dev1 = cl.Development(drop_high=True)
+    dev2 = cl.Development(drop_low=True)
+    no_drop = dev0.fit_transform(tri).cdf_.to_frame().values
+    drop_high = dev1.fit_transform(tri).cdf_.to_frame().values
+    drop_low = dev2.fit_transform(tri).cdf_.to_frame().values
+    print(_FutureDevelopment(dev2).fit(tri).ldf_)
     assert (drop_low >= no_drop).all()
     assert (no_drop >= drop_high).all()
+    assert (_FutureDevelopment(dev2).fit(tri).ldf_.values >= _FutureDevelopment(dev0).fit(tri).ldf_.values).all()
+    assert (_FutureDevelopment(dev0).fit(tri).ldf_.values >= _FutureDevelopment(dev1).fit(tri).ldf_.values).all()
 
 
-def test_dropabovebelow():
-    raa = cl.load_sample("raa")
-
-    lhs = np.round(cl.Development(drop_above=40.0).fit(raa).cdf_.values, 4).flatten()
+def test_dropabovebelow(raa):
+    dev = cl.Development(drop_above=40.0)
+    lhs = np.round(dev.fit(raa).cdf_.values, 4).flatten()
     rhs = np.array(
         [8.3771, 2.9740, 1.8318, 1.4414, 1.2302, 1.1049, 1.0604, 1.0263, 1.0092]
     )
     assert np.all(lhs == rhs)
+    assert dev.fit(raa).ldf_ == _FutureDevelopment(dev).fit(raa).ldf_
 
-    lhs = np.round(cl.Development(drop_above=1.2).fit(raa).cdf_.values, 4).flatten()
+    dev = cl.Development(drop_above=1.2)
+    lhs = np.round(dev.fit(raa).cdf_.values, 4).flatten()
     rhs = np.array(
         [7.6859, 2.5625, 1.5784, 1.4072, 1.2302, 1.1049, 1.0604, 1.0263, 1.0092]
     )
     assert np.all(lhs == rhs)
+    assert dev.fit(raa).ldf_ == _FutureDevelopment(dev).fit(raa).ldf_
 
-    lhs = np.round(
-        cl.Development(drop_above=1.2, drop_below=1.05).fit(raa).cdf_.values, 4
-    ).flatten()
+    dev = cl.Development(drop_above=1.2, drop_below=1.05)
+    lhs = np.round(dev.fit(raa).cdf_.values, 4).flatten()
     rhs = np.array(
         [8.4983, 2.8334, 1.7452, 1.5560, 1.3602, 1.1802, 1.0604, 1.0263, 1.0092]
     )
     assert np.all(lhs == rhs)
+    assert dev.fit(raa).ldf_ == _FutureDevelopment(dev).fit(raa).ldf_
 
-    lhs = np.round(
-        cl.Development(drop_above=[40.0], drop_below=[0.0, 0.0, 1.05, 1.7])
-        .fit(raa)
-        .cdf_.values,
-        4,
-    ).flatten()
+    dev = cl.Development(drop_above=[40.0], drop_below=[0.0, 0.0, 1.05, 1.7])
+    lhs = np.round(dev.fit(raa).cdf_.values,4,).flatten()
     rhs = np.array(
         [8.3771, 2.9740, 1.8318, 1.4414, 1.2302, 1.1049, 1.0604, 1.0263, 1.0092]
     )
     assert np.all(lhs == rhs)
+    assert dev.fit(raa).ldf_ == _FutureDevelopment(dev).fit(raa).ldf_
 
-    lhs = np.round(
-        cl.Development(drop_above=[40.0], drop_below=[0.0, 0.0, 1.05, 1.2])
-        .fit(raa)
-        .cdf_.values,
-        4,
-    ).flatten()
+    dev = cl.Development(drop_above=[40.0], drop_below=[0.0, 0.0, 1.05, 1.2])
+    lhs = np.round(dev.fit(raa).cdf_.values,4,).flatten()
     rhs = np.array(
         [8.9773, 3.1871, 1.9631, 1.5447, 1.2302, 1.1049, 1.0604, 1.0263, 1.0092]
     )
     assert np.all(lhs == rhs)
+    assert dev.fit(raa).ldf_ == _FutureDevelopment(dev).fit(raa).ldf_
 
 
-def test_drop_valuation():
-    raa = cl.load_sample("raa")
+def test_drop_valuation_1(raa):
+    dev1 = cl.Development(drop_valuation="1981-12-31")
+    dev2 = cl.Development(drop_valuation="1982-12-31")
+    dev3 = cl.Development(drop_valuation="1983-12-31")
     assert (
-        cl.Development(drop_valuation="1981-12-31").fit_transform(raa).cdf_
-        != cl.Development(drop_valuation="1982-12-31").fit_transform(raa).cdf_
+        dev1.fit_transform(raa).cdf_
+        != dev2.fit_transform(raa).cdf_
     )
     assert (
-        cl.Development(drop_valuation="1982-12-31").fit_transform(raa).cdf_
-        != cl.Development(drop_valuation="1983-12-31").fit_transform(raa).cdf_
+        dev2.fit_transform(raa).cdf_
+        != dev3.fit_transform(raa).cdf_
     )
     assert (
-        cl.Development(drop_valuation="1981-12-31").fit_transform(raa).cdf_
-        != cl.Development(drop_valuation="1983-12-31").fit_transform(raa).cdf_
-    )
-
-    quarterly = cl.load_sample("quarterly")
-    assert (
-        cl.Development().fit_transform(quarterly["incurred"]).cdf_
-        != cl.Development(drop_valuation="1995-03-31")
-        .fit_transform(quarterly["incurred"])
-        .cdf_
+        dev1.fit_transform(raa).cdf_
+        != dev3.fit_transform(raa).cdf_
     )
     assert (
-        cl.Development().fit_transform(quarterly["incurred"]).cdf_
-        != cl.Development(drop_valuation="1995-06-30")
-        .fit_transform(quarterly["incurred"])
-        .cdf_
+        _FutureDevelopment(dev1).fit(raa).ldf_
+        != _FutureDevelopment(dev2).fit(raa).ldf_
     )
     assert (
-        cl.Development(drop_valuation="1995-03-31")
-        .fit_transform(quarterly["incurred"])
-        .cdf_
-        != cl.Development(drop_valuation="1995-06-30")
-        .fit_transform(quarterly["incurred"])
-        .cdf_
+        _FutureDevelopment(dev2).fit(raa).ldf_
+        != _FutureDevelopment(dev3).fit(raa).ldf_
     )
     assert (
-        cl.Development(drop_valuation="1995-06-30")
-        .fit_transform(quarterly["incurred"])
-        .cdf_
-        != cl.Development(drop_valuation="1995-09-30")
-        .fit_transform(quarterly["incurred"])
-        .cdf_
+        _FutureDevelopment(dev1).fit(raa).ldf_
+        != _FutureDevelopment(dev3).fit(raa).ldf_
     )
 
 
-def test_assymetric_development(atol):
-    quarterly = cl.load_sample("quarterly")["paid"]
+def test_drop_valuation_2(qtr):
+    dev1 = cl.Development()
+    dev2 = cl.Development(drop_valuation="1995-03-31")
+    dev3 = cl.Development(drop_valuation="1995-06-30")
+    dev4 = cl.Development(drop_valuation="1995-09-30")
+
+    assert (
+        dev1.fit_transform(qtr["incurred"]).cdf_
+        != dev2.fit_transform(qtr["incurred"]).cdf_
+    )
+    assert (
+        dev1.fit_transform(qtr["incurred"]).cdf_
+        != dev3.fit_transform(qtr["incurred"]).cdf_
+    )
+    assert (
+        dev2.fit_transform(qtr["incurred"]).cdf_
+        != dev3.fit_transform(qtr["incurred"]).cdf_
+    )
+    assert (
+        dev3.fit_transform(qtr["incurred"]).cdf_
+        != dev4.fit_transform(qtr["incurred"]).cdf_
+    )
+    assert (
+        _FutureDevelopment(dev1).fit(qtr["incurred"]).ldf_
+        != _FutureDevelopment(dev2).fit(qtr["incurred"]).ldf_
+    )
+    assert (
+        _FutureDevelopment(dev1).fit(qtr["incurred"]).ldf_
+        != _FutureDevelopment(dev3).fit(qtr["incurred"]).ldf_
+    )
+    assert (
+        _FutureDevelopment(dev2).fit(qtr["incurred"]).ldf_
+        != _FutureDevelopment(dev3).fit(qtr["incurred"]).ldf_
+    )
+    assert (
+        _FutureDevelopment(dev3).fit(qtr["incurred"]).ldf_
+        != _FutureDevelopment(dev4).fit(qtr["incurred"]).ldf_
+    )
+
+
+def test_assymetric_development(qtr,atol):
+    quarterly = qtr["paid"]
     xp = np if quarterly.array_backend == "sparse" else quarterly.get_array_module()
-    dev = cl.Development(n_periods=1, average="simple").fit(quarterly)
-    dev2 = cl.Development(n_periods=1, average="regression").fit(quarterly)
-    assert xp.allclose(dev.ldf_.values, dev2.ldf_.values, atol=atol)
-
+    dev1 = cl.Development(n_periods=1, average="simple")
+    dev2 = cl.Development(n_periods=1, average="regression")
+    assert xp.allclose(
+        dev1.fit(quarterly).ldf_.values, 
+        dev2.fit(quarterly).ldf_.values, 
+        atol=atol
+    )
+    assert xp.allclose(
+        _FutureDevelopment(dev1).fit(quarterly).ldf_.values,
+        _FutureDevelopment(dev2).fit(quarterly).ldf_.values,
+        atol=atol
+    )
 
 def test_hilo_multiple_indices(clrd):
     tri = clrd.groupby("LOB")["CumPaidLoss"].sum()
@@ -316,17 +443,16 @@ def test_new_drop_7(clrd):
     compare_new_drop(dev, clrd)
 
 
-def test_new_drop_8():
-    tri = cl.load_sample("prism")["Paid"].sum().grain("OYDQ")
-
+def test_new_drop_8(prism):
+    tri = prism["Paid"].sum().grain("OYDQ")
     try:
         cl.Development(drop_high=False).fit_transform(tri)
     except:
         assert False
 
 
-def test_new_drop_9():
-    tri = cl.load_sample("prism")["Paid"].sum().grain("OYDQ")
+def test_new_drop_9(prism):
+    tri = prism["Paid"].sum().grain("OYDQ")
 
     lhs = cl.Development(drop_high=True).fit(tri).cdf_.to_frame().fillna(0).values
     rhs = cl.Development(drop_high=1).fit(tri).cdf_.to_frame().fillna(0).values

--- a/chainladder/tests/test_public_api.py
+++ b/chainladder/tests/test_public_api.py
@@ -24,6 +24,7 @@ EXPECTED_PUBLIC_API = {
     "ValuationCorrelation",
     # utils
     "WeightedRegression",
+    "TriangleWeight",
     "parallelogram_olf",
     "read_csv",
     "read_pickle",

--- a/chainladder/utils/__init__.py
+++ b/chainladder/utils/__init__.py
@@ -5,6 +5,10 @@ from chainladder.utils.weighted_regression import (
     WeightedRegression,
 )  # noqa (API import)
 
+from chainladder.utils.triangle_weight import (
+    TriangleWeight,
+)  # noqa (API import)
+
 from chainladder.utils.utility_functions import (  # noqa (API import)
     parallelogram_olf,
     read_csv,
@@ -24,6 +28,7 @@ from chainladder.utils.dask import dp
 
 __all__ = [
     "WeightedRegression",
+    "TriangleWeight",
     "parallelogram_olf",
     "read_csv",
     "read_pickle",

--- a/chainladder/utils/triangle_weight.py
+++ b/chainladder/utils/triangle_weight.py
@@ -1,0 +1,518 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+from chainladder.utils.sparse import sp
+from sklearn.base import BaseEstimator, TransformerMixin
+import warnings
+
+from chainladder.utils.utility_functions import num_to_nan
+from pandas.api.types import is_string_dtype
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from chainladder.core.typing import TriangleLike
+
+class TriangleWeight(BaseEstimator,TransformerMixin):
+    """
+    Helper class that produces a triangle of weights based on pattern selections
+
+    Parameters
+    ----------
+    n_periods: integer, optional (default = -1)
+        number of origin periods to be used in the ldf average calculation. For
+        all origin periods, set n_periods = -1
+    drop: tuple or list of tuples
+        Drops specific origin/development combination(s). See order of operations
+        below when combined with multiple drop parameters.
+    drop_high: bool, int, list of bools, or list of ints (default = None)
+        Drops highest (by rank) link ratio(s) from LDF calculation
+        If a boolean variable is passed, drop_high is set to 1, dropping only the
+        highest value. Protected by ``preserve``.
+        See order of operations below when combined with multiple drop parameters.
+    drop_low: bool, int, list of bools, or list of ints (default = None)
+        Drops lowest (by rank) link ratio(s) from LDF calculation
+        If a boolean variable is passed, drop_low is set to 1, dropping only the
+        lowest value. Protected by ``preserve``.
+        See order of operations below when combined with multiple drop parameters.
+    drop_above: float or list of floats (default = numpy.inf)
+        Drops all link ratio(s) above the given parameter from the LDF calculation.
+        Protected by ``preserve``.
+        See order of operations below when combined with multiple drop parameters.
+    drop_below: float or list of floats (default = 0.00)
+        Drops all link ratio(s) below the given parameter from the LDF calculation.
+        Protected by ``preserve``.
+        See order of operations below when combined with multiple drop parameters.
+    preserve: int (default = 1)
+        The minimum number of link ratio(s) required for LDF calculation.
+        See order of operations below when combined with multiple drop parameters.
+    drop_valuation: str or list of str (default = None)
+        Drops specific valuation periods. str must be date convertible.
+        See order of operations below when combined with multiple drop parameters.
+
+        .. note ::
+    
+            (Order of Drop Operations)
+            
+            When multiple drop parameters are used together, the weights are built in this order:
+        
+            1. ``n_periods`` — limit to the most recent origin periods.
+            2. ``drop`` — remove specific origin/development cells.
+            3. ``drop_valuation`` — remove entire valuation diagonal in the triangle.
+            4. ``drop_high`` / ``drop_low`` — remove highest/lowest link ratios by rank
+               (eligible factors from ``n_periods`` are used; protected by ``preserve``,
+               which may relax exclusions from this step if too few ratios would remain then this step is skipped).
+            5. ``drop_above`` / ``drop_below`` — remove link ratios outside a range
+               (Protected by``preserve``, which may relax exclusions from this step if too few ratios would remain
+               then this step is skipped).
+            6. Calculate the loss development factors using ``average`` method.
+
+    Attributes
+    ----------
+    w_: Triangle
+        The weight
+    """
+
+    def __init__(
+        self,
+        n_periods: int = -1,
+        drop: tuple | list[tuple] | None = None,
+        drop_high: bool | int | list[bool] | list[int] | None = None,
+        drop_low: bool | int | list[bool] | list[int] | None = None,
+        preserve: int = 1,
+        drop_valuation: str | list[str] = None,
+        drop_above: float = np.inf,
+        drop_below: float = 0.00,
+    ):
+        self.n_periods = n_periods
+        self.drop_high = drop_high
+        self.drop_low = drop_low
+        self.preserve = preserve
+        self.drop_valuation = drop_valuation
+        self.drop_above = drop_above
+        self.drop_below = drop_below
+        self.drop = drop
+
+    def fit(self, X: TriangleLike, y: None = None, sample_weight: None = None):
+        """
+        Fit the model with X.
+
+        Parameters
+        ----------
+        X : TriangleLike
+            Set of LDFs to which the Munich adjustment will be applied.
+        y : None
+            Ignored
+        sample_weight : None
+            Ignored
+
+        Returns
+        -------
+        self : object
+            Returns the instance itself.
+        """
+
+        if hasattr(X, "w_"):
+            self.w_ = self._set_weight_func(
+                X=X * X.w_,
+            )
+        else:
+            self.w_ = self._set_weight_func(
+                X=X,
+            )
+        return self
+
+    def transform(self, X: TriangleLike):
+        """If X and self are of different shapes, align self to X, else
+        return self.
+
+        Parameters
+        ----------
+        X : Triangle
+            The triangle to be transformed
+
+        Returns
+        -------
+        X_new : New triangle with transformed attributes.
+
+        """
+        X_new = X.copy()
+        X_new.w_ = self.w_
+        return X_new
+
+    def _cascade_param(
+            self, 
+            size:int, 
+            param: bool | int | float | str | None | list[bool|int|float|str|None], 
+            default_param: bool | int | float | str | None
+    ) -> np.ndarray:
+        """
+        Internal helper function to explicitly cascade a parameter to a given triangle size
+
+        Parameters
+        ----------
+        size: integer
+            the width of the triangle
+        param: bool or int or float or str or None or list
+            the selected parameter, such as n_periods or drop_low, etc. 
+        default_param: bool or int or float or str or None
+            the default param to fill where unspecificied
+
+        Returns
+        -------
+        numpy array of the cascaded parameter
+
+        """
+        # setting dimension and default value of output
+        out = pd.Series(size * [default_param]).astype("object")
+        # an array of parameters is provided
+        if isinstance(param, list):
+            out[range(len(param))] = np.array(param)
+        # only a single parameter is provided
+        else:
+            out.loc[:] = param
+        # Fill missing with default
+        out.loc[out.isna()] = default_param
+        # return properly typed numpy array
+        return out.astype(type(default_param)).to_numpy()
+
+    def _set_weight_func(
+            self,
+            X: TriangleLike,
+            secondary_rank: TriangleLike | None = None
+    ) -> TriangleLike:
+        """
+        Combines weights from all parameters
+
+        Parameters
+        ----------
+        X: TriangleLike
+            Triangle of values to be weighted
+        secondary_rank: TriangleLike
+            Triangle of values to break ties for drop_high and drop_low
+
+        Returns
+        -------
+        A Triangle of weights
+
+        """
+        w = (~np.isnan(X.values)).astype(float)
+        w = w * self._assign_n_periods_weight_func(X)
+        if self.drop is not None:
+            w = w * self._drop_func(X)
+
+        if self.drop_valuation is not None:
+            w = w * self._drop_valuation_func(X)
+
+        if (self.drop_above != np.inf) | (self.drop_below != 0.0):
+            w = w * self._drop_x_func(X)
+
+        if (self.drop_high is not None) | (self.drop_low is not None):
+            w = w * self._drop_n_func(X * num_to_nan(w), secondary_rank)
+
+        w_tri = X.copy()
+        w_tri.values = num_to_nan(w)
+
+        return w_tri
+
+    def _assign_n_periods_weight_func(self, X: TriangleLike) -> TriangleLike:
+        """
+        Generates weights for the `n_periods` parameter
+
+        Parameters
+        ----------
+        X: TriangleLike
+            Triangle of values to be weighted
+
+        Returns
+        -------
+        A Triangle of weights
+
+        """
+        # cascading n_periods across all columns
+        dev_len = X.shape[3]
+        n_periods_param = self._cascade_param(dev_len, self.n_periods, -1)
+
+        #helper function that generates the weights for individual n_periods
+        def _assign_n_periods_weight_int(X, n_periods):
+            xp = X.get_array_module()
+            val_offset = {
+                "Y": {"Y": 1},
+                "S": {"Y": 2, "S": 1},
+                "Q": {"Y": 4, "S": 2, "Q": 1},
+                "M": {"Y": 12, "S": 6, "Q": 3, "M": 1},
+            }
+            if n_periods < 1 or n_periods >= X.shape[-2]:
+                return X.values * 0 + 1
+            else:
+                val_date_min = X.valuation[X.valuation <= X.valuation_date]
+                val_date_min = val_date_min.drop_duplicates().sort_values()
+                z = -n_periods * val_offset[X.development_grain][X.origin_grain]
+                val_date_min = val_date_min[z]
+                w = X[X.valuation >= val_date_min]
+                return xp.nan_to_num((w / w).values) * X.nan_triangle
+
+        xp = X.get_array_module()
+
+        # a dict of weights (val) by n_periods (key)
+        dict_map = {
+            item: _assign_n_periods_weight_int(X, item)
+            for item in set(n_periods_param)
+        }
+        # collection of development columns based on n_periods specified for that column
+        conc = [
+            dict_map[item][..., num : num + 1]
+            for num, item in enumerate(n_periods_param)
+        ]
+        return xp.concatenate(tuple(conc), -1).astype(float)
+
+    def _drop_n_func(
+            self,
+            X: TriangleLike,
+            secondary_rank: TriangleLike | None = None
+    ) -> TriangleLike:
+        """
+        Generates weights for the `drop_high` and `drop_low` parameter
+
+        Parameters
+        ----------
+        X: TriangleLike
+            Triangle of values to be weighted
+        secondary_rank: TriangleLike
+            Triangle of values to break ties
+
+        Returns
+        -------
+        A Triangle of weights
+
+        """        
+        # Preparing to set up 3D array for drop_n parameters
+        X_val = X.values.copy()
+        dev_len = X_val.shape[3]
+        indices = X_val.shape[0]
+        columns = X_val.shape[1]
+
+        # secondary rank is the optional triangle that breaks ties in X
+        # the original use case is for dropping the link ratio of 1 with the lowest loss value
+        # (pass in a reverse rank of loss to drop link of ratio of 1 with the highest loss value)
+        # leaving to caller to ensure that secondary rank is the same dimensions as X
+        # also leaving to caller to pick whether to trim head or tail
+        if secondary_rank is None:
+            sec_rank_val = X_val.copy()
+        else:
+            sec_rank_val = secondary_rank.values.copy()
+
+        # explicitly setting up 3D arrays for drop_n parameters to avoid broadcasting bugs
+        drop_high_array = np.zeros((indices, columns, dev_len))
+        drop_high_array[:, :, :] = self._cascade_param(
+            dev_len, self.drop_high, 0
+        )[None, None]
+        drop_low_array = np.zeros((indices, columns, dev_len))
+        drop_low_array[:, :, :] = self._cascade_param(
+            dev_len, self.drop_low, 0
+        )[None, None]
+        preserve_array = np.zeros((indices, columns, dev_len))
+        preserve_array[:, :, :] = self._cascade_param(
+            dev_len, self.preserve, self.preserve
+        )[None, None]
+
+        # ranking values by itself and secondary rank
+        X_ranks = np.lexsort((sec_rank_val, X_val), axis=2).argsort(axis=2)
+
+        # counting valid values per development period
+        valid_count = (~np.isnan(X_val)).sum(axis=2)
+
+        # getting max index after drop high
+        max_rank_unpreserve = valid_count - drop_high_array
+
+        # applying preserve
+        preserve_trigger = (max_rank_unpreserve - drop_low_array) < preserve_array
+        
+        # setting up flag to produce warning
+        warning_flag = np.any(preserve_trigger)
+
+        # getting ranks of values that correspond to the max and min after preserve
+        max_rank = np.where(preserve_trigger, valid_count, max_rank_unpreserve)
+        min_rank = np.where(preserve_trigger, 0, drop_low_array)
+
+        # getting weights that are within the max and min ranks
+        w = (
+            X_ranks < max_rank[:,:,None,:]
+        ) & (X_ranks > min_rank[:,:,None,:] - 1)
+
+        # NOTE: The "Some exclusions have been ignored..." UserWarning below is
+        # asserted by the test suite (see chainladder/development/tests/
+        # test_development.py and test_incremental.py, which use
+        # pytest.warns(..., match="exclusions have been ignored")).
+        # Do not modify the warning message or remove the warnings.warn(...)
+        # call without updating the corresponding pytest.warns matchers,
+        # otherwise those tests will fail.
+        if warning_flag:
+            if self.preserve == 1:
+                warning = (
+                    "Some exclusions have been ignored. At least "
+                    + str(self.preserve)
+                    + " (use preserve = ...)"
+                    + " link ratio(s) is required for development estimation."
+                )
+            else:
+                warning = (
+                    "Some exclusions have been ignored. At least "
+                    + str(self.preserve)
+                    + " link ratio(s) is required for development estimation."
+                )
+            warnings.warn(warning)
+
+        return w.astype(float)
+    
+    def _drop_func(self, X: TriangleLike) -> TriangleLike:
+        """
+        Generates weights for the `drop` parameter
+
+        Parameters
+        ----------
+        X: TriangleLike
+            Triangle of values to be weighted
+
+        Returns
+        -------
+        A Triangle of weights
+
+        """        
+        # get the appropriate backend for nan_to_num
+        xp = X.get_array_module()
+        # turn single drop_valuation parameter to list if necessary
+        drop_list = self.drop if isinstance(self.drop, list) else [self.drop]
+        # get an starting array of weights
+        w = X.nan_triangle
+        # accommodate ldf triangle where the dimensions are '12-24'
+        dev_list = (
+            X.development.str.split("-", expand=True)[0]
+            if is_string_dtype(X.development)
+            else X.development.astype("string")
+        )
+        # create ndarray of drop_list for further operation in numpy
+        drop_np = np.asarray(drop_list)
+        # find indices of drop_np
+        origin_ind = np.where(
+            np.array([X.origin.astype("string")]) == drop_np[:, [0]]
+        )[1]
+        dev_ind = np.where(np.array([dev_list]) == drop_np[:, [1]])[1]
+        # set weight of dropped factors to 0
+        w[(origin_ind, dev_ind)] = 0
+        return xp.nan_to_num(w)[None, None]
+
+    def _drop_valuation_func(self, X: TriangleLike) -> TriangleLike:
+        """
+        Generates weights for the `drop` parameter
+
+        Parameters
+        ----------
+        X: TriangleLike
+            Triangle of values to be weighted
+
+        Returns
+        -------
+        A Triangle of weights
+
+        """        
+        # get the appropriate backend for nan_to_num
+        xp = X.get_array_module()
+        # turn single drop_valuation parameter to list if necessary
+        if isinstance(self.drop_valuation, list):
+            drop_valuation_list = self.drop_valuation
+        else:
+            drop_valuation_list = [self.drop_valuation]
+        # turn drop_valuation to same valuation freq as X
+        v = pd.PeriodIndex(
+            drop_valuation_list, freq=X.development_grain
+        ).to_timestamp(how="e")
+        # warn that some drop_valuation are outside of X
+        if np.any(~v.isin(X.valuation)):
+            warnings.warn("Some valuations could not be dropped.")
+        # return triangle of weight where dropped factors have 0
+        w = xp.nan_to_num(X.iloc[0, 0][~X.valuation.isin(v)].values * 0 + 1)
+        # check to make sure some factors are still left
+        if w.sum() == 0:
+            raise Exception("The entire triangle has been dropped via drop_valuation.")
+        return w
+    
+    def _drop_x_func(self, X):
+        """
+        Generates weights for the `drop_above` and `drop_below` parameters
+
+        Parameters
+        ----------
+        X: TriangleLike
+            Triangle of values to be weighted
+
+        Returns
+        -------
+        A Triangle of weights
+
+        """        
+        # Preparing to set up 3D array for drop_x parameters
+        X_val = X.values.copy()
+        dev_len = X_val.shape[3]
+        indices = X_val.shape[0]
+        columns = X_val.shape[1]
+
+        # explicitly setting up 3D arrays for drop parameters to avoid broadcasting bugs
+        drop_above_array = np.zeros((indices, columns, dev_len))
+        drop_above_array[:, :, :] = self._cascade_param(
+            dev_len, self.drop_above, np.inf
+        )[None, None]
+        drop_below_array = np.zeros((indices, columns, dev_len))
+        drop_below_array[:, :, :] = self._cascade_param(
+            dev_len, self.drop_below, 0.0
+        )[None, None]
+        preserve_array = np.zeros((indices, columns, dev_len))
+        preserve_array[:, :, :] = self._cascade_param(
+            dev_len, self.preserve, self.preserve
+        )[None, None]
+
+        # setting up starting array of weights
+        w = ~np.isnan(X_val)
+
+        # weights without considering preserve
+        index_array_weights = (X_val < drop_above_array[:,:,None,:]) & (
+            X_val > drop_below_array[:,:,None,:]
+        )
+
+        # counting remaining factors
+        valid_count = index_array_weights.sum(axis=2)
+
+        # applying preserve
+        warning_flag = np.any(valid_count < preserve_array)
+        w = np.where(
+            valid_count[:,:,None,:] < preserve_array[:,:,None,:], w, index_array_weights
+        )
+
+        # NOTE: The "Some exclusions have been ignored..." UserWarning below is
+        # asserted by the test suite (see chainladder/development/tests/
+        # test_development.py and test_incremental.py, which use
+        # pytest.warns(..., match="exclusions have been ignored")).
+        # Do not modify the warning message or remove the warnings.warn(...)
+        # call without updating the corresponding pytest.warns matchers,
+        # otherwise those tests will fail.
+        if warning_flag:
+            if self.preserve == 1:
+                warning = (
+                    "Some exclusions have been ignored. At least "
+                    + str(self.preserve)
+                    + " (use preserve = ...)"
+                    + " link ratio(s) is required for development estimation."
+                )
+            else:
+                warning = (
+                    "Some exclusions have been ignored. At least "
+                    + str(self.preserve)
+                    + " link ratio(s) is required for development estimation."
+                )
+            warnings.warn(warning)
+
+        return w.astype(float)

--- a/chainladder/utils/triangle_weight.py
+++ b/chainladder/utils/triangle_weight.py
@@ -441,7 +441,7 @@ class TriangleWeight(BaseEstimator,TransformerMixin):
             raise Exception("The entire triangle has been dropped via drop_valuation.")
         return w
     
-    def _drop_x_func(self, X):
+    def _drop_x_func(self, X: TriangleLike) -> TriangleLike:
         """
         Generates weights for the `drop_above` and `drop_below` parameters
 

--- a/chainladder/utils/triangle_weight.py
+++ b/chainladder/utils/triangle_weight.py
@@ -58,17 +58,17 @@ class TriangleWeight(BaseEstimator,TransformerMixin):
     
             (Order of Drop Operations)
             
-            When multiple drop parameters are used together, the weights are built in this order:
+            When multiple drop parameters are used together, the weights are built in this order (steps 4 and 5 are reversed from `Development`):
         
             1. ``n_periods`` — limit to the most recent origin periods.
             2. ``drop`` — remove specific origin/development cells.
             3. ``drop_valuation`` — remove entire valuation diagonal in the triangle.
-            4. ``drop_high`` / ``drop_low`` — remove highest/lowest link ratios by rank
-               (eligible factors from ``n_periods`` are used; protected by ``preserve``,
-               which may relax exclusions from this step if too few ratios would remain then this step is skipped).
-            5. ``drop_above`` / ``drop_below`` — remove link ratios outside a range
+            4. ``drop_above`` / ``drop_below`` — remove link ratios outside a range
                (Protected by``preserve``, which may relax exclusions from this step if too few ratios would remain
                then this step is skipped).
+            5. ``drop_high`` / ``drop_low`` — remove highest/lowest link ratios by rank
+               (eligible factors from ``n_periods`` are used; protected by ``preserve``,
+               which may relax exclusions from this step if too few ratios would remain then this step is skipped).
             6. Calculate the loss development factors using ``average`` method.
 
     Attributes


### PR DESCRIPTION
## Summary of Changes  


## Related GitHub Issue(s)  


## Additional Context for Reviewers  


- [ ] I passed tests locally for both code (`uv run pytest`) and documentation changes (`uv run jb build docs --builder=custom --custom-builder=doctest`)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New public API and ~500 lines of weight logic that must stay consistent with `Development`; wrong ordering or preserve behavior would change LDFs once integrated, though production `Development` paths are unchanged in this diff.
> 
> **Overview**
> Introduces **`TriangleWeight`**, a new sklearn-style utility that builds a weight triangle from the same exclusion knobs as `Development` (`n_periods`, `drop`, `drop_valuation`, `drop_above`/`drop_below`, `drop_high`/`drop_low`, `preserve`). It is exported from `chainladder.utils` and the top-level `chainladder` package, with `EXPECTED_PUBLIC_API` updated accordingly.
> 
> The implementation lives in `chainladder/utils/triangle_weight.py` and documents a **different drop order** than `Development`: threshold drops (`drop_above`/`drop_below`) run **before** rank-based `drop_high`/`drop_low` (the docstring notes steps 4 and 5 are reversed relative to `Development`). `fit`/`transform` set `w_` on triangles and can compose with existing `w_` weights.
> 
> **Tests** in `test_development.py` are expanded with `_FutureDevelopment`, a `TriangleWeight` subclass that recomputes LDFs via weighted regression, and assertions that its LDFs match `Development` across drop scenarios—exercising the new utility without wiring it into `Development` yet.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 60cabb2fdc5465caa44e7114a09ef1658c4eb0bf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->