### PR TITLE
Add Slicing tests, annotations.

### DIFF
--- a/chainladder/core/slice.py
+++ b/chainladder/core/slice.py
@@ -377,7 +377,7 @@ class Location(_LocBase):
             raise AttributeError("Unable to slice.")
 
 
-    def key_to_slice(self, key: _LabelKey) -> tuple:
+    def key_to_slice(self, key: _LabelKey) -> tuple[_AxisKey, _AxisKey, _AxisKey, _AxisKey]:
         """
         Converts keys to integer slices.
 
@@ -392,7 +392,7 @@ class Location(_LocBase):
         """
 
         # Preprocess key into a normalized 4-D key.
-        key: tuple[_LabelKey, _LabelKey, _LabelKey, _LabelKey] = self.format_key(key)
+        key = self.format_key(key)
         # Transform into integer-based slices.
         out = (self.index_key(key[0]),
                 self.other_key(key[1], 'columns'),
@@ -400,8 +400,8 @@ class Location(_LocBase):
                 self.other_key(key[3], 'development'))
         return out
 
-    def __setitem__(self, key, values):
-        super().__setitem__(self.key_to_slice(key), values)
+    def __setitem__(self, key: _LabelKey, values: int | float | TriangleSlicer) -> None:
+        super().__setitem__(cast(tuple[_AxisKey, _AxisKey, _AxisKey, _AxisKey], self.key_to_slice(key)), values)
 
 class Ilocation(_LocBase):
     """

--- a/chainladder/core/slice.py
+++ b/chainladder/core/slice.py
@@ -1,14 +1,22 @@
+"""
+Support pandas-style slicing to the Triangle class.
+"""
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 from __future__ import annotations
 
+import importlib
 import numpy as np
 import pandas as pd
 
-from chainladder.core.typing import _AxisKey
+from chainladder.core.typing import (
+    _AxisKey,
+    _LabelKey
+)
+
 from chainladder.utils.utility_functions import num_to_nan
-from sparse import _slicing
+
 from typing import (
     cast,
     TYPE_CHECKING
@@ -17,6 +25,11 @@ from typing import (
 if TYPE_CHECKING:
     from chainladder import Triangle
     from chainladder.core.typing import IndexExpression
+    from sparse import COO
+    from typing import Literal
+
+
+_slicing = importlib.import_module("sparse._slicing")
 
 class _LocBase:
     """
@@ -105,13 +118,33 @@ class _LocBase:
             min_arr, max_arr = max_arr - 1, min_arr - 1 if min_arr else min_arr
         return slice(min_arr, max_arr, step)
 
-    def __setitem__(self, key, values):
+    def __setitem__(
+            self,
+            key: tuple[_AxisKey, _AxisKey, _AxisKey, _AxisKey],
+            values: int | float | TriangleSlicer
+    ) -> None:
+        """
+        Supports the square bracket syntax [] for setting Triangle values. Only supported for numpy backend.
+
+        Parameters
+        ----------
+        key: tuple[_AxisKey, _AxisKey, _AxisKey, _AxisKey]
+            Indicates the slice of the Triangle you want to set values for.
+        values: int | float | TriangleSlicer
+            The value(s) you want to assign to the slice of the Triangle.
+
+        Returns
+        -------
+        None
+
+        """
         if self.obj.array_backend == "sparse":
             raise ValueError('Setting values with sparse backend requires .at or .iat')
         if isinstance(values, TriangleSlicer):
             values = values.values
+        # Create a slice for any key elements that are integers, otherwise preserve the slice or array.
         key = tuple(
-            [slice(item, item + 1) if type(item) is int else item for item in key]
+            [slice(item, item + 1) if isinstance(item, int) else item for item in key]
         )
         self.obj.values.__setitem__(self._normalize_index(key), values)
 
@@ -137,7 +170,7 @@ class _LocBase:
         # Preserve start/stop/step boundaries if the user has specified them, otherwise replace them with None.
         # None indicates "go-to-boundary" for the slice.
         for n, i in enumerate(key):
-            if type(i) is slice:
+            if isinstance(i, slice):
                 start: int | None= i.start if i.start > 0 else None
                 stop: int | None = i.stop if i.stop > -1 else None
                 stop: int | None = None if stop == self.obj.shape[n] else stop
@@ -148,48 +181,122 @@ class _LocBase:
         key = tuple(l)
         return key
 
-    def _sparse_setitem(self, key, values):
+    def _sparse_setitem(
+            self,
+            key: tuple[int, int, int, int],
+            values: int | float
+    ) -> None:
+        """
+        Set slice of Triangle when backend is sparse.
+
+        Parameters
+        ----------
+        key: tuple[int, int, int, int]
+        values: int | float
+
+        Returns
+        -------
+        None
+
+        """
+        # Enforce sparse array type.
+        arr: COO = cast("COO", cast(object, self.obj.values))
+        key: tuple = cast("tuple", cast(object, key))
+        # Check if a stored value exists at the coordinate point.
         check = (
-            (self.obj.values.coords[0] == key[0]) *
-            (self.obj.values.coords[1] == key[1]) *
-            (self.obj.values.coords[2] == key[2]) *
-            (self.obj.values.coords[3] == key[3]))
+            (arr.coords[0] == key[0]) *
+            (arr.coords[1] == key[1]) *
+            (arr.coords[2] == key[2]) *
+            (arr.coords[3] == key[3]))
+        # If it does, index the location and assign the value directly.
         if check.max():
             data_index = np.where(check == True)[0][0]
-            self.obj.values.data[data_index] = values
+            arr.data[data_index] = values
+        # Otherwise, create a new sparse array with the updated coordinates and data.
         else:
-            self.obj.values.coords = np.concatenate(
-                (self.obj.values.coords, np.array(key)[:, None]), 1)
-            self.obj.values.data = np.concatenate(
-                (self.obj.values.data, np.array([values])), 0)
+            # Append the new coordinate.
+            arr.coords = np.concatenate(
+                (arr.coords, np.array(key)[:, None]), axis=1)
+            # Append the new data element.
+            arr.data = np.concatenate(
+                (arr.data, np.array([values])), axis=0)
+            # Construct the new sparse array and assign to Triangle.
             self.obj.values = self.obj.get_array_module().COO(
-                self.obj.values.coords, self.obj.values.data, prune=True,
-                has_duplicates=False, shape=self.obj.shape,
-                fill_value=self.obj.values.fill_value)
+                coords=arr.coords,
+                data=arr.data,
+                prune=True,
+                has_duplicates=False,
+                shape=self.obj.shape,
+                fill_value=arr.fill_value
+            )
 
 
 class Location(_LocBase):
     """ class to generate .loc[] functionality """
 
-    def __getitem__(self, key):
-        obj = self.get_idx(self.key_to_slice(key))
+    def __getitem__(
+            self,
+            key: _LabelKey
+    ) -> Triangle:
+        """
+        Support square bracket indexing of Triangle.loc[] to extract data.
+
+        Parameters
+        ----------
+        key: _LabelKey
+            The pandas-style slice that you wish to extract from the Triangle.
+
+        Returns
+        -------
+        Triangle
+            The desired slice of a Triangle, specified by key.
+
+        """
+        # Extract the desired slice.
+        obj: Triangle = self.get_idx(self.key_to_slice(key))
+        # Drop the top-level index if unique, otherwise, return the slice.
         if len(obj) > 1 and obj.index.iloc[:, 0].nunique() == 1:
             obj.set_index(obj.index.iloc[:, 1:], inplace=True)
         return obj
 
-    def format_key(self, key) -> tuple:
-        """ Converts keys to loc slices """
-        if (type(key) is tuple and len(key) > 1
+    def format_key(self, key: _LabelKey) -> tuple[_LabelKey, _LabelKey, _LabelKey, _LabelKey]:
+        """
+        Aligns a user-supplied label-based key to the Triangle's 4 axes, leaving each
+        element as a label-based selector for index_key/other_key to resolve later.
+
+        Parameters
+        ----------
+        key: _LabelKey
+            The user-supplied label-based key.
+
+        Returns
+        -------
+        tuple[_LabelKey, _LabelKey, _LabelKey, _LabelKey]
+            A 4-tuple of per-axis label-based selectors.
+        """
+        # Parse the user-supplied key and determine data type and purpose.
+        # Preprocess into a common tuple-format prior to standardizing the dimensions.
+
+        # Case when key is a tuple representing an index row.
+        if (isinstance(key, tuple) and len(key) > 1
             and len(self.obj.key_labels) > 1 and type(key[1]) is str
             and key[1] in self.obj.index[self.obj.key_labels[1]].unique()):
             key = (key,)
+        # Case when tuple elements represent separate dimensions, keep as-is.
+        elif isinstance(key, tuple):
+            pass
+        # Otherwise, convert to tuple.
         else:
-            key = (key,) if type(key) is not tuple else key
+            key = (key,)
+
+        # Create a placeholder normalized key, with 0 for mapping to user-supplied dimensions, and
+        # a full slice otherwise.
         key_mask = tuple([i if i is Ellipsis else 0 for i in key])
         if len(key_mask) < len(self.obj.shape) and Ellipsis not in key_mask:
             key_mask = tuple(list(key_mask) + [Ellipsis])
-        normalized = self._normalize_index(key_mask)
+        normalized: tuple = self._normalize_index(key_mask)
         key = [item for item in key if item is not Ellipsis]
+        # Populate a new formatted key by replacing the 0s with the user-supplied key elements.
         key_mask = []
         for i in range(len(self.obj.shape)):
             if normalized[i] == 0:
@@ -198,38 +305,95 @@ class Location(_LocBase):
                 key_mask.append(normalized[i])
         return tuple(key_mask)
 
-    def index_key(self, key):
-        if type(key) == pd.Series and len(key) != len(self.obj):
+    def index_key(self, key: _LabelKey) -> np.ndarray:
+        """
+        Converts a label-based key into an integer-based one. Intended to be used for the index axis.
+
+        Parameters
+        ----------
+        key: _LabelKey
+            A label-based to be converted into an integer-based key.
+
+        Returns
+        -------
+        np.ndarray
+            An integer-based key.
+
+        """
+        # Case when key is a single index row and not a boolean mask, preprocess into a DataFrame of labels.
+        if isinstance(key, pd.Series) and len(key) != len(self.obj):
                 key = key.to_frame().T
-        if type(key) == pd.Series:
+        # Case boolean mask. Extract the positions where True.
+        if isinstance(key, pd.Series):
             idx = np.where(key)[0]
-        elif type(key) == pd.DataFrame:
+        # Case DataFrame of labels, find positions in index.
+        elif isinstance(key, pd.DataFrame):
             idx = (self.obj.index.reset_index().set_index(self.obj.key_labels)
                        .loc[key.set_index(list(key.columns)).index]).values.flatten()
+        # Case Pandas-style label selectors, extract positions from index.
         elif type(key) in [slice, list, tuple]:
             idx = (self.obj.index.reset_index()
                        .set_index(self.obj.key_labels).loc[key]).values.flatten()
+        # Case scalar, locate position in first level of index.
         else:
             idx = np.where(self.obj.kdims[:, 0]==key)[0]
         return idx
 
-    def other_key(self, key, idx):
-        if type(key) is np.ndarray:
+    def other_key(
+            self,
+            key: _LabelKey,
+            idx: Literal['columns', 'origin', 'development']
+    ) -> np.ndarray | slice:
+        """
+        Converts a label-based key into an integer-based one. Intended to be used for axes other than the index.
+
+        Parameters
+        ----------
+        key: _LabelKey
+            A label-based to be converted into an integer-based key.
+        idx: Literal['columns', 'origin', 'development']
+            The axis to which the key applies.
+
+        Returns
+        -------
+        np.ndarray | slice
+            An integer-based key.
+
+        """
+        # Case boolean mask, return positions.
+        if isinstance(key, np.ndarray):
             return np.where(key)[0]
-        if key == slice(None, None, None):
-            return key
+        # Case full-axis slice, simply return it.
+        if isinstance(key, slice) and (key == slice(None, None, None)):
+            return cast(slice, key)
+        # Otherwise, extract the index and then find the positions.
         s = getattr(self.obj, idx)
+        obj_idx = pd.Series(range(len(s)), index=s)
         if type(key) in [slice, list]:
-            return pd.Series(range(len(s)), index=s).loc[key].values
+            return obj_idx.loc[key].values
         if not hasattr(key, '__iter__') or type(key) is str:
-            return np.array([pd.Series(range(len(s)), index=s).loc[key]])
+            return np.array([obj_idx.loc[key]])
         else:
             raise AttributeError("Unable to slice.")
 
 
-    def key_to_slice(self, key) -> tuple:
-        """ Converts keys to integer slices """
-        key = self.format_key(key)
+    def key_to_slice(self, key: _LabelKey) -> tuple:
+        """
+        Converts keys to integer slices.
+
+        Parameters
+        ----------
+        key:
+            The pandas-style slice that you wish to extract from the Triangle.
+        Returns
+        -------
+        tuple
+            A 4-tuple of integer-based slices.
+        """
+
+        # Preprocess key into a normalized 4-D key.
+        key: tuple[_LabelKey, _LabelKey, _LabelKey, _LabelKey] = self.format_key(key)
+        # Transform into integer-based slices.
         out = (self.index_key(key[0]),
                 self.other_key(key[1], 'columns'),
                 self.other_key(key[2], 'origin'),
@@ -244,10 +408,10 @@ class Ilocation(_LocBase):
     Class to generate .iloc[] functionality.
     """
 
-    def __getitem__(self, key: tuple):
+    def __getitem__(self, key: IndexExpression) -> Triangle:
         return self.get_idx(self._normalize_index(key))
 
-    def __setitem__(self, key, values):
+    def __setitem__(self, key: IndexExpression, values):
         super().__setitem__(self._normalize_index(key), values)
 
 

--- a/chainladder/core/tests/test_slicing.py
+++ b/chainladder/core/tests/test_slicing.py
@@ -51,7 +51,7 @@ def test_slice_development(raa: Triangle) -> None:
 
     """
     assert raa[raa.development < 72].shape == (1, 1, 10, 5)
-    assert raa.loc[..., 24:].development.min() <= 24
+    assert raa.loc[..., 24:].development.min() == 24
 
 
 def test_slice_by_loc_iloc(clrd):

--- a/chainladder/core/tests/test_slicing.py
+++ b/chainladder/core/tests/test_slicing.py
@@ -21,12 +21,12 @@ def test_slice_by_loc(clrd):
 
 def test_slice_origin(raa):
     assert raa[raa.origin > "1985"].shape == (1, 1, 5, 10)
-    raa.loc[..., raa.origin <= "1994", :]
+    _= raa.loc[..., raa.origin <= "1994", :]
 
 
 def test_slice_development(raa):
     assert raa[raa.development < 72].shape == (1, 1, 10, 5)
-    raa.loc[..., 24:]
+    _= raa.loc[..., 24:]
 
 
 def test_slice_by_loc_iloc(clrd):
@@ -93,7 +93,7 @@ def test_missing_first_lag(raa):
     x = raa.copy()
     x.values[:, :, :, 0] = 0
     x = x.sum(0)
-    x.link_ratio.shape == (1, 1, 9, 9)
+    assert x.link_ratio.shape == (1, 1, 9, 9)
 
 
 def test_reverse_slice_integrity(clrd):
@@ -110,20 +110,20 @@ def test_loc_tuple(clrd):
 def test_at_iat(raa):
     raa1 = raa.copy()
     raa2 = raa.copy()
-    raa1.at["Total", "values", "1985", 120]
+    _= raa1.at["Total", "values", "1985", 120]
     raa1.at["Total", "values", "1985", 120] = 5
     raa1.at["Total", "values", "1985", 12] = 5
     raa2.iat[0, 0, 4, -1] = 5
-    raa2.iat[0, 0, 4, -1]
+    _= raa2.iat[0, 0, 4, -1]
     raa2.iat[-1, -1, 4, 0] = 5
     assert raa1 == raa2
 
 
 def test_at_iat_exceptions(raa):
     with pytest.raises(ValueError):
-        raa.iat[0, 0, 4, :]
+        _= raa.iat[0, 0, 4, :]
     with pytest.raises(ValueError):
-        raa.at["Total", "values", "1985", 0:2]
+        _= raa.at["Total", "values", "1985", 0:2]
 
 
 def test_other_key_unsupported_iterable_raises(raa: Triangle) -> None:
@@ -141,7 +141,7 @@ def test_other_key_unsupported_iterable_raises(raa: Triangle) -> None:
 
     """
     with pytest.raises(AttributeError, match="Unable to slice"):
-        raa.loc[:, (0, 1)]
+        _= raa.loc[:, (0, 1)]
 
 
 def test_at_setitem_triangle_value(raa: Triangle) -> None:
@@ -183,7 +183,7 @@ def test_empty_index_raises(raa: Triangle) -> None:
 
     """
     with pytest.raises(ValueError, match="Slice returns empty Triangle"):
-        raa.iloc[[], :]
+        _= raa.iloc[[], :]
 
 
 def test_get_idx_fancy_origin_raises(raa: Triangle) -> None:
@@ -201,7 +201,7 @@ def test_get_idx_fancy_origin_raises(raa: Triangle) -> None:
 
     """
     with pytest.raises(ValueError, match="Fancy indexing on origin/development is not supported"):
-        raa.iloc[0, 0, [0, 1, 5], :]
+        _= raa.iloc[0, 0, [0, 1, 5], :]
 
 
 def test_get_idx_fancy_development_raises(raa: Triangle) -> None:
@@ -219,7 +219,7 @@ def test_get_idx_fancy_development_raises(raa: Triangle) -> None:
 
     """
     with pytest.raises(ValueError, match="Fancy indexing on origin/development is not supported"):
-        raa.iloc[0, 0, :, [0, 1, 5]]
+        _= raa.iloc[0, 0, :, [0, 1, 5]]
 
 
 def test_get_idx_non_contiguous_index_and_columns(clrd: Triangle) -> None:
@@ -260,6 +260,6 @@ def test_sparse_column_assignment(prism):
     t["Paid2"] = t["Paid"]  # New from physical
     t["Paid2"] = lambda x: x["Paid"]  # Existing from virtual
     t["Paid"] = t["Paid2"]  # Existing from physical
-    t["Paid3"] = lambda t: t["Paid"]  # New from virtual
+    t["Paid3"] = lambda x: x["Paid"]  # New from virtual
     assert out == t["Paid"]
     assert t.shape == (34244, 6, 120, 120)

--- a/chainladder/core/tests/test_slicing.py
+++ b/chainladder/core/tests/test_slicing.py
@@ -126,6 +126,43 @@ def test_at_iat_exceptions(raa):
         raa.at["Total", "values", "1985", 0:2]
 
 
+def test_other_key_unsupported_iterable_raises(raa: Triangle) -> None:
+    """
+    Pass a nonsense key to raa.loc[], should raise an error.
+
+    Parameters
+    ----------
+    raa: Triangle
+        The raa sample data set fixture.
+
+    Returns
+    -------
+    None
+
+    """
+    with pytest.raises(AttributeError, match="Unable to slice"):
+        raa.loc[:, (0, 1)]
+
+
+def test_at_setitem_triangle_value(raa: Triangle) -> None:
+    """
+    Use Triangle.at to set a single value via a TriangleSlicer.
+
+    Parameters
+    ----------
+    raa: Triangle
+        The raa sample data set fixture.
+
+    Returns
+    -------
+    None
+
+    """
+    tri = raa.copy()
+    tri.at["Total", "values", "1981", 12] = tri.iloc[0, 0, 1:2, 0:1]
+    assert tri.at["Total", "values", "1981", 12] == 106.0
+
+
 @pytest.mark.xfail
 def test_sparse_at_iat(prism):
     prism.iloc[0, 0, 0, 0] = 1.0

--- a/chainladder/core/tests/test_slicing.py
+++ b/chainladder/core/tests/test_slicing.py
@@ -51,7 +51,7 @@ def test_slice_development(raa: Triangle) -> None:
 
     """
     assert raa[raa.development < 72].shape == (1, 1, 10, 5)
-    assert raa.loc[..., 24:].development.max() <= 120
+    assert raa.loc[..., 24:].development.min() <= 24
 
 
 def test_slice_by_loc_iloc(clrd):

--- a/chainladder/core/tests/test_slicing.py
+++ b/chainladder/core/tests/test_slicing.py
@@ -8,7 +8,7 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from chainladder import Triangle
 
-def test_slice_by_boolean(clrd):
+def test_slice_by_boolean(clrd : Triangle) -> None:
     assert (
         clrd[clrd["LOB"] == "ppauto"].loc["Wolverine Mut Ins Co"]["CumPaidLoss"]
         == clrd.loc["Wolverine Mut Ins Co"].loc["ppauto"]["CumPaidLoss"]
@@ -19,14 +19,39 @@ def test_slice_by_loc(clrd):
     assert clrd.loc["Aegis Grp"].loc["comauto"].index.iloc[0, 0] == "comauto"
 
 
-def test_slice_origin(raa):
+def test_slice_origin(raa: Triangle) -> None:
+    """
+    Slice the Triangle on the origin. Check the shape and year boundary.
+
+    Parameters
+    ----------
+    raa: Triangle
+        The raa sample data set fixture
+
+    Returns
+    -------
+    None
+    """
     assert raa[raa.origin > "1985"].shape == (1, 1, 5, 10)
-    _= raa.loc[..., raa.origin <= "1994", :]
+    assert raa.loc[..., raa.origin <= "1985", :].origin.max().year == 1985
 
 
-def test_slice_development(raa):
+def test_slice_development(raa: Triangle) -> None:
+    """
+    Slice the Triangle on the development axis. Check the shape and development periods.
+
+    Parameters
+    ----------
+    raa: Triangle
+        The raa sample data set fixture
+
+    Returns
+    -------
+    None
+
+    """
     assert raa[raa.development < 72].shape == (1, 1, 10, 5)
-    _= raa.loc[..., 24:]
+    assert raa.loc[..., 24:].development.max() <= 120
 
 
 def test_slice_by_loc_iloc(clrd):

--- a/chainladder/core/typing.py
+++ b/chainladder/core/typing.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import numpy as np
+import pandas as pd
 
 from types import EllipsisType
 from typing import TYPE_CHECKING, TypeAlias
@@ -11,12 +12,15 @@ if TYPE_CHECKING:
 # Alias for a Triangle or any object that behaves like one.
 TriangleLike: TypeAlias = "Triangle"
 
-# A raw indexing expression as passed by the user to an indexer such as
-# .iloc[] or .loc[] before normalization.
+# A raw indexing expression as passed by the user to an indexer such aa .iloc[] before normalization.
 IndexExpression: TypeAlias = int | slice | list | np.ndarray | tuple | EllipsisType
 
 # A single axis key after normalization: a bounded slice, an integer position,
 # or a fancy-index array.
 _AxisKey: TypeAlias = slice | int | np.int64 | np.int32 | np.ndarray
+
+# A label-based selector for a single Triangle axis, as accepted by .loc[]
+# before index_key/other_key resolve it to a positional _AxisKey.
+_LabelKey: TypeAlias = IndexExpression | str | pd.Series | pd.DataFrame
 
 


### PR DESCRIPTION
## Summary of Changes  

Adding some tests for uncovered lines in `slice.py`. Add some docstrings and typing for `Locaction` class.

## Related GitHub Issue(s)  

#486

## Additional Context for Reviewers  


- [x] I passed tests locally for both code (`uv run pytest`) and documentation changes (`uv run jb build docs --builder=custom --custom-builder=doctest`)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are mostly annotations, docs, and tests; sparse COO rebuild is a small refactor in an already-used code path with new tests guarding behavior.
> 
> **Overview**
> Adds **typing, module docstring, and docstrings** across Triangle `.loc`/`.iloc` slicing in `slice.py`, including a new `_LabelKey` alias in `typing.py` for label-based indexers.
> 
> **Implementation tweaks:** `sparse._slicing` is loaded via `importlib` instead of a direct import; sparse single-cell updates in `_sparse_setitem` use explicit `COO` typing and keyword construction; several `type()` checks become `isinstance`.
> 
> **Tests:** `test_slicing.py` gains stricter assertions (origin/development bounds, missing `assert` on `link_ratio`), coverage for invalid `.loc` column keys, `.at` assignment from a `TriangleSlicer`, and minor hygiene (`_=` for intentional reads).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 219b5864040da0cfe411c9baa01b8adc43bb29b2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->