### PR TITLE
Switching codecov to main

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -21,7 +21,7 @@
 .. |Build Status| image:: https://github.com/casact/chainladder-python/actions/workflows/pytest.yml/badge.svg
    :target: https://github.com/casact/chainladder-python/actions/workflows/pytest.yml
 
-.. |codecov io| image:: https://codecov.io/gh/casact/chainladder-python/branch/master/graphs/badge.svg
+.. |codecov io| image:: https://codecov.io/gh/casact/chainladder-python/branch/main/graphs/badge.svg
    :target: https://codecov.io/github/casact/chainladder-python?branch=latest
 
 .. |Documentation Status| image:: https://readthedocs.org/projects/chainladder-python/badge/?version=main


### PR DESCRIPTION
## Summary of Changes  
Switching codecov badge on the readme from `master` to `main`

## Related GitHub Issue(s)  
Closes #935 

## Additional Context for Reviewers  
`master` was supposed to convert to `main` after the deprecation, I'm not even sure what `master` is now.

- [ ] I passed tests locally for both code (`uv run pytest`) and documentation changes (`uv run jb build docs --builder=custom --custom-builder=doctest`)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only badge URL change with no runtime or security impact.
> 
> **Overview**
> Updates the README **codecov** badge image URL so coverage is reported for the **`main`** branch instead of **`master`**, aligning the badge with the repository’s default branch after the rename (closes #935).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 07ec79cb3bbebaf5feb792b29b507be9b19f455c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->