### PR TITLE
fix and enhance utils.model_diagnostics part 1

### DIFF
--- a/chainladder/methods/tests/test_predict.py
+++ b/chainladder/methods/tests/test_predict.py
@@ -8,18 +8,20 @@ cl_ult = cl.Chainladder().fit(raa).ultimate_  # Chainladder Ultimate
 apriori = cl_ult * 0 + (float(cl_ult.sum()) / 10)  # Mean Chainladder Ultimate
 apriori_1989 = apriori[apriori.origin < "1990"]
 
-
-def test_cc_predict():
-    cc = cl.CapeCod().fit(raa_1989, sample_weight=apriori_1989)
-    assert cc.predict(raa, sample_weight=apriori)
-
-def test_bf_predict():
-    bf = cl.BornhuetterFerguson().fit(raa_1989, sample_weight=apriori_1989)
-    assert bf.predict(raa, sample_weight=apriori)
-
-def test_el_predict():
-    bf = cl.ExpectedLoss().fit(raa_1989, sample_weight=apriori_1989)
-    assert bf.predict(raa, sample_weight=apriori)
+@pytest.mark.parametrize(
+    "estimators",
+    [
+        cl.CapeCod,
+        cl.BornhuetterFerguson,
+        cl.ExpectedLoss,
+        cl.Benktander,
+        cl.Chainladder
+    ],
+)
+def test_predict_and_weights(estimators,atol):
+    est = estimators().fit(raa_1989, sample_weight=apriori_1989)
+    pred = est.predict(raa, sample_weight=apriori)
+    assert pred
 
 def test_mack_predict():
     mack = cl.MackChainladder().fit(raa_1989)


### PR DESCRIPTION
## Summary of Changes  
streamlining a few tests for `predict`

## Related GitHub Issue(s)  


## Additional Context for Reviewers  


- [X] I passed tests locally for both code (`uv run pytest`) and documentation changes (`uv run jb build docs --builder=custom --custom-builder=doctest`)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only refactor with broader estimator coverage; no production code changes.
> 
> **Overview**
> Consolidates three separate `predict` tests (`CapeCod`, `BornhuetterFerguson`, `ExpectedLoss`) into one **`@pytest.mark.parametrize`** test, **`test_predict_and_weights`**, and extends coverage to **`Benktander`** and **`Chainladder`** using the same fit-on-`raa_1989` / predict-on-full-`raa` pattern with apriori sample weights.
> 
> Also restores a trailing newline at the end of **`test_predict.py`** (no behavior change).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 86b8dacad7bb47e8486d7d879b5fc42e384b8f45. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->