### PR TITLE
Fix and enhance utils.model diagnostics part 2

### DIFF
--- a/chainladder/core/tests/test_triangle.py
+++ b/chainladder/core/tests/test_triangle.py
@@ -49,7 +49,10 @@ def test_link_ratio(raa, atol):
         raa.link_ratio * raa.iloc[:, :, :-1, :-1].values - raa.values[:, :, :-1, 1:]
     ).sum().sum() < atol
 
-
+def test_align_pattern(raa, atol):
+    with pytest.raises(ValueError):
+        raa.align_pattern(raa)
+        
 def test_incr_to_cum(clrd):
     clrd.cum_to_incr().incr_to_cum() == clrd
 

--- a/chainladder/core/triangle.py
+++ b/chainladder/core/triangle.py
@@ -918,6 +918,40 @@ class Triangle(TriangleBase):
     def is_pattern(self, pattern: bool):
         self._pattern = pattern
 
+    def align_pattern(self, X:Triangle, sample_weight:Triangle|None=None) -> Triangle:
+        """ 
+        Vertically align a selected pattern to origin period latest diagonal. Triangle must be a selected pattern.
+
+        Parameters
+        ----------
+        X: Triangle
+        The target triangle to align to
+        
+        sample_weight:  Triangle, option (default=None)
+        Exposure triangle
+
+        Returns
+        -------
+        Triangle
+            Triangle of selected pattern across origin periods
+
+        """
+        if not self._pattern:
+            raise ValueError("Triangle is not a selected pattern, such as .ldf_ or .cdf_")
+        valuation = X.valuation_date
+        pattern = self.iloc[..., : X.shape[-1]]
+        a = X.iloc[0, 0] * 0
+        a = a + a.nan_triangle
+        if X.array_backend == "sparse":
+            a = a - a[a.valuation < a.valuation_date]
+        if sample_weight:
+            X = X * a + sample_weight * a
+        else:
+            X = X * a
+        pattern = X / X * pattern
+        pattern.valuation_date = valuation
+        return pattern.latest_diagonal
+    
     @property
     def is_ultimate(self) ->  bool:
         """

--- a/chainladder/methods/base.py
+++ b/chainladder/methods/base.py
@@ -25,19 +25,7 @@ class MethodBase(BaseEstimator, EstimatorIO, Common):
 
     def _align_cdf(self, X, sample_weight=None):
         """ Vertically align CDF to origin period latest diagonal. """
-        valuation = X.valuation_date
-        cdf = X.cdf_.iloc[..., : X.shape[-1]]
-        a = X.iloc[0, 0] * 0
-        a = a + a.nan_triangle
-        if X.array_backend == "sparse":
-            a = a - a[a.valuation < a.valuation_date]
-        if sample_weight:
-            X = X * a + sample_weight * a
-        else:
-            X = X * a
-        cdf = X / X * cdf
-        cdf.valuation_date = valuation
-        return cdf.latest_diagonal
+        return X.cdf_.align_pattern(X,sample_weight)
 
     def _set_ult_attr(self, ultimate):
         """ Ultimate scaffolding """


### PR DESCRIPTION
## Summary of Changes  
adding align_pattern as a triangle method, replicating current _align_cdf implementation

## Related GitHub Issue(s)  


## Additional Context for Reviewers  


- [X] I passed tests locally for both code (`uv run pytest`) and documentation changes (`uv run jb build docs --builder=custom --custom-builder=doctest`)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Reserving methods depend on CDF alignment; logic is moved not rewritten, but any subtle difference in `align_pattern` would affect ultimates across estimators.
> 
> **Overview**
> Adds **`Triangle.align_pattern`** so development patterns (e.g. `cdf_`, `ldf_`) can be aligned to a target triangle’s latest diagonal, with optional `sample_weight`—the same behavior that used to live only inside reserving code.
> 
> **`MethodBase._align_cdf`** is reduced to a one-liner that calls `X.cdf_.align_pattern(X, sample_weight)`, so Chainladder/Benktander-style methods keep the same path but through the public Triangle API. Non-pattern triangles get a **`ValueError`** when `align_pattern` is used.
> 
> `test_triangle.py` gains **`test_align_pattern`** / **`test_align_non_pattern`** plus widespread quote/formatting cleanup with no intended behavior change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 717daca6fc00ff9da0e845c971bbb72dec64ec58. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->