### PR TITLE
Fix and enhance utils.model diagnostics part 4

### DIFF
--- a/chainladder/methods/benktander.py
+++ b/chainladder/methods/benktander.py
@@ -243,6 +243,8 @@ class Benktander(MethodBase):
             2012  15914.716737
             2013  17193.715555
         """
+        if sample_weight is None:
+            raise ValueError("sample_weight is required.")
         X_new = super().predict(X, sample_weight)
         X_new.expectation_ = self._get_benktander_aprioris(X, sample_weight)
         X_new.ultimate_ = self._get_ultimate(X_new, X_new.expectation_)

--- a/chainladder/methods/tests/test_predict.py
+++ b/chainladder/methods/tests/test_predict.py
@@ -22,25 +22,16 @@ def test_predict_and_weights(estimators,atol):
     est = estimators().fit(raa_1989, sample_weight=apriori_1989)
     pred = est.predict(raa, sample_weight=apriori)
     assert pred
+    #Test validation of sample_weight requirement. Should raise a value error if no weight is supplied.
+    if estimators != cl.Chainladder:
+        with pytest.raises(ValueError):
+            estimators().fit(raa_1989)
+        with pytest.raises(ValueError):
+            estimators().fit(raa_1989, sample_weight=apriori_1989).predict(raa)
 
 def test_mack_predict():
     mack = cl.MackChainladder().fit(raa_1989)
     assert mack.predict(raa_1989)
-
-def test_capecod_fit_weight():
-    """
-    Test validation of sample_weight requirement. Should raise a value error if no weight is supplied.
-    """
-    with pytest.raises(ValueError):
-        cl.CapeCod().fit(raa_1989)
-
-def test_capecod_predict_weight():
-    """
-    Test validation of sample_weight requirement. Should raise a value error if no weight is supplied.
-    """
-    with pytest.raises(ValueError):
-        cc = cl.CapeCod().fit(raa_1989, sample_weight=apriori_1989)
-        cc.predict(raa)
 
 def test_bs_random_state_predict(clrd):
     tri = clrd.groupby("LOB").sum().loc["wkcomp", ["CumPaidLoss", "EarnedPremNet"]]


### PR DESCRIPTION
## Summary of Changes  
adding error handling for benktander predict
streamlining tests

## Related GitHub Issue(s)  


## Additional Context for Reviewers  


- [X] I passed tests locally for both code (`uv run pytest`) and documentation changes (`uv run jb build docs --builder=custom --custom-builder=doctest`)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small API guard on predict plus test refactor; behavior change only when callers omitted required sample_weight on Benktander predict.
> 
> **Overview**
> **Benktander** now rejects `predict` calls without `sample_weight`, matching **`fit`** and other exposure-based methods (e.g. CapeCod): missing weights raise `ValueError("sample_weight is required.")` before apriori/ultimate logic runs.
> 
> Predict tests were tightened by folding CapeCod-only `fit`/`predict` weight checks into the shared **`test_predict_and_weights`** parametrized case (CapeCod, BF, ExpectedLoss, Benktander), and dropping the duplicate CapeCod test functions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dd38aaedfbf9ed30ad6c27dfb01c336e42e336bd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->