### PR TITLE
setting max sparse version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ keywords = ["actuarial", "reserving", "insurance", "chainladder", "IBNR"]
 dependencies = [
     "pandas >=2.3.3",
     "scikit-learn>1.4.2",
-    "sparse>=0.9",
+    "sparse>=0.9, <=0.17.0",
     "numpy>=2.0",
     "matplotlib",  # Required for TriangleDisplay.heatmap()
     "dill",


### PR DESCRIPTION
setting max sparse version

## Summary of Changes  
setting max sparse version to avoid import error on sparse._slicing

## Related GitHub Issue(s)  
closes #956 

## Additional Context for Reviewers  


- [X] I passed tests locally for both code (`uv run pytest`) and documentation changes (`uv run jb build docs --builder=custom --custom-builder=doctest`)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line dependency constraint in pyproject.toml; limits sparse upgrades but avoids known import breakage with no runtime logic changes.
> 
> **Overview**
> Caps the **`sparse`** dependency in `pyproject.toml` with an upper bound **`<=0.17.0`** (still **`>=0.9`**) so installs do not pull in a newer **`sparse`** release that triggers an import failure involving **`sparse._slicing`** (see #956).
> 
> This is packaging-only: no application code changes, only resolver/install-time version constraints.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 099182b389f450744178abd78319ad9f8e365d8b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->