### PR TITLE
Fix and enhance utils.model diagnostics part 3

### DIFF
--- a/chainladder/methods/tests/test_predict.py
+++ b/chainladder/methods/tests/test_predict.py
@@ -22,6 +22,30 @@ def test_predict_and_weights(estimators,atol):
     est = estimators().fit(raa_1989, sample_weight=apriori_1989)
     pred = est.predict(raa, sample_weight=apriori)
     assert pred
+    assert np.allclose(
+        raa_1989.latest_diagonal.values.swapaxes(0,1),
+        cl.model_diagnostics(est)['Latest'].values,
+        atol=atol,
+        equal_nan=True
+    )
+    assert np.allclose(
+        raa.latest_diagonal.values.swapaxes(0,1),
+        cl.model_diagnostics(pred)['Latest'].values,
+        atol=atol,
+        equal_nan=True
+    )
+    assert np.allclose(
+        est.ultimate_.values.swapaxes(0,1),
+        cl.model_diagnostics(est)['Ultimate'].values,
+        atol=atol,
+        equal_nan=True
+    )
+    assert np.allclose(
+        pred.ultimate_.values.swapaxes(0,1),
+        cl.model_diagnostics(pred)['Ultimate'].values,
+        atol=atol,
+        equal_nan=True
+    )   
     #Test validation of sample_weight requirement. Should raise a value error if no weight is supplied.
     if estimators != cl.Chainladder:
         with pytest.raises(ValueError):
@@ -73,8 +97,8 @@ def test_misaligned_index(prism):
 
 
 def test_misaligned_index2(clrd):
+    w = clrd["EarnedPremDIR"].latest_diagonal
     clrd = clrd["CumPaidLoss"]
-    w = cl.load_sample("clrd")["EarnedPremDIR"].latest_diagonal
     bcl = cl.Chainladder().fit(cl.Development(groupby=["LOB"]).fit_transform(clrd))
     bbk = cl.Benktander().fit(
         cl.Development(groupby=["LOB"]).fit_transform(clrd), sample_weight=w
@@ -140,19 +164,19 @@ def test_misaligned_index2(clrd):
     assert abs(a - b) < 1e-5
 
 
-def test_align_cdfs():
-    ld = cl.load_sample("raa").latest_diagonal * 0 + 40000
-    model = cl.BornhuetterFerguson().fit(cl.load_sample("raa"), sample_weight=ld)
+def test_align_cdfs(raa):
+    ld = raa.latest_diagonal * 0 + 40000
+    model = cl.BornhuetterFerguson().fit(raa, sample_weight=ld)
     a = model.ultimate_.iloc[..., :4, :]
     b = model.predict(
-        cl.load_sample("raa").dev_to_val().iloc[..., :4, -1].val_to_dev(),
+        raa.dev_to_val().iloc[..., :4, -1].val_to_dev(),
         sample_weight=ld.iloc[..., :4, :],
     ).ultimate_
     assert a == b
-    model = cl.Chainladder().fit(cl.load_sample("raa"), sample_weight=ld)
+    model = cl.Chainladder().fit(raa, sample_weight=ld)
     a = model.ultimate_.iloc[..., :4, :]
     b = model.predict(
-        cl.load_sample("raa").dev_to_val().iloc[..., :4, -1].val_to_dev(),
+        raa.dev_to_val().iloc[..., :4, -1].val_to_dev(),
         sample_weight=ld.iloc[..., :4, :],
     ).ultimate_
     assert a == b

--- a/chainladder/methods/tests/test_predict.py
+++ b/chainladder/methods/tests/test_predict.py
@@ -1,4 +1,5 @@
 import chainladder as cl
+import numpy as np
 import pandas as pd
 import pytest 
 
@@ -47,7 +48,7 @@ def test_predict_and_weights(estimators,atol):
         equal_nan=True
     )   
     #Test validation of sample_weight requirement. Should raise a value error if no weight is supplied.
-    if estimators != cl.Chainladder:
+    if estimators in [cl.CapeCod,cl.BornhuetterFerguson,cl.ExpectedLoss,cl.Benktander]:
         with pytest.raises(ValueError):
             estimators().fit(raa_1989)
         with pytest.raises(ValueError):

--- a/chainladder/utils/tests/test_utilities.py
+++ b/chainladder/utils/tests/test_utilities.py
@@ -116,7 +116,7 @@ def test_concat(clrd):
 
 
 def test_model_diagnostics(qtr,atol):
-    md = cl.model_diagnostics(cl.Chainladder().fit(qtr))
+    md = cl.model_diagnostics(cl.Chainladder().fit_predict(qtr))
     assert np.allclose(md['Latest'].values.swapaxes(0,1),qtr.latest_diagonal.values,atol=atol,equal_nan=True)
 
 

--- a/chainladder/utils/tests/test_utilities.py
+++ b/chainladder/utils/tests/test_utilities.py
@@ -117,7 +117,7 @@ def test_concat(clrd):
 
 def test_model_diagnostics(qtr,atol):
     md = cl.model_diagnostics(cl.Chainladder().fit(qtr))
-    assert np.allclose(md['Latest'].values,qtr.latest_diagonal.values,atol=atol,equal_nan=True)
+    assert np.allclose(md['Latest'].values.swapaxes(0,1),qtr.latest_diagonal.values,atol=atol,equal_nan=True)
 
 
 def test_model_diagnostics_erorr(raa):

--- a/chainladder/utils/tests/test_utilities.py
+++ b/chainladder/utils/tests/test_utilities.py
@@ -115,7 +115,7 @@ def test_concat(clrd):
     )
 
 
-def test_model_diagnostics(qtr):
+def test_model_diagnostics(qtr,atol):
     md = cl.model_diagnostics(cl.Chainladder().fit(qtr))
     assert np.allclose(md['Latest'].values,qtr.latest_diagonal.values,atol=atol,equal_nan=True)
 

--- a/chainladder/utils/tests/test_utilities.py
+++ b/chainladder/utils/tests/test_utilities.py
@@ -115,11 +115,6 @@ def test_concat(clrd):
     )
 
 
-def test_model_diagnostics(qtr):
-    md = cl.model_diagnostics(cl.Chainladder().fit(qtr))
-    assert np.allclose(md['Latest'].values,raa.latest_diagonal.values,atol=atol,equal_nan=True)
-
-
 def test_model_diagnostics_erorr(raa):
     with pytest.raises(ValueError):
         cl.model_diagnostics(raa)

--- a/chainladder/utils/tests/test_utilities.py
+++ b/chainladder/utils/tests/test_utilities.py
@@ -116,8 +116,23 @@ def test_concat(clrd):
 
 
 def test_model_diagnostics(qtr):
-    cl.model_diagnostics(cl.Chainladder().fit(qtr))
+    md = cl.model_diagnostics(cl.Chainladder().fit(qtr))
+    assert np.allclose(md['Latest'].values,raa.latest_diagonal.values,atol=atol,equal_nan=True)
 
+
+def test_model_diagnostics_erorr(raa):
+    with pytest.raises(ValueError):
+        cl.model_diagnostics(raa)
+
+
+def test_model_diagnostics_groupby(prism,atol):
+    dev = cl.Development().fit(prism["Incurred"].sum())
+    est = cl.Chainladder().fit(dev.transform(prism["Incurred"]))
+    lhs = cl.model_diagnostics(est,groupby=['Line'])
+    rhs = cl.model_diagnostics(cl.Chainladder().fit(dev.transform(prism["Incurred"].groupby('Line').sum())))
+    assert np.allclose(lhs['Ultimate'].values,rhs['Ultimate'].values,atol=atol,equal_nan=True)
+    assert np.allclose(lhs['IBNR'].values,rhs['IBNR'].values,atol=atol,equal_nan=True)
+    
 
 def test_concat_immutability(raa):
     u = cl.Chainladder().fit(raa).ultimate_

--- a/chainladder/utils/tests/test_utilities.py
+++ b/chainladder/utils/tests/test_utilities.py
@@ -115,11 +115,6 @@ def test_concat(clrd):
     )
 
 
-def test_model_diagnostics(qtr,atol):
-    md = cl.model_diagnostics(cl.Chainladder().fit_predict(qtr))
-    assert np.allclose(md['Latest'].values.swapaxes(0,1),qtr.latest_diagonal.values,atol=atol,equal_nan=True)
-
-
 def test_model_diagnostics_erorr(raa):
     with pytest.raises(ValueError):
         cl.model_diagnostics(raa)
@@ -131,7 +126,7 @@ def test_model_diagnostics_groupby(prism,atol):
     lhs = cl.model_diagnostics(est,groupby=['Line'])
     rhs = cl.model_diagnostics(cl.Chainladder().fit(dev.transform(prism["Incurred"].groupby('Line').sum())))
     assert np.allclose(lhs['Ultimate'].values,rhs['Ultimate'].values,atol=atol,equal_nan=True)
-    assert np.allclose(lhs['IBNR'].values,rhs['IBNR'].values,atol=atol,equal_nan=True)
+    assert np.allclose(np.nan_to_num(lhs['IBNR'].values),np.nan_to_num(rhs['IBNR'].values),atol=atol,equal_nan=True)
     
 
 def test_concat_immutability(raa):

--- a/chainladder/utils/tests/test_utilities.py
+++ b/chainladder/utils/tests/test_utilities.py
@@ -115,6 +115,11 @@ def test_concat(clrd):
     )
 
 
+def test_model_diagnostics(qtr):
+    md = cl.model_diagnostics(cl.Chainladder().fit(qtr))
+    assert np.allclose(md['Latest'].values,qtr.latest_diagonal.values,atol=atol,equal_nan=True)
+
+
 def test_model_diagnostics_erorr(raa):
     with pytest.raises(ValueError):
         cl.model_diagnostics(raa)

--- a/chainladder/utils/utility_functions.py
+++ b/chainladder/utils/utility_functions.py
@@ -20,7 +20,7 @@ from sklearn.base import BaseEstimator, TransformerMixin
 from typing import Iterable, Union, Optional, TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from chainladder import Triangle
+    from chainladder import Triangle, MethodBase
     from numpy.typing import ArrayLike
     from pandas import DataFrame
     from sparse import COO
@@ -689,15 +689,18 @@ class PatsyFormula(BaseEstimator, TransformerMixin):
         return dmatrix(self.design_info_, X)
 
 
-def model_diagnostics(model, name=None, groupby=None):
+def model_diagnostics(
+        model:Triangle|MethodBase|Pipeline, 
+        name:str|None=None, 
+        groupby:str|list(str)|None=None) -> Triangle:
     """A helper function that summarizes various vectors of an
     IBNR model as columns of a Triangle
 
     Parameters
     ----------
-    model:
-        A chainladder IBNR estimator or Pipeline
-    name:
+    model: Triangle|MethodBase|Pipeline
+        A predicted Triangle, chainladder IBNR estimator or Pipeline
+    name: str, optional (default=None)
         An alias to give the model. This will be added to the index of the return
         triangle.
     groupby:
@@ -713,13 +716,16 @@ def model_diagnostics(model, name=None, groupby=None):
         obj = copy.deepcopy(model.steps[-1][-1])
     else:
         obj = copy.deepcopy(model)
+    if not (hasattr(obj,"ultimate_") & hasattr(obj,"ibnr_") & hasattr(obj,"ldf_")):
+        raise ValueError("model does not have ultimate_/ibnr_/ldf_")
+    if isinstance(model, Triangle):
+        obj.X_ = obj
     if groupby is not None:
         obj.X_ = obj.X_.groupby(groupby).sum().cum_to_incr()
         obj.ultimate_ = obj.ultimate_.groupby(groupby).sum()
         if hasattr(obj, "expectation_"):
             obj.expectation_ = obj.expectation_.groupby(groupby).sum()
-    else:
-        obj.X_ = obj.X_.incr_to_cum()
+    obj.X_ = obj.X_.incr_to_cum()
     val = obj.X_.valuation
     latest = obj.X_.sum("development")
     run_off = obj.full_expectation_.iloc[..., :-1].dev_to_val().cum_to_incr()
@@ -761,8 +767,8 @@ def model_diagnostics(model, name=None, groupby=None):
             ).sum("development")[col]
         else:
             out["Year Incremental"] = 0
-        out["IBNR"] = obj.ibnr_[col]
         out["Ultimate"] = obj.ultimate_[col]
+        out["IBNR"] = out["Ultimate"] - out["Latest"]
         for i in range(run_off.shape[-1]):
             out["Run Off " + str(i + 1)] = run_off[col].iloc[..., i]
         if hasattr(obj, "expectation_"):

--- a/chainladder/utils/utility_functions.py
+++ b/chainladder/utils/utility_functions.py
@@ -710,7 +710,7 @@ def model_diagnostics(
     -------
     Triangle up select origin vectors, IBNR, ultimate, Latest diagonal, etc.
     """
-    from chainladder import Pipeline
+    from chainladder import Pipeline, Triangle
 
     if isinstance(model, Pipeline):
         obj = copy.deepcopy(model.steps[-1][-1])

--- a/chainladder/utils/utility_functions.py
+++ b/chainladder/utils/utility_functions.py
@@ -725,7 +725,7 @@ def model_diagnostics(
         obj.ultimate_ = obj.ultimate_.groupby(groupby).sum()
         if hasattr(obj, "expectation_"):
             obj.expectation_ = obj.expectation_.groupby(groupby).sum()
-    obj.X_ = obj.X_.incr_to_cum()
+    obj.X_ = obj.X_.cum_to_incr()
     val = obj.X_.valuation
     latest = obj.X_.sum("development")
     run_off = obj.full_expectation_.iloc[..., :-1].dev_to_val().cum_to_incr()


### PR DESCRIPTION
## Summary of Changes  
fixing bug on latest
adding support for predicted triangles
adding more tests
simplifying some existing tests

## Related GitHub Issue(s)  


## Additional Context for Reviewers  


- [X] I passed tests locally for both code (`uv run pytest`) and documentation changes (`uv run jb build docs --builder=custom --custom-builder=doctest`)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes diagnostic outputs (Latest/IBNR) that downstream users may rely on, though behavior is now aligned with ultimate and latest diagonal; scope is limited to a utility helper plus tests.
> 
> **Overview**
> **`model_diagnostics`** is updated so **Latest** and **IBNR** line up with triangle semantics: loss data is always taken through **`cum_to_incr()`** (replacing the prior **`incr_to_cum()`** path when not grouping), and **IBNR** is **`Ultimate − Latest`** instead of **`obj.ibnr_`**. The helper also accepts a **fitted/predicted `Triangle`**, rejects inputs without **`ultimate_` / `ibnr_` / `ldf_`**, and documents **`Triangle | MethodBase | Pipeline`** in its signature.
> 
> Tests add **`np.allclose`** checks that **`model_diagnostics`** matches **`latest_diagonal`** and **`ultimate_`** on fit and **`predict`** across several estimators, a **`groupby`** parity test on prism, and a **`ValueError`** when passing a raw triangle; a few predict tests are simplified (fixtures, sample-weight expectations, **`clrd`** ordering).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fd8af0bdfbcbd78c54e31528d8a39a9cc66495c7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->