### PR TITLE
docs(utilities): live list_samples table + model_diagnostics demo (#915)

### DIFF
--- a/docs/user_guide/utilities.ipynb
+++ b/docs/user_guide/utilities.ipynb
@@ -2,7 +2,6 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "7e2c2fa7-9d32-404b-9121-51d06ac57324",
    "metadata": {},
    "source": [
     "# Utilities\n",
@@ -13,38 +12,54 @@
     "\n",
     "## Sample Datasets\n",
     "\n",
-    "A variety of datasets can be loaded using :func:`load_sample()`.  These are\n",
-    "sample datasets that are used in a variety of examples within this\n",
-    "documentation.\n",
+    "A variety of datasets can be loaded using `load_sample()`. These are sample\n",
+    "datasets that are used throughout the examples in this documentation. The full\n",
+    "list is available through `list_samples()`, which returns a table of every\n",
+    "bundled dataset along with its index, columns, and grain."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import chainladder as cl\n",
     "\n",
+    "cl.list_samples()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Model Diagnostics\n",
     "\n",
-    "| Dataset   | Description                                          | \n",
-    "|-----------|------------------------------------------------------|\n",
-    "| abc       | ABC Data                                             |\n",
-    "| auto      | Auto Data                                            |\n",
-    "| berqsherm | Data from the Berquist Sherman paper                 |\n",
-    "| cc_sample | Sample Insurance Data for Cape Cod Method in Struhuss|\n",
-    "| clrd      | CAS Loss Reserving Database                          |\n",
-    "| genins    | General Insurance Data used in Clark                 |\n",
-    "| ia_sample | Sample data for Incremental Additive Method in Schmidt|\n",
-    "| liab      | more data|\n",
-    "| m3ir5     | more data|\n",
-    "| mcl       | Sample insurance data for Munich Adjustment in Quarg|\n",
-    "| mortgage  | more data|\n",
-    "| mw2008    | more data|\n",
-    "| mw2014    | more data|\n",
-    "| quarterly | Sample data to demonstrate changing Triangle grain|\n",
-    "| raa       | Sample data used in Mack Chainladder|\n",
-    "| ukmotor   | more data|\n",
-    "| usaa      | more data|\n",
-    "| usauto    | more data|\n",
-    "\n",
-    "\n",
+    "`model_diagnostics()` summarizes a fitted IBNR model into a single Triangle\n",
+    "whose columns are the diagnostic vectors of interest, such as the latest\n",
+    "diagonal, IBNR, and ultimate. It accepts a fitted estimator or a `Pipeline`,\n",
+    "and an optional `groupby` to summarize at a coarser index level."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "model = cl.Chainladder().fit(cl.load_sample('raa'))\n",
+    "cl.model_diagnostics(model)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "## Chainladder Persistence\n",
     "\n",
-    "All estimators can be persisted to disk or database\n",
-    "using ``to_json`` or ``to_pickle``.  Restoring the estimator is as simple as\n",
-    "``cl.read_json`` or ``cl.read_pickle``.\n"
+    "All estimators can be persisted to disk or database using `to_json` or\n",
+    "`to_pickle`. Restoring the estimator is as simple as `cl.read_json` or\n",
+    "`cl.read_pickle`."
    ]
   },
   {


### PR DESCRIPTION
Closes #915.

Two changes to `docs/user_guide/utilities.ipynb`:

**Sample Datasets** — the section listed 18 datasets in a hand-maintained markdown table that had drifted out of date. The package now bundles 46. Replaced the static table with a live `cl.list_samples()` call so the docs render straight from the manifest and can no longer drift.

**Model Diagnostics** — `model_diagnostics()` is in the public API but was never demonstrated. Added a short section showing it against a fitted `Chainladder` model.

Verified both code cells execute against the current package (`list_samples()` returns the 46-row table, `model_diagnostics()` returns the summary Triangle).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only notebook edits with no runtime or API changes.
> 
> **Overview**
> Updates the **Utilities** user guide so sample-dataset and diagnostics docs stay aligned with the package.
> 
> **Sample Datasets** drops the hand-maintained markdown table (18 entries, many stale) in favor of prose pointing to `list_samples()` plus an executable `cl.list_samples()` cell, so the rendered table always matches the bundled manifest.
> 
> **Model Diagnostics** adds a new section documenting `model_diagnostics()` with a fitted `Chainladder` on `raa`.
> 
> The **Chainladder Persistence** blurb is lightly reworded (inline `` `to_json` `` / `` `read_pickle` `` style); behavior is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 169923e7f81a5ca39607bdfaf45aec4c2ab2ef53. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->