### PR TITLE
fixing formula for sigma

### DIFF
--- a/chainladder/utils/weighted_regression.py
+++ b/chainladder/utils/weighted_regression.py
@@ -100,19 +100,20 @@ class WeightedRegression(BaseEstimator):
         fitted_value = xp.repeat(xp.expand_dims(coef, axis), x.shape[axis], axis)
         fitted_value = fitted_value * x * (y * 0 + 1)
 
-        residual = (y - fitted_value) * xp.sqrt(w)
+        residual = (y - fitted_value)
 
-        wss_residual = xp.nansum(residual**2, axis)
+        wss_residual = xp.nansum(residual**2 * w, axis)
         mse_denom = xp.nansum((y * 0 + 1) * (xp.nan_to_num(w) != 0), axis) - 1
         mse_denom = num_to_nan(mse_denom)
         mse = wss_residual / mse_denom
 
         std_err = xp.sqrt(mse / denominator)
-        std_err = std_err[..., None]
-
+        sigma = std_err * xp.sqrt(mse_denom + 1)
+        
         coef = coef[..., None]
-        sigma = xp.sqrt(mse)[..., None]
-
+        sigma = sigma[..., None]
+        std_err = std_err[..., None]
+        
         self._w_reg = w
 
         self.slope_ = coef


### PR DESCRIPTION
## Summary of Changes  


## Related GitHub Issue(s)  


## Additional Context for Reviewers  


- [ ] I passed tests locally for both code (`uv run pytest`) and documentation changes (`uv run jb build docs --builder=custom --custom-builder=doctest`)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes Mack volatility and standard-error outputs that feed link-ratio development and stochastic reserving; limited scope to one regression path but can shift published sigma-based results.
> 
> **Overview**
> **Corrects Mack-style statistics** in `WeightedRegression._fit_OLS_thru_orig` (used by development/Munich fitting for `sigma_` and `std_err_`).
> 
> Residuals are no longer multiplied by `sqrt(w)` before squaring; instead **weighted sum of squares** uses `(y - fitted_value)**2 * w`, aligning MSE with standard weighted least squares.
> 
> **`sigma_` is no longer `sqrt(mse)`** — it is computed as `std_err * sqrt(mse_denom + 1)` (with `std_err = sqrt(mse / denominator)`), and the reshape order for `sigma_` vs `std_err_` is adjusted so both broadcast consistently.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 86ec9d36ec7f380a029d5c97300714595cd74ea4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->