### PR TITLE
#952 sigma fix

### DIFF
--- a/chainladder/development/tests/test_development.py
+++ b/chainladder/development/tests/test_development.py
@@ -691,3 +691,45 @@ def test_pipeline(clrd):
     assert np.array_equal(
         dev1.w_v2_.values, dev2.named_steps.drop_hilo.w_v2_.values, True
     )
+
+def test_sigma1(atol):
+    data = {
+        "valuation": [
+            1981,1982,1983,1984,1985,
+            1982,1983,1984,1985,
+            1983,1984,1985,
+            1984,1985,
+            1985,
+        ],
+        "origin": [
+            1981,1981,1981,1981,1981,
+            1982,1982,1982,1982,
+            1983,1983,1983,
+            1984,1984,
+            1985,
+        ],
+        "values": [
+            1000,1385,1700,1905,2000,
+            1000,1395,1700,1895,
+            1000,1405,1700,
+            1000,1415,
+            1000,
+        ],
+    }
+    tri = cl.Triangle(
+        data,
+        origin="origin",
+        development="valuation",
+        columns=["values"],
+        cumulative=True,
+    )
+    assert np.allclose(
+        cl.Development(average='simple').fit(tri).sigma_.values,
+        cl.Development(average='volume').fit(tri).sigma_.values,
+        atol = atol
+    )        
+    assert np.allclose(
+        cl.Development(average='simple').fit(tri).sigma_.values,
+        cl.Development(average='regression').fit(tri).sigma_.values,
+        atol = atol
+    )      

--- a/chainladder/utils/weighted_regression.py
+++ b/chainladder/utils/weighted_regression.py
@@ -100,19 +100,20 @@ class WeightedRegression(BaseEstimator):
         fitted_value = xp.repeat(xp.expand_dims(coef, axis), x.shape[axis], axis)
         fitted_value = fitted_value * x * (y * 0 + 1)
 
-        residual = (y - fitted_value) * xp.sqrt(w)
+        residual = (y - fitted_value)
 
-        wss_residual = xp.nansum(residual**2, axis)
+        wss_residual = xp.nansum(residual**2 * w, axis)
         mse_denom = xp.nansum((y * 0 + 1) * (xp.nan_to_num(w) != 0), axis) - 1
         mse_denom = num_to_nan(mse_denom)
         mse = wss_residual / mse_denom
 
         std_err = xp.sqrt(mse / denominator)
-        std_err = std_err[..., None]
-
+        sigma = std_err * xp.sqrt(mse_denom + 1)
+        
         coef = coef[..., None]
-        sigma = xp.sqrt(mse)[..., None]
-
+        sigma = sigma[..., None]
+        std_err = std_err[..., None]
+        
         self._w_reg = w
 
         self.slope_ = coef


### PR DESCRIPTION
## Summary of Changes  
fixing the calculation for sigma. this was previously unnoticed as the previous implementation yielded the correct result when `average = 'simple'`. 

## Related GitHub Issue(s)  
close #952 

## Additional Context for Reviewers  


- [X] I passed tests locally for both code (`uv run pytest`) and documentation changes (`uv run jb build docs --builder=custom --custom-builder=doctest`)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core Mack regression uncertainty used by `Development` and downstream stochastic methods; behavior changes for non-simple averages while simple-average outputs are intended to stay aligned with existing tests.
> 
> **Overview**
> Fixes **`sigma_`** (and how MSE is built) in `WeightedRegression._fit_OLS_thru_orig` so volume- and regression-weighted development factors get the right Mack-style standard deviation. Previously, residuals were scaled by `sqrt(w)` before squaring, and **`sigma_`** was set to `sqrt(mse)`; that matched **`average='simple'`** by accident but was wrong for other averaging modes.
> 
> The change uses unscaled residuals, accumulates **`residual**2 * w`**, and sets **`sigma_`** from **`std_err * sqrt(mse_denom + 1)`** (with **`std_err`** unchanged in role). Adds **`test_sigma1`**, which checks that **`sigma_`** agrees across simple, volume, and regression on a small triangle.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5ceb04d692e26dbc0c7120cad434e8f565250b88. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->