### PR TITLE
docs: link Triangle.minimum/maximum to util docs (#704)

### DIFF
--- a/chainladder/core/pandas.py
+++ b/chainladder/core/pandas.py
@@ -444,9 +444,17 @@ class TrianglePandas:
         return self.get_array_module().log(self)
 
     def minimum(self, other):
+        """Element-wise minimum of this Triangle and another operand.
+
+        See :func:`chainladder.minimum` for parameters, usage, and examples.
+        """
         return self.get_array_module().minimum(self, other)
 
     def maximum(self, other):
+        """Element-wise maximum of this Triangle and another operand.
+
+        See :func:`chainladder.maximum` for parameters, usage, and examples.
+        """
         return self.get_array_module().maximum(self, other)
 
     def sqrt(self):


### PR DESCRIPTION
@henrydingliu — per your #704 comment, this PR adds cross-links from `Triangle.minimum` / `Triangle.maximum` to the dedicated `chainladder.minimum` / `chainladder.maximum` doc pages. Would appreciate a look when you have a moment.

## Summary
- Add brief docstrings to `Triangle.minimum` and `Triangle.maximum` that cross-link to the dedicated `chainladder.minimum` / `chainladder.maximum` API pages (where the detailed #704 examples live)
- Addresses your request on #704: keep rich docs on the util functions, with pointers from the buried Triangle class methods

Refs #704

## Test plan
- [x] `pytest chainladder/core/tests/test_triangle.py::test_base_minimum_exposure_triangle`
- [x] `pytest chainladder/utils/tests/test_utilities.py -k "minimum or maximum"`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only docstring additions with no logic or public behavior changes.
> 
> **Overview**
> Adds short docstrings on **`Triangle.minimum`** and **`Triangle.maximum`** in `pandas.py` so Sphinx/help surfaces them on the class methods, with **`:func:`** cross-links to **`chainladder.minimum`** and **`chainladder.maximum`** where the full parameters, usage, and #704 examples already live.
> 
> No runtime or API behavior changes—only documentation discoverability from the Triangle API back to the util functions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5888449a6c8a8584d2c7c0f83f5a5314847fbb27. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->