### PR TITLE
docs: reset ULT_VAL after demo in methods notebook

### DIFF
--- a/docs/user_guide/methods.ipynb
+++ b/docs/user_guide/methods.ipynb
@@ -161,6 +161,18 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ult-val-reset",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Reset ULT_VAL to its default so the demo above does not affect later cells\n",
+    "cl.options.reset_option('ULT_VAL')\n",
+    "cl.options.get_option('ULT_VAL')"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "id": "retired-january",
    "metadata": {},


### PR DESCRIPTION
## Summary

The **Ultimates** section of `docs/user_guide/methods.ipynb` sets `ULT_VAL` to 2050 to demonstrate the option:

```python
cl.options.set_option('ULT_VAL', '2050-12-31 23:59:59.999999999')
```

but never restores it. `ULT_VAL` is a global option, so the mutated value carries forward to every later cell. The **Complete Triangles** run-off cell is the first to break on it:

```python
expected_3y_run_off = model.full_triangle_.dev_to_val().cum_to_incr().loc[..., '2014':'2016']
# ValueError: Could not convert object to NumPy timedelta
```

This is the same class of issue as #895 (an un-reset global option), just a different option. It is **not** a library regression: the run-off cell runs fine against released `0.9.2` in isolation, and runs fine on `experimental` once `ULT_VAL` is back at its default. The failure only appears in the full notebook execution where the mutated global is still in effect.

## Fix

Add a single cell immediately after the demo that resets the option:

```python
cl.options.reset_option('ULT_VAL')
cl.options.get_option('ULT_VAL')
```

## Verification

Reproduced the build locally with the RTD steps (`jupyter-book config sphinx docs/` then `sphinx-build`):

- Before: `docs/_build/html/reports/user_guide/methods.err.log` written, traceback rendered into `methods.html`.
- After: no `methods.err.log`, zero traceback markers in the rendered page, run-off output renders normally.

`reset_option('ULT_VAL')` restores the default (`2261-12-31 23:59:59.999999`) and the run-off cell returns shape `(1, 1, 7, 3)`.

Targeting `experimental` since that is where the rendered docs and the options refactor live.

## Note for reviewers

This is one of three notebooks whose cells currently raise during the docs build while the build still exits 0 (see the discussion on #895). The build does not fail on notebook execution errors because myst-nb's `nb_execution_raise_on_error` defaults to `False`. A follow-up will fix the remaining two (`gallery/plot_munich.ipynb`, `getting_started/tutorials/stochastic-tutorial.ipynb`) and then propose gating the build on notebook execution errors so these cannot ship silently again.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only notebook change with no library or runtime behavior changes.
> 
> **Overview**
> Adds a **reset cell** right after the `ULT_VAL` demo in `docs/user_guide/methods.ipynb` so the notebook calls `cl.options.reset_option('ULT_VAL')` before later examples run.
> 
> That stops the temporary `set_option('ULT_VAL', '2050-...')` from leaking as a **global** into downstream cells (notably the **Complete Triangles** IBNR run-off example), which otherwise raised `ValueError: Could not convert object to NumPy timedelta` during full notebook/docs execution.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e7c0bf00d7a63aafd3f739f4855fe9e712f06b90. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->