### PR TITLE
[DOCS] True up to_frame docstring

### DIFF
--- a/chainladder/core/pandas.py
+++ b/chainladder/core/pandas.py
@@ -76,15 +76,24 @@ class TrianglePandas:
         Parameters
         ----------
         origin_as_datetime : bool
-            Whether the origin vector should be converted from PeriodIndex
-            into a datetime dtype. Default is False.
+            When all dimensions are returned, whether the origin vector should be 
+            converted from PeriodIndex into a datetime dtype. Default is True.
         keepdims : bool
             If True, the triangle will be converted to a DataFrame with all
             dimensions intact.  The argument will force a consistent DataFrame
-            format regardless of whether any dimensions are of length 1.
+            format regardless of whether any dimensions are of length 1. 
+
+            If False, but 3 or more dimensions (index, column, origin, and development)
+            have lengths greater than 1, this parameter is treated as True. 
+
+            If False, and 2 or fewer dimensions (index, column, origin, and development)
+            have lengths greater than 1, those dimensions will no longer be included 
+            in the returning DataFrame
+            
+            Default is False.
         implicit_axis : bool
-            When keepdims is True, this denotes whether to include the implicit
-            valuation axis in addition to the origin and development.
+            When implicit_axis is True, this denotes whether to include the implicit
+            valuation axis in addition to the origin and development. Default is False.
 
         Returns
         -------

--- a/chainladder/core/pandas.py
+++ b/chainladder/core/pandas.py
@@ -75,25 +75,18 @@ class TrianglePandas:
 
         Parameters
         ----------
-        origin_as_datetime : bool
-            When all dimensions are returned, whether the origin vector should be 
-            converted from PeriodIndex into a datetime dtype. Default is True.
-        keepdims : bool
-            If True, the triangle will be converted to a DataFrame with all
-            dimensions intact.  The argument will force a consistent DataFrame
+        origin_as_datetime : bool (default = True)
+            When all dimensions are returned, whether the origin vector 
+            should be converted from PeriodIndex into a datetime dtype. 
+        keepdims : bool (default = False)
+            Converted DataFrame will keep all dimensions intact and maintain a consistent
             format regardless of whether any dimensions are of length 1. 
 
-            If False, but 3 or more dimensions (index, column, origin, and development)
-            have lengths greater than 1, this parameter is treated as True. 
-
-            If False, and 2 or fewer dimensions (index, column, origin, and development)
-            have lengths greater than 1, those dimensions will no longer be included 
-            in the returning DataFrame
-            
-            Default is False.
-        implicit_axis : bool
+            Ignored when 3 or more dimensions (index, column, origin, and development)
+            have lengths greater than 1
+        implicit_axis : bool (default = False)
             When implicit_axis is True, this denotes whether to include the implicit
-            valuation axis in addition to the origin and development. Default is False.
+            valuation axis in addition to the origin and development.
 
         Returns
         -------


### PR DESCRIPTION
## Summary of Changes  
fixing and enhancing docstring for to_frame

## Related GitHub Issue(s)  


## Additional Context for Reviewers  


- [ ] I passed tests locally for both code (`uv run pytest`) and documentation changes (`uv run jb build docs --builder=custom --custom-builder=doctest`)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docstring-only changes with no runtime or API behavior modifications.
> 
> **Overview**
> Documentation-only update to **`TrianglePandas.to_frame`** in `pandas.py`.
> 
> **`origin_as_datetime`** now documents the actual default **`True`** (the previous text incorrectly said default **False**) and clarifies that datetime conversion applies when all dimensions are returned.
> 
> **`keepdims`** and **`implicit_axis`** use `(default = …)` in the parameter lines; **`keepdims`** adds that it is **ignored** when three or more triangle axes (index, columns, origin, development) have length greater than one—matching the branch that still returns long format via an internal `keepdims=True` call.
> 
> No implementation changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 298edcb9307e2642c10616a415ad790771140c47. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->