### PR TITLE
test: replace stale xfails with pytest.raises (#963)

### DIFF
--- a/chainladder/core/tests/test_arithmetic.py
+++ b/chainladder/core/tests/test_arithmetic.py
@@ -59,7 +59,6 @@ def test_index_broadcasting4(clrd):
     assert (a.index == c.index).all().all()
 
 
-@pytest.mark.xfail
 def test_index_broadacsting4(clrd):
     """ If one triangle has key_labels that are not a subset of the other, then fail """
     a = clrd['CumPaidLoss']
@@ -67,7 +66,8 @@ def test_index_broadacsting4(clrd):
     idx = b.index
     idx['New Field'] = 'New'
     b.index = idx
-    c = a + b
+    with pytest.raises(ValueError, match="Index broadcasting is ambiguous"):
+        a + b
 
 def test_index_broadcasting5(clrd):
     """ If a and b have shared key labels but no matching levels, then they will stack """

--- a/chainladder/core/tests/test_triangle.py
+++ b/chainladder/core/tests/test_triangle.py
@@ -15,12 +15,6 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from chainladder import Triangle
 
-try:
-    from IPython.core.display import HTML
-except ImportError:
-    HTML = None
-
-
 def test_repr(raa):
     np.testing.assert_array_equal(
         pd.read_html(StringIO(raa._repr_html_()))[0].set_index("Unnamed: 0").values,
@@ -435,12 +429,12 @@ def test_correct_valutaion(raa):
     assert new.valuation_date == raa.valuation_date
 
 
-@pytest.mark.xfail
 @pytest.mark.parametrize(
     "prop", ["cdf_", "ibnr_", "full_expectation_", "full_triangle_"]
 )
 def test_no_fitted(raa, prop):
-    getattr(raa, prop)
+    with pytest.raises(AttributeError, match=f"no attribute '{prop}'"):
+        getattr(raa, prop)
 
 
 def test_pipe(raa):
@@ -453,11 +447,6 @@ def test_pipe(raa):
 def test_repr_html(raa, clrd):
     assert type(raa._repr_html_()) == str
     assert type(clrd._repr_html_()) == str
-
-
-@pytest.mark.xfail(HTML is None, reason="ipython needed for test")
-def test_heatmap(raa):
-    raa.link_ratio.heatmap()
 
 
 def test_agg_sparse():


### PR DESCRIPTION
## Summary
- Replace stale `@pytest.mark.xfail` decorators with explicit `pytest.raises` in `test_no_fitted` and `test_index_broadacsting4`
- Remove redundant `test_heatmap` xfail from `test_triangle.py` (coverage already exists in `test_display.py`)

Remaining xfails (`test_new_drop_10`, `test_sparse_at_iat`) are out of scope here. `test_new_drop_10` needs a separate PR; cc @henrydingliu for that follow-up.

## Test plan
- [x] `pytest chainladder/core/tests/test_triangle.py::test_no_fitted`
- [x] `pytest chainladder/core/tests/test_arithmetic.py::test_index_broadacsting4`
- [x] `pytest chainladder/core/tests/test_display.py -k heatmap`

Closes #963

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to test files; no production code or runtime behavior is modified.
> 
> **Overview**
> Test-only cleanup: stale **expected-failure** markers are replaced with **assertions that document current behavior**, and one duplicate test is removed.
> 
> **`test_arithmetic.py`:** `test_index_broadacsting4` now expects a **`ValueError`** with message *"Index broadcasting is ambiguous"* when adding triangles whose index key labels are not a compatible subset, instead of marking the test as xfail.
> 
> **`test_triangle.py`:** `test_no_fitted` now asserts **`AttributeError`** when accessing unfitted estimator properties (`cdf_`, `ibnr_`, etc.) on a raw triangle. The optional **IPython** import and **`test_heatmap`** xfail test are removed because heatmap behavior is already covered in **`test_display.py`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 210cbf4aca88d339b6c981decf88349a62b0e895. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->