### PR TITLE
docs: show full inherited method docstrings on Triangle API page (#970)

### DIFF
--- a/docs/_templates/autosummary/class_inherited.rst
+++ b/docs/_templates/autosummary/class_inherited.rst
@@ -4,23 +4,6 @@
 
 .. autoclass:: {{ objname }}
    :members:
+   :inherited-members:
    :undoc-members:
    :exclude-members: set_fit_request, set_predict_request, set_score_request, set_transform_request, {{ attributes | join(', ') }}
-
-{% set inherited = [] %}
-{% for method in methods %}
-{% if method in inherited_members and not method.startswith('_') %}
-{% set _ = inherited.append(method) %}
-{% endif %}
-{% endfor %}
-
-{% if inherited %}
-.. rubric:: Inherited Methods
-
-.. autosummary::
-   :nosignatures:
-
-{% for method in inherited %}
-   {{ objname }}.{{ method }}
-{% endfor %}
-{% endif %}


### PR DESCRIPTION
﻿@henrydingliu — rebased onto `experimental` and retargeted this PR accordingly.

## Summary
- Add `:inherited-members:` to `docs/_templates/autosummary/class_inherited.rst`
- Remove the separate inherited-methods autosummary block that only showed signatures/links
- Affects `Triangle`, `DevelopmentCorrelation`, and `ValuationCorrelation` API pages

Fixes #970

## Test plan
- [x] `jb build .` from `docs/` completes successfully
- [x] Built `chainladder.Triangle.html` shows inline docs for inherited methods (e.g. `dev_to_val`, `minimum`) and no "Inherited Methods" rubric

Supersedes #975
