### PR TITLE
Fix and enhance utils.model diagnostics part 5

### DIFF
--- a/chainladder/utils/tests/test_utilities.py
+++ b/chainladder/utils/tests/test_utilities.py
@@ -118,7 +118,8 @@ def test_concat(clrd):
 def test_model_diagnostics_erorr(raa,atol):
     with pytest.raises(ValueError):
         cl.model_diagnostics(raa)
-    est = cl.Chainladder().fit(raa)
+    dev = cl.Development().fit_transform(raa)
+    est = cl.Chainladder().fit(dev)
     emerg = est.full_expectation_.cum_to_incr()
     md = cl.model_diagnostics(est)
     assert np.allclose(
@@ -130,6 +131,18 @@ def test_model_diagnostics_erorr(raa,atol):
     assert np.allclose(
         md['Year Incremental'].values,
         raa.cum_to_incr().latest_diagonal.values,
+        atol=atol,
+        equal_nan=True
+    )
+    assert np.allclose(
+        md['LDF'].values.flatten()[:0:-1],
+        dev.ldf_.values.flatten(),
+        atol=atol,
+        equal_nan=True
+    )
+    assert np.allclose(
+        md['CDF'].values.flatten()[:0:-1],
+        dev.cdf_.values.flatten(),
         atol=atol,
         equal_nan=True
     )

--- a/chainladder/utils/tests/test_utilities.py
+++ b/chainladder/utils/tests/test_utilities.py
@@ -115,9 +115,24 @@ def test_concat(clrd):
     )
 
 
-def test_model_diagnostics_erorr(raa):
+def test_model_diagnostics_erorr(raa,atol):
     with pytest.raises(ValueError):
         cl.model_diagnostics(raa)
+    est = cl.Chainladder().fit(raa)
+    emerg = est.full_expectation_.cum_to_incr()
+    md = cl.model_diagnostics(est)
+    assert np.allclose(
+        md['Run Off 1'].values,
+        emerg[emerg.valuation.year==1991].latest_diagonal.values,
+        atol=atol,
+        equal_nan=True
+    )
+    assert np.allclose(
+        md['Year Incremental'].values,
+        raa.cum_to_incr().latest_diagonal.values,
+        atol=atol,
+        equal_nan=True
+    )
 
 
 def test_model_diagnostics_groupby(prism,atol):

--- a/chainladder/utils/utility_functions.py
+++ b/chainladder/utils/utility_functions.py
@@ -946,7 +946,16 @@ def model_diagnostics(
 
     Returns
     -------
-    Triangle up select origin vectors, IBNR, ultimate, Latest diagonal, etc.
+    Triangle with relevant figures as columns, including 
+    - Latest
+    - Month/Quarter/Year Incremental: Actual emergence from the latest month/quarter/year
+    - LDF
+    - CDF
+    - Ultimate
+    - IBNR
+    - Run Off 1/2/3...: Expected emergence for the next development period
+
+    Columns from the original Triangle are cross-joined into the index
     """
     from chainladder import Pipeline, Triangle
 
@@ -1005,6 +1014,9 @@ def model_diagnostics(
             ).sum("development")[col]
         else:
             out["Year Incremental"] = 0
+        if groupby is None:
+            out["LDF"] = obj.ldf_.align_pattern(obj.X_.incr_to_cum(),sample_weight = obj.ultimate_[col])[col]
+            out["CDF"] = obj.cdf_.align_pattern(obj.X_.incr_to_cum(),sample_weight = obj.ultimate_[col])[col]
         out["Ultimate"] = obj.ultimate_[col]
         out["IBNR"] = out["Ultimate"] - out["Latest"]
         for i in range(run_off.shape[-1]):


### PR DESCRIPTION
## Summary of Changes  
adding CDF and LDF
adding detail to docstring
adding test

## Related GitHub Issue(s)  
closes #839

## Additional Context for Reviewers  


- [X] I passed tests locally for both code (`uv run pytest`) and documentation changes (`uv run jb build docs --builder=custom --custom-builder=doctest`)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive diagnostics columns and expanded tests on a utility helper; no changes to core reserving math beyond exposing existing ldf_/cdf_ through align_pattern.
> 
> **Overview**
> **`model_diagnostics`** now includes **`LDF`** and **`CDF`** columns (via `align_pattern` on the fitted cumulative triangle, weighted by ultimate) when **`groupby` is not used**; grouped summaries still omit those columns. The function docstring documents the full set of diagnostic columns and index behavior.
> 
> **`test_model_diagnostics_erorr`** keeps the invalid-input check and adds a fitted Chainladder path that asserts Run Off 1, Year Incremental, LDF, and CDF match the underlying model/development objects.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c30d94779f3d0f8e93e2a218ee20976bf20b16b6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->