### PR TITLE
Fix and enhance utils.model diagnostics part 5

### DIFF
--- a/chainladder/methods/tests/test_predict.py
+++ b/chainladder/methods/tests/test_predict.py
@@ -49,6 +49,18 @@ def test_predict_and_weights(estimators,atol):
     )   
     #Test validation of sample_weight requirement. Should raise a value error if no weight is supplied.
     if estimators in [cl.CapeCod,cl.BornhuetterFerguson,cl.ExpectedLoss,cl.Benktander]:
+        assert np.allclose(
+            est.expectation_.values.swapaxes(0,1),
+            cl.model_diagnostics(est)['Apriori'].values,
+            atol=atol,
+            equal_nan=True
+        )
+        assert np.allclose(
+            pred.expectation_.values.swapaxes(0,1),
+            cl.model_diagnostics(pred)['Apriori'].values,
+            atol=atol,
+            equal_nan=True
+        )   
         with pytest.raises(ValueError):
             estimators().fit(raa_1989)
         with pytest.raises(ValueError):

--- a/chainladder/utils/tests/test_utilities.py
+++ b/chainladder/utils/tests/test_utilities.py
@@ -118,7 +118,8 @@ def test_concat(clrd):
 def test_model_diagnostics_erorr(raa,atol):
     with pytest.raises(ValueError):
         cl.model_diagnostics(raa)
-    est = cl.Chainladder().fit(raa)
+    dev = cl.Development().fit_transform(raa)
+    est = cl.Chainladder().fit(dev)
     emerg = est.full_expectation_.cum_to_incr()
     md = cl.model_diagnostics(est)
     assert np.allclose(
@@ -130,6 +131,18 @@ def test_model_diagnostics_erorr(raa,atol):
     assert np.allclose(
         md['Year Incremental'].values,
         raa.cum_to_incr().latest_diagonal.values,
+        atol=atol,
+        equal_nan=True
+    )
+    assert np.allclose(
+        md['LDF'].values.flatten()[:0:-1],
+        dev.ldf_.values.flatten(),
+        atol=atol,
+        equal_nan=True
+    )
+    assert np.allclose(
+        md['CDF'].values.flatten()[:0:-1],
+        dev.cdf_.values.flatten(),
         atol=atol,
         equal_nan=True
     )

--- a/chainladder/utils/tests/test_utilities.py
+++ b/chainladder/utils/tests/test_utilities.py
@@ -115,9 +115,24 @@ def test_concat(clrd):
     )
 
 
-def test_model_diagnostics_erorr(raa):
+def test_model_diagnostics_erorr(raa,atol):
     with pytest.raises(ValueError):
         cl.model_diagnostics(raa)
+    est = cl.Chainladder().fit(raa)
+    emerg = est.full_expectation_.cum_to_incr()
+    md = cl.model_diagnostics(est)
+    assert np.allclose(
+        md['Run Off 1'].values,
+        emerg[emerg.valuation.year==1991].latest_diagonal.values,
+        atol=atol,
+        equal_nan=True
+    )
+    assert np.allclose(
+        md['Year Incremental'].values,
+        raa.cum_to_incr().latest_diagonal.values,
+        atol=atol,
+        equal_nan=True
+    )
 
 
 def test_model_diagnostics_groupby(prism,atol):

--- a/chainladder/utils/utility_functions.py
+++ b/chainladder/utils/utility_functions.py
@@ -946,7 +946,16 @@ def model_diagnostics(
 
     Returns
     -------
-    Triangle up select origin vectors, IBNR, ultimate, Latest diagonal, etc.
+    Triangle with relevant figures as columns, including 
+    - Latest
+    - Month/Quarter/Year Incremental: Actual emergence from the latest month/quarter/year
+    - LDF
+    - CDF
+    - Ultimate
+    - IBNR
+    - Run Off 1/2/3...: Expected emergence for the next development period
+
+    Columns from the original Triangle are cross-joined into the index
     """
     from chainladder import Pipeline, Triangle
 
@@ -1005,6 +1014,9 @@ def model_diagnostics(
             ).sum("development")[col]
         else:
             out["Year Incremental"] = 0
+        if groupby is None:
+            out["LDF"] = obj.ldf_.align_pattern(obj.X_.incr_to_cum(),sample_weight = obj.ultimate_[col])[col]
+            out["CDF"] = obj.cdf_.align_pattern(obj.X_.incr_to_cum(),sample_weight = obj.ultimate_[col])[col]
         out["Ultimate"] = obj.ultimate_[col]
         out["IBNR"] = out["Ultimate"] - out["Latest"]
         for i in range(run_off.shape[-1]):

--- a/chainladder/utils/utility_functions.py
+++ b/chainladder/utils/utility_functions.py
@@ -952,7 +952,7 @@ def model_diagnostics(
     - ``LDF``: Age-to-age loss development factor to the next development/valuation period (from ``ldf_``); ignored if ``groupby`` is supplied
     - ``CDF``: Cumulative loss development factor from current age to ultimate (from ``cdf_``); ignored if ``groupby`` is supplied
     - ``Ultimate``: Projected ultimate loss from the fitted IBNR model (``ultimate_``)
-    - ``IBNR``: Ultiamte - Latest
+    - ``IBNR``: Ultimate - Latest
     - ``Run Off 1/2/3...``: Expected incremental emergence in successive future valuation periods (from ``full_expectation_``)
     - ``Apriori``: Expected ultimate for Benktander family of methods (from ``expectation_``)
 

--- a/chainladder/utils/utility_functions.py
+++ b/chainladder/utils/utility_functions.py
@@ -947,13 +947,13 @@ def model_diagnostics(
     Returns
     -------
     Triangle with relevant figures as columns, including 
-    - Latest
-    - Month/Quarter/Year Incremental: Actual emergence from the latest month/quarter/year
-    - LDF
-    - CDF
-    - Ultimate
-    - IBNR
-    - Run Off 1/2/3...: Expected emergence for the next development period
+    - ``Latest``: Cumulative value at the latest valuation date, equivalent to ``latest_diagonal``
+    - ``Month/Quarter/Year Incremental``: Actual emergence between the latest valuation and the one prior valuation date
+    - ``LDF``: Age-to-age loss development factor to the next development/valuation period (from ``ldf_``)
+    - ``CDF``: Cumulative loss development factor from current age to ultimate (from ``cdf_``)
+    - ``Ultimate``: Projected ultimate loss from the fitted IBNR model (``ultimate_``)
+    - ``IBNR``: Ultiamte - Latest
+    - ``Run Off 1/2/3...``: Expected incremental emergence in successive future valuation periods (from ``full_expectation_``)
 
     Columns from the original Triangle are cross-joined into the index
     """

--- a/chainladder/utils/utility_functions.py
+++ b/chainladder/utils/utility_functions.py
@@ -949,13 +949,14 @@ def model_diagnostics(
     Triangle with relevant figures as columns, including 
     - ``Latest``: Cumulative value at the latest valuation date, equivalent to ``latest_diagonal``
     - ``Month/Quarter/Year Incremental``: Actual emergence between the latest valuation and the one prior valuation date
-    - ``LDF``: Age-to-age loss development factor to the next development/valuation period (from ``ldf_``)
-    - ``CDF``: Cumulative loss development factor from current age to ultimate (from ``cdf_``)
+    - ``LDF``: Age-to-age loss development factor to the next development/valuation period (from ``ldf_``); ignored if ``groupby`` is supplied
+    - ``CDF``: Cumulative loss development factor from current age to ultimate (from ``cdf_``); ignored if ``groupby`` is supplied
     - ``Ultimate``: Projected ultimate loss from the fitted IBNR model (``ultimate_``)
     - ``IBNR``: Ultiamte - Latest
     - ``Run Off 1/2/3...``: Expected incremental emergence in successive future valuation periods (from ``full_expectation_``)
+    - ``Apriori``: Expected ultimate for Benktander family of methods (from ``expectation_``)
 
-    Columns from the original Triangle are cross-joined into the index
+    Columns from the original Triangle are cross-joined into the index. ``Measure`` will contain all the columns from the original Triangle. 
     """
     from chainladder import Pipeline, Triangle
 


### PR DESCRIPTION
## Summary of Changes  
adding CDF and LDF
adding detail to docstring
adding test

## Related GitHub Issue(s)  
closes #839

## Additional Context for Reviewers  


- [X] I passed tests locally for both code (`uv run pytest`) and documentation changes (`uv run jb build docs --builder=custom --custom-builder=doctest`)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to a diagnostics helper, documentation, and regression tests; reserving logic is unchanged aside from exposing existing factors in the summary output.
> 
> **Overview**
> Extends **`model_diagnostics`** so the summary triangle includes **`LDF`** and **`CDF`** columns (aligned to the model triangle via `ldf_` / `cdf_` and `align_pattern`) when **`groupby`** is not used; grouped summaries still omit those columns, as documented.
> 
> The function docstring now describes the full set of output columns (Latest, incrementals, LDF/CDF, Ultimate, IBNR, Run Off, Apriori).
> 
> **Tests** pin those behaviors: Chainladder diagnostics are checked against `full_expectation_` run-off, year incremental actuals, and Development `ldf_`/`cdf_`; Benktander-family fit/predict paths assert **`Apriori`** matches **`expectation_`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 129c08ec36692c1e4b56e5c866cb385335c9fb5b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->