### PR TITLE
docs: add docstrings for Triangle broadcast_axis, copy, reindex (#970)

### DIFF
--- a/chainladder/core/triangle.py
+++ b/chainladder/core/triangle.py
@@ -1846,6 +1846,11 @@ class Triangle(TriangleBase):
         return obj
 
     def broadcast_axis(self, axis, value):
+        """Broadcast values along an axis.
+
+        .. deprecated::
+            Use Triangle arithmetic for broadcasting instead.
+        """
         warnings.warn(
             """
             Broadcast axis is deprecated in favor of broadcasting
@@ -1854,6 +1859,13 @@ class Triangle(TriangleBase):
         return self
 
     def copy(self):
+        """Return a shallow copy of the Triangle.
+
+        Returns
+        -------
+        Triangle
+            A new Triangle with copied ``values`` and shared metadata.
+        """
         X = object.__new__(self.__class__)
         X.__dict__.update(vars(self))
         X._set_slicers()
@@ -2149,6 +2161,22 @@ class Triangle(TriangleBase):
         return obj
 
     def reindex(self, columns=None, fill_value=np.nan):
+        """Conform Triangle columns to a new set of labels.
+
+        Any column in ``columns`` that is not already present is added and
+        filled with ``fill_value``.
+
+        Parameters
+        ----------
+        columns : list
+            Column labels for the returned Triangle.
+        fill_value : float, default nan
+            Value assigned to newly added columns.
+
+        Returns
+        -------
+        Triangle
+        """
         obj = self.copy()
         for column in columns:
             if column not in obj.columns:


### PR DESCRIPTION
@henrydingliu First in a series of small #970 follow-up PRs (methods only, properties deferred per your guidance).

## Summary
- Add docstrings for `Triangle.broadcast_axis`, `copy`, and `reindex`

Refs #970

## Test plan
- [x] Docstrings only, no runtime changes

## Series plan
1. This PR: `triangle.py` methods
2. Skip min/max cross-links (already on `experimental` via main sync)
3. Next: `pandas.py` ufuncs, then indexing helpers, then `compute`/`pipe`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docstring-only changes with no runtime or behavioral impact.
> 
> **Overview**
> Documentation-only follow-up to #970: adds NumPy-style docstrings on **`Triangle`** in `triangle.py` for three methods that previously had little or no API text.
> 
> **`broadcast_axis`** now documents that it broadcasts along an axis and includes a **`.. deprecated::`** note pointing users to Triangle arithmetic instead (behavior and existing `warnings.warn` are unchanged).
> 
> **`copy`** documents that it returns a shallow copy: new **`values`** array, shared metadata.
> 
> **`reindex`** documents conforming column labels, adding missing columns with **`fill_value`** (default **`nan`**), plus **Parameters** / **Returns** sections.
> 
> No logic, signatures, or tests change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cb1ef404d9b03e939da829859cdf25880eff9754. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->