### PR TITLE
docs: add docstrings for Triangle exp, log, sqrt, round (#970)

### DIFF
--- a/chainladder/core/pandas.py
+++ b/chainladder/core/pandas.py
@@ -438,9 +438,21 @@ class TrianglePandas:
         return self.iloc[self.index.sort_values(self.key_labels, *args, **kwargs).index]
 
     def exp(self):
+        """Return the exponential of each element.
+
+        Returns
+        -------
+        Triangle
+        """
         return self.get_array_module().exp(self)
 
     def log(self):
+        """Return the natural logarithm of each element.
+
+        Returns
+        -------
+        Triangle
+        """
         return self.get_array_module().log(self)
 
     def minimum(self, other):
@@ -458,9 +470,26 @@ class TrianglePandas:
         return self.get_array_module().maximum(self, other)
 
     def sqrt(self):
+        """Return the non-negative square root of each element.
+
+        Returns
+        -------
+        Triangle
+        """
         return self.get_array_module().sqrt(self)
 
     def round(self, decimals=0, *args, **kwargs):
+        """Round each element to the given number of decimal places.
+
+        Parameters
+        ----------
+        decimals : int, default 0
+            Number of decimal places to round to.
+
+        Returns
+        -------
+        Triangle
+        """
         return round(self, decimals)
 
     def xs(

--- a/chainladder/core/pandas.py
+++ b/chainladder/core/pandas.py
@@ -481,6 +481,10 @@ class TrianglePandas:
     def round(self, decimals=0, *args, **kwargs):
         """Round each element to the given number of decimal places.
 
+        Uses banker's rounding (round half to even). For example,
+        ``(8.5).round(0)`` returns 8, not 9. For conventional rounding,
+        add a small epsilon before rounding, e.g. ``(tri + 1e-9).round(0)``.
+
         Parameters
         ----------
         decimals : int, default 0


### PR DESCRIPTION
@henrydingliu Part 3 of #970 method docstring follow-up (methods only).

## Summary
- Add docstrings for `Triangle.exp`, `log`, `sqrt`, and `round`

Refs #970

## Test plan
- [x] Docstrings only, no runtime changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docstrings only; no behavior or API signature changes.
> 
> **Overview**
> Adds NumPy-style docstrings on **`TrianglePandas`** for element-wise **`exp`**, **`log`**, and **`sqrt`**, each documenting that they return a **`Triangle`**.
> 
> **`round`** gets a fuller docstring: **`decimals`** parameter, return type, and a note that rounding uses **banker's rounding** (half to even), with a tip to add epsilon for conventional rounding.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a213e93f5217ad19a4d2a0e0ea00a66d23d907e3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->