### PR TITLE
docs: add docstrings for Triangle head, tail, sort_index (#970)

### DIFF
--- a/chainladder/core/pandas.py
+++ b/chainladder/core/pandas.py
@@ -429,12 +429,12 @@ class TrianglePandas:
         return obj
 
     def head(self, n=5):
-        """Return the first ``n`` rows along the index axis.
+        """Return the first ``n`` triangles along the index axis.
 
         Parameters
         ----------
         n : int, default 5
-            Number of rows to select.
+            Number of triangles to select.
 
         Returns
         -------
@@ -443,12 +443,12 @@ class TrianglePandas:
         return self.iloc[:n]
 
     def tail(self, n=5):
-        """Return the last ``n`` rows along the index axis.
+        """Return the last ``n`` triangles along the index axis.
 
         Parameters
         ----------
         n : int, default 5
-            Number of rows to select.
+            Number of triangles to select.
 
         Returns
         -------

--- a/chainladder/core/pandas.py
+++ b/chainladder/core/pandas.py
@@ -429,12 +429,40 @@ class TrianglePandas:
         return obj
 
     def head(self, n=5):
+        """Return the first ``n`` rows along the index axis.
+
+        Parameters
+        ----------
+        n : int, default 5
+            Number of rows to select.
+
+        Returns
+        -------
+        Triangle
+        """
         return self.iloc[:n]
 
     def tail(self, n=5):
+        """Return the last ``n`` rows along the index axis.
+
+        Parameters
+        ----------
+        n : int, default 5
+            Number of rows to select.
+
+        Returns
+        -------
+        Triangle
+        """
         return self.iloc[-n:]
 
     def sort_index(self, *args, **kwargs):
+        """Sort Triangle rows by index labels.
+
+        Returns
+        -------
+        Triangle
+        """
         return self.iloc[self.index.sort_values(self.key_labels, *args, **kwargs).index]
 
     def exp(self):


### PR DESCRIPTION
@henrydingliu Part 4 of #970 method docstring follow-up (methods only).

## Summary
- Add docstrings for `Triangle.head`, `tail`, and `sort_index`

Refs #970

## Test plan
- [x] Docstrings only, no runtime changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change with no runtime or API behavior modifications.
> 
> **Overview**
> Adds NumPy-style docstrings to **`Triangle.head`**, **`tail`**, and **`sort_index`** in `chainladder/core/pandas.py`, documenting parameters (where applicable) and that each returns a **`Triangle`**.
> 
> **`head`** / **`tail`** describe selecting the first or last `n` rows along the index axis (default `n=5`). **`sort_index`** notes sorting rows by index labels. Implementation is unchanged—still delegates to **`iloc`** and **`index.sort_values`** as before.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 38325a21760b4c1f2e62cd9e68cd2f5e7b633c7c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->