### PR TITLE
docs: add docstrings for Triangle compute and pipe (#970)

### DIFF
--- a/chainladder/core/base.py
+++ b/chainladder/core/base.py
@@ -651,6 +651,16 @@ class TriangleBase(
         return HANDLED_FUNCTIONS[func](*args, **kwargs)
 
     def compute(self, *args, **kwargs):
+        """Materialize a lazy dask-backed Triangle.
+
+        When ``values`` is a dask array, compute it and update
+        ``array_backend`` to match the resulting array type. Returns ``self``
+        unchanged when the Triangle is already materialized.
+
+        Returns
+        -------
+        Triangle
+        """
         if hasattr(self.values, "chunks"):
             obj = self.copy()
             obj.values = obj.values.compute(*args, **kwargs)

--- a/chainladder/core/common.py
+++ b/chainladder/core/common.py
@@ -166,6 +166,14 @@ class Common:
         -------
         object
             The return value of ``func``.
+
+        Examples
+        --------
+        Keep development periods from 48 onward:
+
+        >>> import chainladder as cl
+        >>> raa = cl.load_sample('raa')
+        >>> raa.pipe(lambda tri: tri.loc[..., 48:])
         """
         return func(self, *args, **kwargs)
 

--- a/chainladder/core/common.py
+++ b/chainladder/core/common.py
@@ -151,6 +151,22 @@ class Common:
         return _get_full_triangle(X, self.ultimate_, X.is_cumulative)
 
     def pipe(self, func, *args, **kwargs):
+        """Apply ``func(self, *args, **kwargs)``.
+
+        Parameters
+        ----------
+        func : callable
+            Function to apply to the Triangle.
+        *args
+            Positional arguments passed to ``func``.
+        **kwargs
+            Keyword arguments passed to ``func``.
+
+        Returns
+        -------
+        object
+            The return value of ``func``.
+        """
         return func(self, *args, **kwargs)
 
     def set_backend(


### PR DESCRIPTION
@henrydingliu Part 5 of #970 method docstring follow-up (methods only).

## Summary
- Add docstrings for `Triangle.compute` and `pipe`

Refs #970

## Test plan
- [x] Docstrings only, no runtime changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes with no runtime or API behavior impact.
> 
> **Overview**
> Adds NumPy-style docstrings only; **no behavior changes**.
> 
> **`Triangle.compute`** (`base.py`) now documents dask materialization, `array_backend` updates after compute, and that already-materialized triangles return unchanged.
> 
> **`Common.pipe`** (`common.py`) now documents the callable signature, parameters, return value, and includes an example slicing development periods with `loc[..., 48:]`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit af81678cbafe3211acd5f6092de6b7a9e8a894e0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->