### PR TITLE
test: replace test_sparse_at_iat xfail with pytest.raises (#963)

### DIFF
--- a/chainladder/core/tests/test_slicing.py
+++ b/chainladder/core/tests/test_slicing.py
@@ -188,9 +188,9 @@ def test_at_setitem_triangle_value(raa: Triangle) -> None:
     assert tri.at["Total", "values", "1981", 12] == 106.0
 
 
-@pytest.mark.xfail
 def test_sparse_at_iat(prism):
-    prism.iloc[0, 0, 0, 0] = 1.0
+    with pytest.raises(ValueError, match="Setting values with sparse backend requires .at or .iat"):
+        prism.iloc[0, 0, 0, 0] = 1.0
 
 
 def test_empty_index_raises(raa: Triangle) -> None:


### PR DESCRIPTION
## Summary
- Replace the remaining `@pytest.mark.xfail` on `test_sparse_at_iat` with an explicit `pytest.raises(ValueError)` assertion
- Follow-up to #977, which addressed the other stale xfails

`test_new_drop_10` is out of scope here and tracked separately in #944.

## Test plan
- [x] `pytest chainladder/core/tests/test_slicing.py::test_sparse_at_iat`

Closes #963

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change; behavior under test is unchanged and already enforced in slice.py.
> 
> **Overview**
> Updates **`test_sparse_at_iat`** so it no longer uses **`@pytest.mark.xfail`**. The test now expects a **`ValueError`** when assigning through **`prism.iloc[0, 0, 0, 0]`** on a sparse-backed triangle, matching the message that sparse writes must use **`.at`** or **`.iat`**.
> 
> No production code changes—only the test expectation is made explicit.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3b9451ca7d5088b86fdd230bed86a14d9b4d8427. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->