### PR TITLE
added a checkbox asking for help

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -44,3 +44,13 @@ body:
         ```
     validations:
       required: true
+  - type: checkboxes
+    attributes:
+      label: Would you be willing to contribute this ticket?:
+      options:
+        - label: Yes, absolutely!
+          required: false
+        - label: Yes, but I would like some help.
+          required: false
+        - label: No.
+          required: false

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -35,3 +35,13 @@ body:
       description: >-
         Such as papers, spreadsheet workbooks, screenshots, or datasets that may
         help with this ticket.
+  - type: checkboxes
+    attributes:
+      label: Would you be willing to contribute this ticket?:
+      options:
+        - label: Yes, absolutely!
+          required: false
+        - label: Yes, but I would like some help.
+          required: false
+        - label: No.
+          required: false


### PR DESCRIPTION
## Summary of Changes  
Added a checkbox to both feature request and bug report tickets

## Related GitHub Issue(s)  
closes #693 

## Additional Context for Reviewers  


- [x] I passed tests locally for both code (`uv run pytest`) and documentation changes (`uv run jb build docs --builder=custom --custom-builder=doctest`)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> GitHub issue template YAML only; no runtime or security impact.
> 
> **Overview**
> Adds an optional **“Would you be willing to contribute this ticket?”** checkbox block to the **Bug Report** and **Feature Request** GitHub issue forms, with the same three choices on both templates: willing to contribute outright, willing with help, or not willing.
> 
> This is template-only metadata for triage and maintainer outreach; it does not change application code or CI behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit de7ad5d8ab228de1f34600629a08933d80c2b37b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->