### PR TITLE
Removed deprecated broadcast_axis

### DIFF
--- a/chainladder/core/triangle.py
+++ b/chainladder/core/triangle.py
@@ -1845,14 +1845,6 @@ class Triangle(TriangleBase):
         obj.values = obj.values * trend
         return obj
 
-    def broadcast_axis(self, axis, value):
-        warnings.warn(
-            """
-            Broadcast axis is deprecated in favor of broadcasting
-            using Triangle arithmetic."""
-        )
-        return self
-
     def copy(self):
         X = object.__new__(self.__class__)
         X.__dict__.update(vars(self))


### PR DESCRIPTION
## Summary of Changes  
- The only thing that changed in this PR is the removal of `broadcast_axis`.

## Related GitHub Issue(s)  
Closes #988 

## Additional Context for Reviewers  
whoever reviews this is awesome :)

- [x] I passed tests locally for both code (`uv run pytest`) and documentation changes (`uv run jb build docs --builder=custom --custom-builder=doctest`)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small API removal of an already-deprecated no-op; no security or data-path impact.
> 
> **Overview**
> Removes the deprecated **`Triangle.broadcast_axis`** method from `chainladder/core/triangle.py`. That API only emitted a deprecation warning and returned `self` unchanged; broadcasting is expected via Triangle arithmetic instead.
> 
> No other references to `broadcast_axis` remain in the codebase.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cead3dbcdf90c56f43728de7f98cbc17a42fd5d8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->