### PR TITLE
Util weight step2

### DIFF
--- a/chainladder/development/development.py
+++ b/chainladder/development/development.py
@@ -8,7 +8,7 @@ import pandas as pd
 import warnings
 
 from chainladder.development.base import DevelopmentBase
-from chainladder.utils import WeightedRegression
+from chainladder.utils import WeightedRegression, TriangleWeight
 from chainladder.utils.utility_functions import num_to_nan
 
 from typing import (
@@ -358,14 +358,21 @@ class Development(DevelopmentBase):
 
         link_ratio: ArrayLike = y / x
 
+        tw = TriangleWeight(
+            n_periods = self.n_periods,
+            drop_high = self.drop_high,
+            drop_low = self.drop_low,
+            drop_above = self.drop_above,
+            drop_below = self.drop_below,
+            drop_valuation = self.drop_valuation,
+            preserve = self.preserve,
+            drop = self.drop
+        )
+
         if hasattr(X, "w_v2_"):
-            self.w_v2_ = self._set_weight_func(
-                factor=obj.age_to_age * X.w_v2_,
-            )
+            self.w_v2_ = tw.fit(obj.age_to_age * X.w_v2_).w_
         else:
-            self.w_v2_ = self._set_weight_func(
-                factor=obj.age_to_age,
-            )
+            self.w_v2_ = tw.fit(obj.age_to_age).w_
 
         self.w_ = self._assign_n_periods_weight(
             obj, n_periods_

--- a/chainladder/development/incremental.py
+++ b/chainladder/development/incremental.py
@@ -2,7 +2,7 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 from chainladder.development import Development, DevelopmentBase
-from chainladder.utils import WeightedRegression
+from chainladder.utils import WeightedRegression, TriangleWeight
 import numpy as np
 import pandas as pd
 import warnings
@@ -134,10 +134,20 @@ class IncrementalAdditive(DevelopmentBase):
             X_trended = X_incr.trend(self.trend, axis='valuation')
         x = X_trended / sample_weight.values
         #assign weights according to n_periods and drops
+        tw = TriangleWeight(
+            n_periods = self.n_periods,
+            drop_high = self.drop_high,
+            drop_low = self.drop_low,
+            drop_above = self.drop_above,
+            drop_below = self.drop_below,
+            drop_valuation = self.drop_valuation,
+            preserve = self.preserve,
+            drop = self.drop
+        )
         if hasattr(X, "w_"):
-            self.w_tri_ = self._set_weight_func(x * X.w_,X_trended)
+            self.w_tri_ = tw.fit(X=x * X.w_,sample_weight=X_trended).w_
         else:
-            self.w_tri_ = self._set_weight_func(x,X_trended)
+            self.w_tri_ = tw.fit(X=x,sample_weight=X_trended).w_
         self.w_ = self.w_tri_.values
         #calculate factors
         super().fit(sample_weight.values,X_trended.values,self.w_)

--- a/chainladder/development/learning.py
+++ b/chainladder/development/learning.py
@@ -9,6 +9,7 @@ from sklearn.preprocessing import OneHotEncoder, StandardScaler, PolynomialFeatu
 from sklearn.compose import ColumnTransformer
 from chainladder.development.base import DevelopmentBase
 from chainladder import options
+from chainladder import TriangleWeight
 
 
 class DevelopmentML(DevelopmentBase):
@@ -156,11 +157,9 @@ class DevelopmentML(DevelopmentBase):
 
     def _prep_w_ml(self,X,sample_weight=None):
         weight_base = (~np.isnan(X.values)).astype(float)
-        weight = weight_base.copy()               
-        if self.drop is not None:
-            weight = weight * self._drop_func(X)
-        if self.drop_valuation is not None:
-            weight = weight * self._drop_valuation_func(X)
+        weight = weight_base.copy()
+        weight1 = weight_base.copy()
+        weight = weight * TriangleWeight(drop=self.drop,drop_valuation=self.drop_valuation).fit(X).w_.fillzero().values
         if sample_weight is not None:
             weight = weight * sample_weight.values 
         return weight.flatten()[weight_base.flatten()>0]

--- a/chainladder/utils/triangle_weight.py
+++ b/chainladder/utils/triangle_weight.py
@@ -116,14 +116,7 @@ class TriangleWeight(BaseEstimator,TransformerMixin):
             Returns the instance itself.
         """
 
-        if hasattr(X, "w_"):
-            self.w_ = self._set_weight_func(
-                X=X * X.w_,
-            )
-        else:
-            self.w_ = self._set_weight_func(
-                X=X,
-            )
+        self.w_ = self._set_weight_func(X=X,secondary_rank=sample_weight)
         return self
 
     def transform(self, X: TriangleLike):


### PR DESCRIPTION
## Summary of Changes  


## Related GitHub Issue(s)  


## Additional Context for Reviewers  


- [ ] I passed tests locally for both code (`uv run pytest`) and documentation changes (`uv run jb build docs --builder=custom --custom-builder=doctest`)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Refactors how LDF and ML fitting masks cells across three estimators; **`IncrementalAdditive`** now exposes tie-breaking via **`sample_weight`**, so weights could differ from the previous **`_set_weight_func`** calls if logic is not perfectly aligned.
> 
> **Overview**
> **Development**, **IncrementalAdditive**, and **DevelopmentML** now build pattern-selection weights via the shared **`TriangleWeight`** helper instead of calling **`DevelopmentBase._set_weight_func`** (or ad hoc drop helpers in ML).
> 
> In **`Development.fit`**, **`w_v2_`** is set with **`TriangleWeight(...).fit(...).w_`** on the age-to-age triangle (optionally multiplied by **`X.w_v2_`**). Regression still uses the existing **`self.w_`** path (**`_assign_n_periods_weight`** × **`_drop_adjustment`**).
> 
> **`IncrementalAdditive`** constructs the same **`TriangleWeight`** from its drop/`n_periods` params and sets **`w_tri_`** via **`fit`**, passing **`sample_weight=X_trended`** so high/low drops can use secondary tie-breaking.
> 
> **`DevelopmentML._prep_w_ml`** applies **`drop`** / **`drop_valuation`** through **`TriangleWeight.fit(X).w_`** rather than inline **`_drop_func`** / **`_drop_valuation_func`**.
> 
> **`TriangleWeight.fit`** always delegates to **`_set_weight_func(X=..., secondary_rank=sample_weight)`**, dropping the old branch that treated **`X.w_`** specially inside **`fit`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 512d3fcc063271f21f6724d73ba7fb8b583ecec4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->