### PR TITLE
Drop doctest from codecov

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -76,18 +76,4 @@ jobs:
       - name: Install dependencies
         run: uv sync --extra docs
       - name: Run doctests
-        env:
-          COVERAGE_FILE: ${{ github.workspace }}/.coverage.doctest
-        run: |
-          JB="$(uv run which jb)"
-          uv run --with coverage --directory docs coverage run --source=chainladder \
-            "$JB" build . --builder=custom --custom-builder=doctest
-          uv run --with coverage coverage xml -o "${{ github.workspace }}/coverage-doctest.xml"
-      - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v4
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
-          file: ./coverage-doctest.xml
-          flags: unittests
-          name: codecov-umbrella
-          fail_ci_if_error: false
+        run: uv run --directory docs jb build . --builder=custom --custom-builder=doctest

--- a/.gitignore
+++ b/.gitignore
@@ -47,7 +47,6 @@ htmlcov/
 .cache
 nosetests.xml
 coverage.xml
-coverage-doctest.xml
 *.cover
 .hypothesis/
 


### PR DESCRIPTION
## Summary of Changes  
Reverting back, and now dropping doctest from codecov

## Related GitHub Issue(s)  
Closes #789 

## Additional Context for Reviewers  
N/A

- [ ] I passed tests locally for both code (`uv run pytest`) and documentation changes (`uv run jb build docs --builder=custom --custom-builder=doctest`)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow and ignore-list only; unit test Codecov uploads are unchanged and doctest execution remains.
> 
> **Overview**
> **Doctests still run in CI**, but they no longer feed Codecov. The `doctest` job in `.github/workflows/pytest.yml` now only runs `jb build` with the custom doctest builder instead of wrapping the build in `coverage run`, emitting `coverage-doctest.xml`, or uploading to Codecov.
> 
> `.gitignore` drops the `coverage-doctest.xml` entry since that artifact is no longer produced.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b2d51f7bc1ec59c619b0b59a23b7bf27431a2c03. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->