### PR TITLE
removing all references to _set_weight_func

### DIFF
--- a/chainladder/development/tests/test_development.py
+++ b/chainladder/development/tests/test_development.py
@@ -410,19 +410,19 @@ def test_new_drop_5a(clrd):
     # drop_hi/low without preserve
     with pytest.warns(UserWarning, match="exclusions have been ignored"):
         lhs = (
-            cl.Development(drop_high=1, drop_low=1, preserve=3)
-            ._set_weight_func(clrd.age_to_age, clrd.age_to_age)
-            .values
+            cl.TriangleWeight(drop_high=1, drop_low=1, preserve=3)
+            .fit(X=clrd.age_to_age, sample_weight = clrd.age_to_age)
+            .w_.values
         )
     with pytest.warns(UserWarning, match="exclusions have been ignored"):
         rhs = (
-            cl.Development(
+            cl.TriangleWeight(
                 drop_high=True,
                 drop_low=[True, True, True, True, True, True, True, True, True],
                 preserve=3,
             )
-            ._set_weight_func(clrd.age_to_age)
-            .values
+            .fit(X=clrd.age_to_age, sample_weight = clrd.age_to_age)
+            .w_.values
         )
     assert np.array_equal(lhs, rhs, True)
 
@@ -775,8 +775,8 @@ def test_std_residuals():
 
 def compare_new_drop(dev, tri):
     assert np.array_equal(
-        dev._set_weight_func(tri.age_to_age, tri.age_to_age).values,
-        dev.transform(tri).age_to_age.values * 0 + 1,
+        _FutureDevelopment(dev).fit(tri).ldf_.values,
+        dev.transform(tri).ldf_.values,
         True,
     )
 


### PR DESCRIPTION
## Summary of Changes  
step 2.5

## Related GitHub Issue(s)  


## Additional Context for Reviewers  


- [ ] I passed tests locally for both code (`uv run pytest`) and documentation changes (`uv run jb build docs --builder=custom --custom-builder=doctest`)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes; no production behavior is modified in this diff.
> 
> **Overview**
> Updates **development** tests so they no longer call the private **`Development._set_weight_func`** API, aligning with the **`TriangleWeight`** refactor (PR step 2.5).
> 
> In **`test_new_drop_5a`**, weight-matrix equivalence is asserted via **`TriangleWeight.fit(...).w_.values`** on **`age_to_age`** (with **`sample_weight`**) instead of building weights through **`Development`**.
> 
> **`compare_new_drop`** now checks that **`_FutureDevelopment(dev).fit(tri).ldf_`** matches **`dev.transform(tri).ldf_`**, replacing the old pattern that compared **`_set_weight_func`** output to an all-ones **`age_to_age`** mask.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c30f19c2c05404eebdd19ef47a738efd73c9272a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->