### PR TITLE
feedback from reviewer

### DIFF
--- a/chainladder/methods/tests/test_predict.py
+++ b/chainladder/methods/tests/test_predict.py
@@ -49,6 +49,18 @@ def test_predict_and_weights(estimators,atol):
     )   
     #Test validation of sample_weight requirement. Should raise a value error if no weight is supplied.
     if estimators in [cl.CapeCod,cl.BornhuetterFerguson,cl.ExpectedLoss,cl.Benktander]:
+        assert np.allclose(
+            est.expectation_.values.swapaxes(0,1),
+            cl.model_diagnostics(est)['Apriori'].values,
+            atol=atol,
+            equal_nan=True
+        )
+        assert np.allclose(
+            pred.expectation_.values.swapaxes(0,1),
+            cl.model_diagnostics(pred)['Apriori'].values,
+            atol=atol,
+            equal_nan=True
+        )   
         with pytest.raises(ValueError):
             estimators().fit(raa_1989)
         with pytest.raises(ValueError):

--- a/chainladder/utils/utility_functions.py
+++ b/chainladder/utils/utility_functions.py
@@ -947,13 +947,13 @@ def model_diagnostics(
     Returns
     -------
     Triangle with relevant figures as columns, including 
-    - Latest
-    - Month/Quarter/Year Incremental: Actual emergence from the latest month/quarter/year
-    - LDF
-    - CDF
-    - Ultimate
-    - IBNR
-    - Run Off 1/2/3...: Expected emergence for the next development period
+    - ``Latest``: Cumulative value at the latest valuation date, equivalent to ``latest_diagonal``
+    - ``Month/Quarter/Year Incremental``: Actual emergence between the latest valuation and the one prior valuation date
+    - ``LDF``: Age-to-age loss development factor to the next development/valuation period (from ``ldf_``)
+    - ``CDF``: Cumulative loss development factor from current age to ultimate (from ``cdf_``)
+    - ``Ultimate``: Projected ultimate loss from the fitted IBNR model (``ultimate_``)
+    - ``IBNR``: Ultiamte - Latest
+    - ``Run Off 1/2/3...``: Expected incremental emergence in successive future valuation periods (from ``full_expectation_``)
 
     Columns from the original Triangle are cross-joined into the index
     """


### PR DESCRIPTION
## Summary of Changes  


## Related GitHub Issue(s)  


## Additional Context for Reviewers  


- [ ] I passed tests locally for both code (`uv run pytest`) and documentation changes (`uv run jb build docs --builder=custom --custom-builder=doctest`)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and test-only changes; no runtime behavior in ``model_diagnostics`` or estimators is modified.
> 
> **Overview**
> **`model_diagnostics` docstring** now spells out each output column (Latest, incrementals, LDF/CDF, Ultimate, IBNR, Run Off, etc.) with ties to the underlying model attributes like ``latest_diagonal``, ``ldf_``, and ``full_expectation_``.
> 
> **`test_predict_and_weights`** gains checks for Cape Cod, Bornhuetter–Ferguson, Expected Loss, and Benktander that ``expectation_`` on fit and predict matches the **Apriori** column from ``model_diagnostics``, alongside the existing Latest/Ultimate assertions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7a420c1724b0b9c94aa34121d95bbeefa79f550d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->