### PR TITLE
bugbot fix

### DIFF
--- a/chainladder/utils/utility_functions.py
+++ b/chainladder/utils/utility_functions.py
@@ -949,13 +949,14 @@ def model_diagnostics(
     Triangle with relevant figures as columns, including 
     - ``Latest``: Cumulative value at the latest valuation date, equivalent to ``latest_diagonal``
     - ``Month/Quarter/Year Incremental``: Actual emergence between the latest valuation and the one prior valuation date
-    - ``LDF``: Age-to-age loss development factor to the next development/valuation period (from ``ldf_``)
-    - ``CDF``: Cumulative loss development factor from current age to ultimate (from ``cdf_``)
+    - ``LDF``: Age-to-age loss development factor to the next development/valuation period (from ``ldf_``); ignored if ``groupby`` is supplied
+    - ``CDF``: Cumulative loss development factor from current age to ultimate (from ``cdf_``); ignored if ``groupby`` is supplied
     - ``Ultimate``: Projected ultimate loss from the fitted IBNR model (``ultimate_``)
     - ``IBNR``: Ultiamte - Latest
     - ``Run Off 1/2/3...``: Expected incremental emergence in successive future valuation periods (from ``full_expectation_``)
+    - ``Apriori``: Expected ultimate for Benktander family of methods (from ``expectation_``)
 
-    Columns from the original Triangle are cross-joined into the index
+    Columns from the original Triangle are cross-joined into the index. ``Measure`` will contain all the columns from the original Triangle. 
     """
     from chainladder import Pipeline, Triangle
 


### PR DESCRIPTION
## Summary of Changes  


## Related GitHub Issue(s)  


## Additional Context for Reviewers  


- [ ] I passed tests locally for both code (`uv run pytest`) and documentation changes (`uv run jb build docs --builder=custom --custom-builder=doctest`)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change in a utility function docstring; no runtime behavior modified.
> 
> **Overview**
> Updates the **`model_diagnostics`** docstring so it matches how the helper already behaves.
> 
> **LDF** and **CDF** are documented as omitted when **`groupby`** is set, consistent with the `if groupby is None` branch that skips those columns. **Apriori** is added to the returned-column list (from **`expectation_`**, when present). The index note now states that **`Measure`** carries every column from the original triangle.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 55f423dcfd155934cf2ad288d8395db5d7b181d9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->