### PR TITLE
FIX: Broken issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -46,7 +46,7 @@ body:
       required: true
   - type: checkboxes
     attributes:
-      label: Would you be willing to contribute this ticket?:
+      label: Would you be willing to contribute this ticket?
       options:
         - label: Yes, absolutely!
           required: false

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -37,7 +37,7 @@ body:
         help with this ticket.
   - type: checkboxes
     attributes:
-      label: Would you be willing to contribute this ticket?:
+      label: Would you be willing to contribute this ticket?
       options:
         - label: Yes, absolutely!
           required: false


### PR DESCRIPTION
## Summary of Changes  

These issue templates weren't popping up, I think it was due to some extra colons, which I removed.

## Related GitHub Issue(s)  


## Additional Context for Reviewers  


- [x] I passed tests locally for both code (`uv run pytest`) and documentation changes (`uv run jb build docs --builder=custom --custom-builder=doctest`)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation/process-only YAML label tweaks with no impact on the chainladder package or CI test behavior.
> 
> **Overview**
> Fixes GitHub issue form rendering for **Bug Report** and **Feature Request** by correcting the checkbox label on “Would you be willing to contribute this ticket?”—the trailing colon after the question mark is removed in both `.github/ISSUE_TEMPLATE/bug_report.yml` and `feature_request.yml`.
> 
> No runtime or library code is touched; this only affects how those templates appear when users open a new issue.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b6af3ab7ee4bfc2ae23de96788e74eb23dd2f55d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->