### PR TITLE
fix: 2 improvements across 2 files

### DIFF
--- a/chainladder/utils/cupy.py
+++ b/chainladder/utils/cupy.py
@@ -11,7 +11,7 @@ try:
 
     cp.array([1])
     module = "cupy"
-except:
+except Exception:
     if options.ARRAY_BACKEND == "cupy":
         import warnings
 

--- a/chainladder/utils/dask.py
+++ b/chainladder/utils/dask.py
@@ -8,7 +8,7 @@ try:
     import dask.array as dp
     dp.array([1])
     module = "dask"
-except:
+except Exception:
     if options.ARRAY_BACKEND == "dask":
         import warnings
 


### PR DESCRIPTION
## Summary

fix: 2 improvements across 2 files

## Problem

**Severity**: `High` | **File**: `chainladder/utils/cupy.py:L15`

Multiple files use bare `except:` clauses that catch all exceptions including `KeyboardInterrupt` and `SystemExit`, making debugging difficult and potentially masking serious errors. This pattern appears in fallback imports for optional dependencies (cupy, dask, rpy2).

## Solution

Use `except Exception:` instead of bare `except:` to avoid catching system-exiting exceptions. Consider also logging the specific exception that occurred during import failure.

## Changes

- `chainladder/utils/cupy.py` (modified)
- `chainladder/utils/dask.py` (modified)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Two-line exception-type tweaks in optional dependency loaders; no change to runtime array logic or public APIs.
> 
> **Overview**
> Replaces bare `except:` with `except Exception:` in the CuPy and Dask array backend shims (`chainladder/utils/cupy.py`, `chainladder/utils/dask.py`).
> 
> Import-time fallback behavior is unchanged: failed optional imports still fall back to NumPy and warn when the configured `ARRAY_BACKEND` expected that library. The change only stops those blocks from catching **system-exiting** exceptions such as `KeyboardInterrupt` and `SystemExit`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8d824138537ccb231bd156146d14afd5abad8518. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->