### PR TITLE
promoting _param_property

### DIFF
--- a/chainladder/development/base.py
+++ b/chainladder/development/base.py
@@ -387,7 +387,6 @@ class DevelopmentBase(
     
     @staticmethod
     def _param_property(
-            self, 
             X: Triangle, 
             params: np.ndarray
     ) -> Triangle:

--- a/chainladder/development/base.py
+++ b/chainladder/development/base.py
@@ -21,7 +21,7 @@ from pandas.api.types import is_string_dtype
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from chainladder.core.typing import TriangleLike
+    from chainladder.core import Triangle
 
 
 class DevelopmentBase(
@@ -45,18 +45,18 @@ class DevelopmentBase(
 
     def _set_fit_groups(
             self,
-            X: TriangleLike
-    ) -> TriangleLike:
+            X: Triangle
+    ) -> Triangle:
         """
         Used for assigning group_index in fit.
 
         Parameters
         ----------
-        X: TriangleLike
+        X: Triangle
 
         Returns
         -------
-        TriangleLike, after performing the groupby on it.
+        Triangle, after performing the groupby on it.
 
         """
         backend = "numpy" if X.array_backend in ["sparse", "numpy"] else "cupy"
@@ -384,3 +384,39 @@ class DevelopmentBase(
                 np.where(X.development == item[1])[0][0],
             ] = 0
         return arr[:, :-1]
+    
+    @staticmethod
+    def _param_property(
+            self, 
+            X: Triangle, 
+            params: np.ndarray
+    ) -> Triangle:
+        """
+        Wrap an array of estimated parameters in a Triangle
+
+        Parameters
+        ----------
+        X: Triangle
+            The Triangle to wrap the parameters with
+
+        params: np.ndarray
+            The parameters to be wrapped
+
+        Returns
+        -------
+        Triangle
+            The wrapped parameters 
+        
+        """
+        from chainladder import options
+        
+        obj: Triangle = X[X.origin == X.origin.min()]
+        xp = X.get_array_module()
+        obj.values = params
+        obj.valuation_date = pd.to_datetime(options.ULT_VAL)
+        obj.is_pattern = True
+        obj.is_additive = True
+        obj.is_cumulative = False
+        obj.virtual_columns.columns = {}
+        obj._set_slicers()
+        return obj

--- a/chainladder/development/incremental.py
+++ b/chainladder/development/incremental.py
@@ -295,17 +295,3 @@ class IncrementalAdditive(DevelopmentBase):
         for item in ["ldf_", "w_", "zeta_", "incremental_", "tri_zeta", "fit_zeta_", "sample_weight"]:
             X_new.__dict__[item] = self.__dict__[item]
         return X_new
-
-    def _param_property(self, factor, params):
-        from chainladder import options
-        
-        obj = factor[factor.origin == factor.origin.min()]
-        xp = factor.get_array_module()
-        obj.values = params
-        obj.valuation_date = pd.to_datetime(options.ULT_VAL)
-        obj.is_pattern = True
-        obj.is_additive = True
-        obj.is_cumulative = False
-        obj.virtual_columns.columns = {}
-        obj._set_slicers()
-        return obj


### PR DESCRIPTION
## Summary of Changes  


## Related GitHub Issue(s)  


## Additional Context for Reviewers  


- [ ] I passed tests locally for both code (`uv run pytest`) and documentation changes (`uv run jb build docs --builder=custom --custom-builder=doctest`)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small refactor with no API change; `Development` still uses its own three-argument `_param_property` for LDF/sigma/std_err.
> 
> **Overview**
> Moves **`_param_property`** from `IncrementalAdditive` onto **`DevelopmentBase`** as a shared static helper that wraps fitted parameter arrays into a pattern `Triangle` (ultimate valuation, additive/non-cumulative flags, slicers).
> 
> `IncrementalAdditive.fit` now calls the inherited helper instead of a local duplicate. **`_set_fit_groups`** type hints switch from `TriangleLike` to concrete **`Triangle`** under `TYPE_CHECKING`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d18939452e70f39404c3ec9ba7aa7b03bb2c676c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->