### PR TITLE
TEST: Add test for Triangle.to_pickle().

### DIFF
--- a/chainladder/core/io.py
+++ b/chainladder/core/io.py
@@ -1,11 +1,14 @@
+"""
+Support Triangle I/O capabilities.
+"""
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
-import pandas as pd
-from sklearn.base import BaseEstimator
-import json
-import joblib
 import dill
+import json
+import pandas as pd
+
+from sklearn.base import BaseEstimator
 
 
 class TriangleIO:

--- a/chainladder/utils/tests/test_utilities.py
+++ b/chainladder/utils/tests/test_utilities.py
@@ -420,6 +420,42 @@ def test_read_pickle_triangle(raa: Triangle, tmp_path: Path) -> None:
     assert cl.read_pickle(str(pkl_path)) == raa
 
 
+def test_triangle_to_pickle(
+        raa: Triangle,
+        clrd: Triangle,
+        tmp_path: Path
+) -> None:
+    """
+    Dump a pickle of a triangle and read it back in. The read-in triangle should
+    equal the one that was dumped.
+
+    Parameters
+    ----------
+    raa: Triangle
+        The raa sample data set Triangle.
+    clrd: Triangle
+        The clrd sample data set Triangle.
+    tmp_path: Path
+        The builtin pytest tmp_path fixture, provides a temporary path to dump the pickle to.
+
+    Returns
+    -------
+    None
+
+    """
+    # Single-dimension case.
+    raa_path = tmp_path / "raa.pkl"
+    raa.to_pickle(str(raa_path))
+    assert raa_path.is_file()
+    assert cl.read_pickle(str(raa_path)) == raa
+
+    # Multidimensional case.
+    clrd_path = tmp_path / "clrd.pkl"
+    clrd.to_pickle(str(clrd_path))
+    assert clrd_path.is_file()
+    assert cl.read_pickle(str(clrd_path)) == clrd
+
+
 def test_read_pickle_estimator(raa: Triangle, tmp_path: Path) -> None:
     """
     Create an estimator, dump a pickle of it, and then read it back in. The ingested pickle should result


### PR DESCRIPTION
## Summary of Changes  

Adds a test for the 2 remaining lines in `io.py`. Dumps a pickle, reads it back in, and compares.

## Related GitHub Issue(s)  


## Additional Context for Reviewers  


- [x] I passed tests locally for both code (`uv run pytest`) and documentation changes (`uv run jb build docs --builder=custom --custom-builder=doctest`)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only coverage plus minor non-functional io.py housekeeping; no production logic changes.
> 
> **Overview**
> Adds **`test_triangle_to_pickle`**, which writes pickles via **`Triangle.to_pickle`** (not raw `dill.dump`) for single-index **`raa`** and multi-index **`clrd`**, then asserts **`cl.read_pickle`** returns an equal triangle and that the file exists—closing coverage gaps on **`TriangleIO.to_pickle`** in `io.py`.
> 
> **`chainladder/core/io.py`** gets a short module docstring and import cleanup: **`joblib`** is removed, and **`dill` / `json` / `pandas`** are grouped at the top (behavior of pickle I/O unchanged).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 433f940111ae4e9501d2501d9d836fde464116a5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->