### PR TITLE
TST: Add arithmetic compatibility tests.

### DIFF
--- a/chainladder/core/tests/test_arithmetic.py
+++ b/chainladder/core/tests/test_arithmetic.py
@@ -1,4 +1,78 @@
+from __future__ import annotations
+import numpy as np
 import pytest
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from chainladder import Triangle
+
+from chainladder.utils.sparse import COO
+
+
+def test_arithmetic_ndarray_other_backend(raa: Triangle) -> None:
+    """
+    When the left side of an arithmetic operator has a sparse backend, and the right side is a numpy ndarray,
+    The result should have a sparse backend.
+
+    Parameters
+    ----------
+    raa: Triangle
+        The raa sample data set Triangle.
+
+    Returns
+    -------
+    None
+    """
+    sparse_raa = raa.set_backend("sparse")
+    other = np.ones(sparse_raa.shape)
+    result = sparse_raa + other
+    assert result.array_backend == "sparse"
+    assert result.set_backend("numpy") == raa + 1
+
+
+def test_arithmetic_coo_other_backend(raa: Triangle) -> None:
+    """
+    When the left side of an arithmetic operator has a numpy backend, and the right side is a sparse COO,
+    The result should have a sparse backend.
+
+    Parameters
+    ----------
+    raa: Triangle
+        The raa sample data set Triangle.
+
+    Returns
+    -------
+    None
+    """
+    numpy_raa = raa.set_backend("numpy")
+    other = COO.from_numpy(np.ones(numpy_raa.shape))
+    result = numpy_raa + other
+    assert result.array_backend == "sparse"
+    assert result.set_backend("numpy") == raa + 1
+
+
+def test_arithmetic_grain_mismatch_raises(raa: Triangle, qtr: Triangle) -> None:
+    """
+    Add two triangles with different grain. Raise an error.
+
+    Parameters
+    ----------
+    raa: Triangle
+        The raa sample data set Triangle.
+
+    qtr: Triangle
+        The quarterly sample data set Triangle.
+
+    Returns
+    -------
+    None
+    """
+    with pytest.raises(
+        ValueError,
+        match="Triangle arithmetic requires both triangles to be the same grain.",
+    ):
+        raa + qtr
 
 
 def test_arithmetic_union(raa):


### PR DESCRIPTION
## Summary of Changes  

Add some tests for uncovered lines in `dunders.py`, dealing with arithmetic operations on Triangles with different grain and backends.

## Related GitHub Issue(s)  


## Additional Context for Reviewers  


- [x] I passed tests locally for both code (`uv run pytest`) and documentation changes (`uv run jb build docs --builder=custom --custom-builder=doctest`)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes with no production code modifications.
> 
> **Overview**
> Adds regression tests in `test_arithmetic.py` for `dunders.py` arithmetic behavior that was previously untested.
> 
> **Backend promotion:** sparse `Triangle` + `numpy.ndarray`, and numpy `Triangle` + sparse `COO`, should both yield a sparse backend and match `raa + 1` when converted to numpy.
> 
> **Grain guard:** adding triangles with mismatched grain (e.g. `raa` vs `qtr`) must raise `ValueError` with the message that both triangles need the same grain.
> 
> Existing arithmetic tests are unchanged aside from new imports and typing (`TYPE_CHECKING`, `Triangle` fixture annotations).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b024736bb4641a7a8e0f21048f91b6f110bf9c48. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->