### PR TITLE
more fixes

### DIFF
--- a/chainladder/adjustments/disposal.py
+++ b/chainladder/adjustments/disposal.py
@@ -211,8 +211,8 @@ class DisposalRate(DevelopmentBase):
             ult = sample_weight.copy()
         #calculate disposal rate triangle
         self.xp = X.get_array_module()
-        self.X_ = X.sort_index()
-        self.disposal_rate_tri = X / ult.values
+        self.X_ = X.incr_to_cum().sort_index()
+        self.disposal_rate_tri = self.X_ / ult.values
         #get weights for estimation
         tw = TriangleWeight(
             n_periods = self.n_periods,

--- a/chainladder/adjustments/tests/test_disposal.py
+++ b/chainladder/adjustments/tests/test_disposal.py
@@ -50,7 +50,8 @@ def test_cl_parity(raa):
 
 def test_sparse_transform(raa):
     raa_sparse = raa.set_backend('sparse')
+    ult = cl.Chainladder().fit(raa_sparse).ultimate_.set_backend('sparse')
+    dr = cl.DisposalRate().fit_transform(raa_sparse,sample_weight=ult)
     from chainladder.utils.sparse import sp
-    dr = cl.DisposalRate().fit_transform(raa_sparse,sample_weight=cl.Chainladder().fit(raa_sparse).ultimate_)
     assert isinstance(dr.full_triangle_.values,sp.COO)
     


### PR DESCRIPTION
## Summary of Changes  


## Related GitHub Issue(s)  


## Additional Context for Reviewers  


- [ ] I passed tests locally for both code (`uv run pytest`) and documentation changes (`uv run jb build docs --builder=custom --custom-builder=doctest`)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes disposal-rate estimation math in fit(), which drives forecast patterns and full_triangle_; scope is small but actuarially meaningful.
> 
> **Overview**
> **`DisposalRate.fit`** now converts the input triangle to cumulative (`incr_to_cum()`) before building `disposal_rate_tri` and the internal `X_` used for development weighting, so disposal rates are **cumulative loss ÷ ultimate** even when callers pass incremental data.
> 
> The sparse **`test_sparse_transform`** keeps **`sample_weight`** on the sparse backend explicitly when calling **`fit_transform`**, matching how production sparse pipelines should pass ultimates.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6eb6afdbb77eed1eecdd1065e643c594462619b8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->