### PR TITLE
sync

### DIFF
--- a/chainladder/core/io.py
+++ b/chainladder/core/io.py
@@ -1,11 +1,14 @@
+"""
+Support Triangle I/O capabilities.
+"""
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
-import pandas as pd
-from sklearn.base import BaseEstimator
-import json
-import joblib
 import dill
+import json
+import pandas as pd
+
+from sklearn.base import BaseEstimator
 
 
 class TriangleIO:

--- a/chainladder/development/base.py
+++ b/chainladder/development/base.py
@@ -387,7 +387,6 @@ class DevelopmentBase(
     
     @staticmethod
     def _param_property(
-            self, 
             X: Triangle, 
             params: np.ndarray
     ) -> Triangle:

--- a/chainladder/development/base.py
+++ b/chainladder/development/base.py
@@ -21,7 +21,7 @@ from pandas.api.types import is_string_dtype
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from chainladder.core.typing import TriangleLike
+    from chainladder.core import Triangle
 
 
 class DevelopmentBase(
@@ -45,18 +45,18 @@ class DevelopmentBase(
 
     def _set_fit_groups(
             self,
-            X: TriangleLike
-    ) -> TriangleLike:
+            X: Triangle
+    ) -> Triangle:
         """
         Used for assigning group_index in fit.
 
         Parameters
         ----------
-        X: TriangleLike
+        X: Triangle
 
         Returns
         -------
-        TriangleLike, after performing the groupby on it.
+        Triangle, after performing the groupby on it.
 
         """
         backend = "numpy" if X.array_backend in ["sparse", "numpy"] else "cupy"
@@ -384,3 +384,39 @@ class DevelopmentBase(
                 np.where(X.development == item[1])[0][0],
             ] = 0
         return arr[:, :-1]
+    
+    @staticmethod
+    def _param_property(
+            self, 
+            X: Triangle, 
+            params: np.ndarray
+    ) -> Triangle:
+        """
+        Wrap an array of estimated parameters in a Triangle
+
+        Parameters
+        ----------
+        X: Triangle
+            The Triangle to wrap the parameters with
+
+        params: np.ndarray
+            The parameters to be wrapped
+
+        Returns
+        -------
+        Triangle
+            The wrapped parameters 
+        
+        """
+        from chainladder import options
+        
+        obj: Triangle = X[X.origin == X.origin.min()]
+        xp = X.get_array_module()
+        obj.values = params
+        obj.valuation_date = pd.to_datetime(options.ULT_VAL)
+        obj.is_pattern = True
+        obj.is_additive = True
+        obj.is_cumulative = False
+        obj.virtual_columns.columns = {}
+        obj._set_slicers()
+        return obj

--- a/chainladder/development/incremental.py
+++ b/chainladder/development/incremental.py
@@ -295,17 +295,3 @@ class IncrementalAdditive(DevelopmentBase):
         for item in ["ldf_", "w_", "zeta_", "incremental_", "tri_zeta", "fit_zeta_", "sample_weight"]:
             X_new.__dict__[item] = self.__dict__[item]
         return X_new
-
-    def _param_property(self, factor, params):
-        from chainladder import options
-        
-        obj = factor[factor.origin == factor.origin.min()]
-        xp = factor.get_array_module()
-        obj.values = params
-        obj.valuation_date = pd.to_datetime(options.ULT_VAL)
-        obj.is_pattern = True
-        obj.is_additive = True
-        obj.is_cumulative = False
-        obj.virtual_columns.columns = {}
-        obj._set_slicers()
-        return obj

--- a/chainladder/utils/tests/test_utilities.py
+++ b/chainladder/utils/tests/test_utilities.py
@@ -420,6 +420,42 @@ def test_read_pickle_triangle(raa: Triangle, tmp_path: Path) -> None:
     assert cl.read_pickle(str(pkl_path)) == raa
 
 
+def test_triangle_to_pickle(
+        raa: Triangle,
+        clrd: Triangle,
+        tmp_path: Path
+) -> None:
+    """
+    Dump a pickle of a triangle and read it back in. The read-in triangle should
+    equal the one that was dumped.
+
+    Parameters
+    ----------
+    raa: Triangle
+        The raa sample data set Triangle.
+    clrd: Triangle
+        The clrd sample data set Triangle.
+    tmp_path: Path
+        The builtin pytest tmp_path fixture, provides a temporary path to dump the pickle to.
+
+    Returns
+    -------
+    None
+
+    """
+    # Single-dimension case.
+    raa_path = tmp_path / "raa.pkl"
+    raa.to_pickle(str(raa_path))
+    assert raa_path.is_file()
+    assert cl.read_pickle(str(raa_path)) == raa
+
+    # Multidimensional case.
+    clrd_path = tmp_path / "clrd.pkl"
+    clrd.to_pickle(str(clrd_path))
+    assert clrd_path.is_file()
+    assert cl.read_pickle(str(clrd_path)) == clrd
+
+
 def test_read_pickle_estimator(raa: Triangle, tmp_path: Path) -> None:
     """
     Create an estimator, dump a pickle of it, and then read it back in. The ingested pickle should result


### PR DESCRIPTION
## Summary of Changes  


## Related GitHub Issue(s)  


## Additional Context for Reviewers  


- [ ] I passed tests locally for both code (`uv run pytest`) and documentation changes (`uv run jb build docs --builder=custom --custom-builder=doctest`)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small refactor plus I/O test coverage; `Development` keeps its own three-argument `_param_property`, so incremental behavior should follow the moved helper unchanged.
> 
> **Overview**
> **Triangle pickle I/O** is documented at the module level in `chainladder/core/io.py`, with imports reordered and an unused `joblib` import dropped from that file (pickling still uses `dill`).
> 
> **Development estimators:** `_param_property` is added as a **static helper on `DevelopmentBase`**, and the duplicate implementation is **removed from `IncrementalAdditive`**, which now calls the shared helper for `zeta_`. Type hints in `DevelopmentBase` switch from `TriangleLike` to **`Triangle`** for `_set_fit_groups`.
> 
> **Tests:** **`test_triangle_to_pickle`** exercises `Triangle.to_pickle` / `read_pickle` round-trips for single- and multi-dimensional sample triangles (`raa`, `clrd`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 468f11a4267e90308a5261e24a27a280fe8f53aa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->