### PR TITLE
Disposal

### DIFF
--- a/chainladder/adjustments/disposal.py
+++ b/chainladder/adjustments/disposal.py
@@ -211,8 +211,8 @@ class DisposalRate(DevelopmentBase):
             ult = sample_weight.copy()
         #calculate disposal rate triangle
         self.xp = X.get_array_module()
-        self.X_ = X.sort_index()
-        self.disposal_rate_tri = X / ult.values
+        self.X_ = X.incr_to_cum().sort_index()
+        self.disposal_rate_tri = self.X_ / ult.values
         #get weights for estimation
         tw = TriangleWeight(
             n_periods = self.n_periods,

--- a/chainladder/adjustments/disposal.py
+++ b/chainladder/adjustments/disposal.py
@@ -97,7 +97,7 @@ class DisposalRate(DevelopmentBase):
         ult = cl.Chainladder().fit(clrd['IncurLoss']).ultimate_
         dr = cl.DisposalRate().fit_transform(clrd['CumPaidLoss'],sample_weight = ult)
 
-    Once we apply this adjustment method via a `fit_transform`, we can examin the emergence pattern via `disposal_rate_tri`. 
+    Once we apply this adjustment method via a `fit_transform`, we can examine the emergence pattern via `disposal_rate_tri`. 
 
     .. testcode::
     

--- a/chainladder/adjustments/tests/test_disposal.py
+++ b/chainladder/adjustments/tests/test_disposal.py
@@ -1,10 +1,17 @@
-mport chainladder as cl
+from __future__ import annotations
+
+import chainladder as cl
 import numpy as np
 import pytest
 
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from chainladder.core import Triangle
+
 def test_friedland_fidelity() -> None:
     '''
-    Demonstrates 
+    Reconciles to Chapter 11 Exhibit 5 of the Friedland reserving textbook
     '''
     tri = cl.load_sample('friedland_gl_insurer')
     ccc_dev = cl.Development(n_periods=3, average='volume').fit_transform(tri['Closed Claim Counts'])

--- a/chainladder/adjustments/tests/test_disposal.py
+++ b/chainladder/adjustments/tests/test_disposal.py
@@ -1,23 +1,24 @@
-import chainladder as cl
+mport chainladder as cl
 import numpy as np
 import pytest
 
-def test_friedland_fidelity():
-    tri = cl.load_sample('friedland_gl_insurer')['Closed Claim Counts']
-    ult_tri = cl.Triangle(
-        data = {
-            'Closed Claim Counts':[873,720,626,629,588,553,438,609],
-            'ay': [2001,2002,2003,2004,2005,2006,2007,2008],
-            'dev':[2008,2008,2008,2008,2008,2008,2008,2008],
-        },
-        origin = 'ay',
-        development='dev',
-        columns='Closed Claim Counts',
-        cumulative=True,
-    )
-    dr = cl.DisposalRate(n_periods = 5, average = 'simple', drop_high = 1, drop_low = 1).fit_transform(X=tri,sample_weight=ult_tri)
-    assert np.all(abs(dr.disposal_.round(3).values.flatten() - [.200,.433,.585,.710,.791,.862,.882,.912,1.000] <=0.001))
-    lhs = (dr.full_triangle_.cum_to_incr()-tri.cum_to_incr()).round(0).values.flatten()
+def test_friedland_fidelity() -> None:
+    '''
+    Demonstrates 
+    '''
+    tri = cl.load_sample('friedland_gl_insurer')
+    ccc_dev = cl.Development(n_periods=3, average='volume').fit_transform(tri['Closed Claim Counts'])
+    ccc_dev.ldf_ = ccc_dev.ldf_.round(3)
+    ccc_dev_wtail = cl.TailConstant(tail = 1.100, projection_period = 0).fit_transform(ccc_dev)
+    ccc_ult = cl.Chainladder().fit(ccc_dev_wtail).ultimate_
+    rcc_dev = cl.Development(n_periods=3, average='volume').fit_transform(tri['Reported Claim Counts'])
+    rcc_dev.ldf_ = rcc_dev.ldf_.round(3)
+    rcc_ult = cl.Chainladder().fit(rcc_dev).ultimate_
+    ult = (ccc_ult + rcc_ult) / 2
+    dr = cl.DisposalRate(n_periods = 5, average = 'simple', drop_high = 1, drop_low = 1).fit_transform(X=tri['Closed Claim Counts'],sample_weight=ult)
+    assert np.all(dr.disposal_.round(3).values.flatten() == [.200,.433,.585,.710,.791,.862,.882,.912,1.000])
+    #Friedland uses rounded ultimates to calculate bottom half of the triangle, which introduces some rounding discrepancies with the implementation
+    lhs = (dr.full_triangle_.cum_to_incr()-tri['Closed Claim Counts'].cum_to_incr()).round(0).values.flatten()
     rhs = np.array([
                                                             77.,  
                                                     24.,    70.,  
@@ -26,11 +27,14 @@ def test_friedland_fidelity():
                             52.,    45.,    13.,    19.,    56.,  
                     76.,    49.,    43.,    12.,    18.,    54.,  
             67.,    55.,    36.,    31.,    9.,     13.,    39.,  
-    140.,   91.,    75.,    49.,    42.,    12.,    18.,    53.
+    140.,   91.,    75.,    49.,    43.,    12.,    18.,    53.
     ])
     assert np.all(abs(lhs[~np.isnan(lhs)] - rhs <= 1))
 
-def test_no_weight_exception(raa):
+def test_no_weight_exception(raa:Triangle) -> None:
+    '''
+    sample_weight is optional in the default sklearn API. however, we require sample_weight to provide the a priori ultimate. 
+    '''
     with pytest.raises(ValueError):
         dr = cl.DisposalRate().fit(raa)
     ult = cl.Chainladder().fit(raa).ultimate_
@@ -38,7 +42,7 @@ def test_no_weight_exception(raa):
     with pytest.raises(ValueError):
         est = dr.transform(raa)
     
-def test_cl_parity(raa):
+def test_cl_parity(raa:Triangle) -> None:
     """
     A no-tail, full-triangle, volume-weighted Chainladder estimator coincides with the disposal rate adjustment. 
     """
@@ -48,7 +52,10 @@ def test_cl_parity(raa):
     dr = cl.DisposalRate().fit_transform(raa,sample_weight=est.ultimate_)
     assert np.all(dr.full_triangle_.round(3).values[...,:-1] == est.full_triangle_.round(3).values[...,:-2])
 
-def test_sparse_transform(raa):
+def test_sparse_transform(raa:Triangle) -> None:
+    """
+    if the supplied Triangle is sparse, then the resulting full_triangle_ is also sparse 
+    """
     raa_sparse = raa.set_backend('sparse')
     ult = cl.Chainladder().fit(raa_sparse).ultimate_.set_backend('sparse')
     dr = cl.DisposalRate().fit_transform(raa_sparse,sample_weight=ult)

--- a/chainladder/adjustments/tests/test_disposal.py
+++ b/chainladder/adjustments/tests/test_disposal.py
@@ -50,7 +50,8 @@ def test_cl_parity(raa):
 
 def test_sparse_transform(raa):
     raa_sparse = raa.set_backend('sparse')
+    ult = cl.Chainladder().fit(raa_sparse).ultimate_.set_backend('sparse')
+    dr = cl.DisposalRate().fit_transform(raa_sparse,sample_weight=ult)
     from chainladder.utils.sparse import sp
-    dr = cl.DisposalRate().fit_transform(raa_sparse,sample_weight=cl.Chainladder().fit(raa_sparse).ultimate_)
     assert isinstance(dr.full_triangle_.values,sp.COO)
     


### PR DESCRIPTION
## Summary of Changes  


## Related GitHub Issue(s)  


## Additional Context for Reviewers  


- [ ] I passed tests locally for both code (`uv run pytest`) and documentation changes (`uv run jb build docs --builder=custom --custom-builder=doctest`)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes disposal-rate math for non-cumulative inputs, which can shift forecasts; tests validate textbook parity but production triangles may behave differently.
> 
> **Overview**
> **DisposalRate** now converts the input triangle to cumulative before computing `disposal_rate_tri` and fitting, so disposal rates are always **cumulative ÷ ultimate** instead of dividing raw `X` by ultimates.
> 
> The Friedland fidelity test was reworked to build ultimates from closed and reported claim-count development (with tail), assert exact disposal factors, and relax incremental bottom-half checks for textbook rounding. Tests gained type hints and docstrings; the sparse test explicitly keeps sparse ultimates. Docs fix a typo (“examine”).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit df8e2f9c8b18e0186fa8880115985b01fb30491a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->