### PR TITLE
restructuring disposal attributes into mixin class

### DIFF
--- a/chainladder/adjustments/disposal.py
+++ b/chainladder/adjustments/disposal.py
@@ -14,8 +14,45 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from chainladder.core import Triangle
 
+class DisposalMixin:
+    '''
+    This class provides attributes for the DisposalRate adjustment method and transformed `Triangle`    
+    '''
 
-class DisposalRate(DevelopmentBase):
+    @property
+    def disposal_(self) -> Triangle:
+        if not hasattr(self, "_disposal_"):
+            x = self.__class__.__name__
+            raise AttributeError("'" + x + "' object has no attribute 'disposal_'")
+        return self._disposal_
+    
+    @disposal_.setter
+    def disposal_(self,value) -> None:
+        output = copy.deepcopy(value)
+        output.is_cumulative = True
+        output.is_pattern = True
+        self._disposal_ = output
+
+    @property
+    def incr_disposal_(self) -> Triangle:
+        if not hasattr(self, "_disposal_"):
+            x = self.__class__.__name__
+            raise AttributeError("'" + x + "' object has no attribute 'incr_disposal_'")
+        disposal_copy = copy.deepcopy(self._disposal_)
+        disposal_copy.is_pattern = False
+        output = disposal_copy.cum_to_incr()
+        output.is_pattern = True
+        return output
+
+    @incr_disposal_.setter
+    def incr_disposal_(self,value) -> None:
+        output = copy.deepcopy(value)
+        output.is_pattern = False
+        output = output.incr_to_cum()
+        output.is_pattern = True
+        self._disposal_ = output
+
+class DisposalRate(DevelopmentBase, DisposalMixin):
     """
     Calculates the bottom of a fitted full_triangle_ using the Disposal Rate method described
     by Friedland.
@@ -231,14 +268,8 @@ class DisposalRate(DevelopmentBase):
         #calculate factors
         super().fit(ult.values,self.X_.values,self.w_)
         #keep attributes
-        self.disposal_ = self._param_property(self.disposal_rate_tri,self.params_.slope_[...,0][..., None, :])
-        self.disposal_ = concat((self.disposal_,(self.X_.latest_diagonal*0 + 1).iloc[:,:,0,:].rename("development", [9999])),axis=3)
-        self.disposal_.is_cumulative = True
-        #pattern multiples from tail and additive adds from head
-        self.disposal_.is_pattern = False
-        self.incr_disposal_ = self.disposal_.cum_to_incr()
-        self.incr_disposal_.is_pattern = True
-        self.disposal_.is_pattern = True
+        disposal = self._param_property(self.disposal_rate_tri,self.params_.slope_[...,0][..., None, :])
+        self._disposal_ = concat((disposal,(self.X_.latest_diagonal*0 + 1).iloc[:,:,0,:].rename("development", [9999])),axis=3)
         return self
 
     def transform(
@@ -270,7 +301,6 @@ class DisposalRate(DevelopmentBase):
         X_new.ultimate_ = sample_weight.set_backend(self.X_.array_backend).latest_diagonal
         X_new.disposal_rate_tri = self.disposal_rate_tri
         X_new.disposal_ = self.disposal_
-        X_new.incr_disposal_ = self.incr_disposal_
         ibnr_pct = 1 - X_new.disposal_.align_pattern(X_new.disposal_rate_tri)
         run_off = X_new.incr_disposal_ / ibnr_pct * X_new.ibnr_
         run_off = run_off[run_off.valuation > X_new.valuation_date]

--- a/chainladder/adjustments/tests/test_disposal.py
+++ b/chainladder/adjustments/tests/test_disposal.py
@@ -22,9 +22,11 @@ def test_friedland_fidelity() -> None:
     rcc_dev.ldf_ = rcc_dev.ldf_.round(3)
     rcc_ult = cl.Chainladder().fit(rcc_dev).ultimate_
     ult = (ccc_ult + rcc_ult) / 2
-    dr = cl.DisposalRate(n_periods = 5, average = 'simple', drop_high = 1, drop_low = 1).fit_transform(X=tri['Closed Claim Counts'],sample_weight=ult)
-    assert np.all(dr.disposal_.round(3).values.flatten() == [.200,.433,.585,.710,.791,.862,.882,.912,1.000])
+    dr_transformer = cl.DisposalRate(n_periods = 5, average = 'simple', drop_high = 1, drop_low = 1).fit(X=tri['Closed Claim Counts'],sample_weight=ult)
+    dr_transformer.disposal_ = dr_transformer.disposal_.round(3)
+    assert np.all(dr_transformer.disposal_.values.flatten() == [.200,.433,.585,.710,.791,.862,.882,.912,1.000])
     #Friedland uses rounded ultimates to calculate bottom half of the triangle, which introduces some rounding discrepancies with the implementation
+    dr = dr_transformer.transform(X=tri['Closed Claim Counts'],sample_weight=ult.round(0))
     lhs = (dr.full_triangle_.cum_to_incr()-tri['Closed Claim Counts'].cum_to_incr()).round(0).values.flatten()
     rhs = np.array([
                                                             77.,  

--- a/chainladder/core/base.py
+++ b/chainladder/core/base.py
@@ -27,6 +27,8 @@ from chainladder.utils.cupy import cp
 from chainladder.utils.dask import dp
 from chainladder.utils.sparse import sp
 
+from chainladder.adjustments.disposal import DisposalMixin
+
 from typing import (
     Optional,
     TYPE_CHECKING
@@ -50,7 +52,8 @@ class TriangleBase(
     TriangleDunders,
     TrianglePandas,
     Common,
-    ABC
+    ABC,
+    DisposalMixin
 ):
     """This class handles the initialization of a triangle"""
 


### PR DESCRIPTION
## Summary of Changes  


## Related GitHub Issue(s)  


## Additional Context for Reviewers  


- [ ] I passed tests locally for both code (`uv run pytest`) and documentation changes (`uv run jb build docs --builder=custom --custom-builder=doctest`)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core `Triangle` inheritance and disposal transform math (`incr_disposal_` is now computed lazily); behavior should match but rounding/flag handling paths changed.
> 
> **Overview**
> **Disposal rate state** (`disposal_` / `incr_disposal_`) moves into a shared **`DisposalMixin`**: cumulative disposal is stored on `_disposal_`, with getters/setters that enforce `is_cumulative` / `is_pattern` and derive incremental disposal from cumulative via `cum_to_incr()`.
> 
> **`DisposalRate`** now subclasses the mixin; **`fit`** writes the fitted pattern straight to `_disposal_` instead of manually toggling flags and building `incr_disposal_`. **`transform`** still assigns `disposal_` on the output triangle but no longer copies `incr_disposal_`—downstream code uses the mixin property on **`Triangle`** ( **`TriangleBase`** also mixes in **`DisposalMixin`**).
> 
> The Friedland fidelity test splits **`fit`** / **`transform`** and rounds **`disposal_`** through the property setter before transforming with rounded ultimates.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 74655d1afbca8f1c590d4629e4c558fa41ecfe94. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->