### PR TITLE
adding `is_disposal_rate` attribute to triangle

### DIFF
--- a/chainladder/adjustments/disposal.py
+++ b/chainladder/adjustments/disposal.py
@@ -20,37 +20,31 @@ class DisposalMixin:
     '''
 
     @property
-    def disposal_(self) -> Triangle:
-        if not hasattr(self, "_disposal_"):
+    def disposal_rate_(self) -> Triangle:
+        if not hasattr(self, "_disposal_rate_"):
             x = self.__class__.__name__
-            raise AttributeError("'" + x + "' object has no attribute 'disposal_'")
-        return self._disposal_
+            raise AttributeError("'" + x + "' object has no attribute 'disposal_rate_'")
+        return self._disposal_rate_
     
-    @disposal_.setter
-    def disposal_(self,value) -> None:
-        output = copy.deepcopy(value)
-        output.is_cumulative = True
-        output.is_pattern = True
-        self._disposal_ = output
+    @disposal_rate_.setter
+    def disposal_rate_(self,value) -> None:
+        obj = copy.deepcopy(value)
+        obj.is_pattern = True
+        obj.is_disposal_rate = True
+        obj.is_cumulative = True
+        self._disposal_rate_ = obj
 
     @property
-    def incr_disposal_(self) -> Triangle:
-        if not hasattr(self, "_disposal_"):
-            x = self.__class__.__name__
-            raise AttributeError("'" + x + "' object has no attribute 'incr_disposal_'")
-        disposal_copy = copy.deepcopy(self._disposal_)
-        disposal_copy.is_pattern = False
-        output = disposal_copy.cum_to_incr()
-        output.is_pattern = True
-        return output
+    def incr_disposal_rate_(self) -> Triangle:
+        return self.disposal_rate_.cum_to_incr()
 
-    @incr_disposal_.setter
-    def incr_disposal_(self,value) -> None:
-        output = copy.deepcopy(value)
-        output.is_pattern = False
-        output = output.incr_to_cum()
-        output.is_pattern = True
-        self._disposal_ = output
+    @incr_disposal_rate_.setter
+    def incr_disposal_rate_(self,value) -> None:
+        obj = copy.deepcopy(value)
+        obj.is_pattern = True
+        obj.is_disposal_rate = True
+        obj.is_cumulative = False
+        self._disposal_rate_ = obj.incr_to_cum()
 
 class DisposalRate(DevelopmentBase, DisposalMixin):
     """
@@ -109,13 +103,10 @@ class DisposalRate(DevelopmentBase, DisposalMixin):
 
     Attributes
     ----------
-    disposal_rate_tri: Triangle
-        actual disposal rates by origin and development
-
-    disposal_: Triangle
+    disposal_rate_: Triangle
         fitted disposal rates
 
-    incr_disposal_: Triangle
+    incr_disposal_rate_: Triangle
         incremental of disposal_
 
     Examples
@@ -154,11 +145,11 @@ class DisposalRate(DevelopmentBase, DisposalMixin):
         1996  0.395603  0.688621       NaN       NaN       NaN       NaN       NaN       NaN       NaN       NaN
         1997  0.393820       NaN       NaN       NaN       NaN       NaN       NaN       NaN       NaN       NaN
 
-    The estimated pattern is stored in `disposal_`. 
+    The estimated pattern is stored in `disposal_rate_`. 
 
     .. testcode::
 
-        dr.disposal_
+        dr.disposal_rate_
         
     .. testoutput::
 
@@ -249,7 +240,7 @@ class DisposalRate(DevelopmentBase, DisposalMixin):
         #calculate disposal rate triangle
         self.xp = X.get_array_module()
         self.X_ = X.incr_to_cum().sort_index()
-        self.disposal_rate_tri = self.X_ / ult.values
+        self.X_.ultimate_ = ult
         #get weights for estimation
         tw = TriangleWeight(
             n_periods = self.n_periods,
@@ -262,14 +253,14 @@ class DisposalRate(DevelopmentBase, DisposalMixin):
             drop = self.drop
         )
         if hasattr(self.X_, "w_"):
-            self.w_ = tw.fit(X=self.disposal_rate_tri * self.X_.w_).w_.values
+            self.w_ = tw.fit(X=self.X_.disposal_rate_tri * self.X_.w_).w_.values
         else:
-            self.w_ = tw.fit(X=self.disposal_rate_tri).w_.values
+            self.w_ = tw.fit(X=self.X_.disposal_rate_tri).w_.values
         #calculate factors
         super().fit(ult.values,self.X_.values,self.w_)
         #keep attributes
-        disposal = self._param_property(self.disposal_rate_tri,self.params_.slope_[...,0][..., None, :])
-        self._disposal_ = concat((disposal,(self.X_.latest_diagonal*0 + 1).iloc[:,:,0,:].rename("development", [9999])),axis=3)
+        disposal = self._param_property(self.X_.disposal_rate_tri,self.params_.slope_[...,0][..., None, :])
+        self.disposal_rate_ = concat((disposal,(self.X_.latest_diagonal*0 + 1).iloc[:,:,0,:].rename("development", [9999])),axis=3)
         return self
 
     def transform(
@@ -299,10 +290,9 @@ class DisposalRate(DevelopmentBase, DisposalMixin):
         MethodBase().validate_weight(X, sample_weight)
         #align backeneds
         X_new.ultimate_ = sample_weight.set_backend(self.X_.array_backend).latest_diagonal
-        X_new.disposal_rate_tri = self.disposal_rate_tri
-        X_new.disposal_ = self.disposal_
-        ibnr_pct = 1 - X_new.disposal_.align_pattern(X_new.disposal_rate_tri)
-        run_off = X_new.incr_disposal_ / ibnr_pct * X_new.ibnr_
+        X_new.disposal_rate_ = self.disposal_rate_
+        ibnr_pct = 1 - X_new.disposal_rate_.align_pattern(X_new.disposal_rate_tri)
+        run_off = X_new.incr_disposal_rate_ / ibnr_pct * X_new.ibnr_
         run_off = run_off[run_off.valuation > X_new.valuation_date]
         X_new.ldf_ = (X_new.cum_to_incr() + run_off).incr_to_cum().age_to_age
         return X_new

--- a/chainladder/adjustments/tests/test_disposal.py
+++ b/chainladder/adjustments/tests/test_disposal.py
@@ -23,8 +23,8 @@ def test_friedland_fidelity() -> None:
     rcc_ult = cl.Chainladder().fit(rcc_dev).ultimate_
     ult = (ccc_ult + rcc_ult) / 2
     dr_transformer = cl.DisposalRate(n_periods = 5, average = 'simple', drop_high = 1, drop_low = 1).fit(X=tri['Closed Claim Counts'],sample_weight=ult)
-    dr_transformer.disposal_ = dr_transformer.disposal_.round(3)
-    assert np.all(dr_transformer.disposal_.values.flatten() == [.200,.433,.585,.710,.791,.862,.882,.912,1.000])
+    dr_transformer.disposal_rate_ = dr_transformer.disposal_rate_.round(3)
+    assert np.all(dr_transformer.disposal_rate_.values.flatten() == [.200,.433,.585,.710,.791,.862,.882,.912,1.000])
     #Friedland uses rounded ultimates to calculate bottom half of the triangle, which introduces some rounding discrepancies with the implementation
     dr = dr_transformer.transform(X=tri['Closed Claim Counts'],sample_weight=ult.round(0))
     lhs = (dr.full_triangle_.cum_to_incr()-tri['Closed Claim Counts'].cum_to_incr()).round(0).values.flatten()
@@ -50,7 +50,16 @@ def test_no_weight_exception(raa:Triangle) -> None:
     dr = cl.DisposalRate().fit(raa,sample_weight=ult)
     with pytest.raises(ValueError):
         est = dr.transform(raa)
-    
+
+def test_no_disposal_exception(raa:Triangle) -> None:
+    '''
+    disposal attributes are available in Triangle through the mixin, but not available before fitting 
+    '''
+    with pytest.raises(AttributeError):
+        _ = raa.disposal_rate_
+    with pytest.raises(AttributeError):
+        _ = raa.incr_disposal_rate_
+
 def test_cl_parity(raa:Triangle) -> None:
     """
     A no-tail, full-triangle, volume-weighted Chainladder estimator coincides with the disposal rate adjustment. 

--- a/chainladder/core/triangle.py
+++ b/chainladder/core/triangle.py
@@ -106,8 +106,10 @@ class Triangle(TriangleBase):
         The grain of the development vector ('Y', 'S', 'Q', 'M')
     shape: tuple
         The 4D shape of the triangle instance with axes corresponding to (index, columns, origin, development)
-    link_ratio, age_to_age
+    link_ratio, age_to_age: Triangle
         Displays age-to-age ratios for the triangle.
+    disposal_rate_tri: Triangle
+        Displays actual disposal rates by origin and development; must have ultimate_
     valuation_date : date
         The latest valuation date of the data
     loc: Triangle
@@ -923,6 +925,19 @@ class Triangle(TriangleBase):
     def is_pattern(self, pattern: bool):
         self._pattern = pattern
 
+    @property
+    def is_disposal_rate(self) -> bool:
+        """
+        Indicates whether the Triangle holds disposal rates (additive ratios going from head to tail)
+        """
+        if hasattr(self, "_is_disposal_rate"):
+            return self._is_disposal_rate
+        return False
+
+    @is_disposal_rate.setter
+    def is_disposal_rate(self, is_dr: bool) -> None:
+        self._is_disposal_rate = is_dr
+
     def align_pattern(self, X:Triangle, sample_weight:Triangle|None=None) -> Triangle:
         """ 
         Vertically align a selected pattern to origin period latest diagonal. Triangle must be a selected pattern.
@@ -1134,6 +1149,58 @@ class Triangle(TriangleBase):
         """
         return self.link_ratio
 
+    @property
+    def disposal_rate_tri(self) -> Triangle:
+        """
+        Displays disposal rates for the triangle. Must have ultimate_
+
+        Returns
+        -------
+
+        Triangle
+            Triangle of disposal rates
+
+        Examples
+        --------
+
+        .. testsetup::
+
+            import chainladder as cl
+
+        .. testcode::
+
+            clrd = cl.load_sample('clrd').sum()
+            ult = cl.Chainladder().fit(clrd['IncurLoss']).ultimate_
+            dr = cl.DisposalRate().fit_transform(clrd['CumPaidLoss'],sample_weight = ult)
+            dr.disposal_rate_tri
+
+        .. testoutput::
+            
+                    12        24        36        48        60        72        84        96        108       120
+            1988  0.313923  0.619459  0.774429  0.865377  0.919077  0.948898  0.964643  0.973184  0.980224  0.983063
+            1989  0.321526  0.626023  0.781086  0.872345  0.924842  0.952533  0.967690  0.977373  0.981938       NaN
+            1990  0.329567  0.634056  0.790752  0.880273  0.927029  0.952951  0.968379  0.976049       NaN       NaN
+            1991  0.330035  0.636233  0.791888  0.881010  0.929460  0.954694  0.968533       NaN       NaN       NaN
+            1992  0.342613  0.650521  0.801875  0.885976  0.932865  0.956495       NaN       NaN       NaN       NaN
+            1993  0.353784  0.663303  0.810639  0.894414  0.939009       NaN       NaN       NaN       NaN       NaN
+            1994  0.367530  0.670460  0.814661  0.897244       NaN       NaN       NaN       NaN       NaN       NaN
+            1995  0.379650  0.680979  0.821603       NaN       NaN       NaN       NaN       NaN       NaN       NaN
+            1996  0.395603  0.688621       NaN       NaN       NaN       NaN       NaN       NaN       NaN       NaN
+            1997  0.393820       NaN       NaN       NaN       NaN       NaN       NaN       NaN       NaN       NaN
+            """
+
+        obj: Triangle = self.incr_to_cum() / self.ultimate_.values
+        if not obj.is_full:
+            obj = obj[obj.valuation <= obj.valuation_date]
+        if hasattr(obj, "w_"):
+            w_ = obj.w_[..., : len(obj.odims), :]
+            obj = obj * w_ if obj.shape == w_.shape else obj
+        obj.is_pattern = True
+        obj.is_cumulative = True
+        obj.is_disposal_rate = True
+        obj.values = num_to_nan(obj.values)
+        return obj
+
     def incr_to_cum(self, inplace=False):
         """Method to convert an incremental triangle into a cumulative triangle.
 
@@ -1215,14 +1282,13 @@ class Triangle(TriangleBase):
         if inplace:
             xp = self.get_array_module()
             if not self.is_cumulative:
-                if self.is_pattern:
-                    if hasattr(self, "is_additive"):
-                        if self.is_additive:
-                            values = xp.nan_to_num(self.values[..., ::-1])
-                            values = num_to_value(values, 0)
-                            self.values = (
-                                xp.cumsum(values, -1)[..., ::-1] * self.nan_triangle
-                            )
+                if self.is_pattern & (not self.is_disposal_rate):
+                    if hasattr(self, "is_additive") and self.is_additive:
+                        values = xp.nan_to_num(self.values[..., ::-1])
+                        values = num_to_value(values, 0)
+                        self.values = (
+                            xp.cumsum(values, -1)[..., ::-1] * self.nan_triangle
+                        )
                     else:
                         values = xp.nan_to_num(self.values[..., ::-1])
                         values = num_to_value(values, 1)
@@ -1297,7 +1363,7 @@ class Triangle(TriangleBase):
         if inplace:
             v = self.valuation_date
             if self.is_cumulative or self.is_cumulative is None:
-                if self.is_pattern:
+                if self.is_pattern & (not self.is_disposal_rate):
                     xp = self.get_array_module()
                     self.values = xp.nan_to_num(self.values)
                     values = num_to_value(self.values, 1)


### PR DESCRIPTION
## Summary of Changes  


## Related GitHub Issue(s)  


## Additional Context for Reviewers  


- [ ] I passed tests locally for both code (`uv run pytest`) and documentation changes (`uv run jb build docs --builder=custom --custom-builder=doctest`)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Renaming `disposal_`/`incr_disposal_` is a breaking API change, and changes to `incr_to_cum`/`cum_to_incr` for disposal patterns affect core reserving math paths.
> 
> **Overview**
> Introduces **`is_disposal_rate`** on `Triangle` and a **`disposal_rate_tri`** property (cumulative paid/incurred over **`ultimate_`**, flagged as a disposal pattern). **`incr_to_cum`** / **`cum_to_incr`** now skip multiplicative link-ratio handling when **`is_disposal_rate`** is set, so disposal patterns use ordinary cumulative differencing instead.
> 
> **`DisposalRate`** renames fitted pattern attributes from **`disposal_`** / **`incr_disposal_`** to **`disposal_rate_`** / **`incr_disposal_rate_`**, sets **`is_disposal_rate`** on stored patterns, and derives weights and transforms via **`X_.disposal_rate_tri`** after attaching **`ultimate_`** on the training triangle rather than keeping a separate **`disposal_rate_tri`** on the estimator. Tests follow the new names and assert **`AttributeError`** when **`disposal_rate_`** is accessed before fit.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6487299151a0c48fc6132bedbaaedf59568d1b65. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->