### PR TITLE
improving docstring and adding codecov coverage

### DIFF
--- a/chainladder/adjustments/disposal.py
+++ b/chainladder/adjustments/disposal.py
@@ -21,6 +21,9 @@ class DisposalMixin:
 
     @property
     def disposal_rate_(self) -> Triangle:
+        '''
+        Gets the estimated disposal rate
+        '''
         if not hasattr(self, "_disposal_rate_"):
             x = self.__class__.__name__
             raise AttributeError("'" + x + "' object has no attribute 'disposal_rate_'")
@@ -28,6 +31,9 @@ class DisposalMixin:
     
     @disposal_rate_.setter
     def disposal_rate_(self,value) -> None:
+        '''
+        Sets disposal_rate_
+        '''
         obj = copy.deepcopy(value)
         obj.is_pattern = True
         obj.is_disposal_rate = True
@@ -36,10 +42,16 @@ class DisposalMixin:
 
     @property
     def incr_disposal_rate_(self) -> Triangle:
+        '''
+        Gets the incremental of the estimated disposal rate
+        '''
         return self.disposal_rate_.cum_to_incr()
 
     @incr_disposal_rate_.setter
     def incr_disposal_rate_(self,value) -> None:
+        '''
+        Sets incr_disposal_rate_
+        '''
         obj = copy.deepcopy(value)
         obj.is_pattern = True
         obj.is_disposal_rate = True
@@ -252,12 +264,12 @@ class DisposalRate(DevelopmentBase, DisposalMixin):
             preserve = self.preserve,
             drop = self.drop
         )
-        if hasattr(self.X_, "w_"):
-            self.w_ = tw.fit(X=self.X_.disposal_rate_tri * self.X_.w_).w_.values
+        if hasattr(self.X_, "disposal_w_"):
+            self.disposal_w_ = tw.fit(X=self.X_.disposal_rate_tri * self.X_.disposal_w_).w_.values
         else:
-            self.w_ = tw.fit(X=self.X_.disposal_rate_tri).w_.values
+            self.disposal_w_ = tw.fit(X=self.X_.disposal_rate_tri).w_.values
         #calculate factors
-        super().fit(ult.values,self.X_.values,self.w_)
+        super().fit(ult.values,self.X_.values,self.disposal_w_)
         #keep attributes
         disposal = self._param_property(self.X_.disposal_rate_tri,self.params_.slope_[...,0][..., None, :])
         self.disposal_rate_ = concat((disposal,(self.X_.latest_diagonal*0 + 1).iloc[:,:,0,:].rename("development", [9999])),axis=3)
@@ -289,6 +301,7 @@ class DisposalRate(DevelopmentBase, DisposalMixin):
         #validate dimensions of sample weight
         MethodBase().validate_weight(X, sample_weight)
         #align backeneds
+        X_new.disposal_w_ = self.disposal_w_
         X_new.ultimate_ = sample_weight.set_backend(self.X_.array_backend).latest_diagonal
         X_new.disposal_rate_ = self.disposal_rate_
         ibnr_pct = 1 - X_new.disposal_rate_.align_pattern(X_new.disposal_rate_tri)

--- a/chainladder/adjustments/tests/test_disposal.py
+++ b/chainladder/adjustments/tests/test_disposal.py
@@ -80,3 +80,12 @@ def test_sparse_transform(raa:Triangle) -> None:
     from chainladder.utils.sparse import sp
     assert isinstance(dr.full_triangle_.values,sp.COO)
     
+def test_setting_incr(raa:Triangle) -> None:
+    """
+    DisposalMixin allows setting incremental disposal rates. Validating that the setting function works properly. 
+    """
+    ult = cl.Chainladder().fit(raa).ultimate_
+    dr = cl.DisposalRate(n_periods = 4).fit(raa,sample_weight=ult)
+    orig_disposal_rate_ = dr.disposal_rate_
+    dr.incr_disposal_rate_ = dr.incr_disposal_rate_ * 2
+    assert dr.disposal_rate_ == orig_disposal_rate_ * 2

--- a/chainladder/core/triangle.py
+++ b/chainladder/core/triangle.py
@@ -1176,25 +1176,24 @@ class Triangle(TriangleBase):
 
         .. testoutput::
             
-                    12        24        36        48        60        72        84        96        108       120
-            1988  0.313923  0.619459  0.774429  0.865377  0.919077  0.948898  0.964643  0.973184  0.980224  0.983063
-            1989  0.321526  0.626023  0.781086  0.872345  0.924842  0.952533  0.967690  0.977373  0.981938       NaN
-            1990  0.329567  0.634056  0.790752  0.880273  0.927029  0.952951  0.968379  0.976049       NaN       NaN
-            1991  0.330035  0.636233  0.791888  0.881010  0.929460  0.954694  0.968533       NaN       NaN       NaN
-            1992  0.342613  0.650521  0.801875  0.885976  0.932865  0.956495       NaN       NaN       NaN       NaN
-            1993  0.353784  0.663303  0.810639  0.894414  0.939009       NaN       NaN       NaN       NaN       NaN
+                    12-Ult    24-Ult    36-Ult    48-Ult    60-Ult    72-Ult    84-Ult    96-Ult   108-Ult   120-Ult
+            1988       NaN       NaN       NaN       NaN       NaN       NaN  0.964643  0.973184  0.980224  0.983063
+            1989       NaN       NaN       NaN       NaN       NaN  0.952533  0.967690  0.977373  0.981938       NaN
+            1990       NaN       NaN       NaN       NaN  0.927029  0.952951  0.968379  0.976049       NaN       NaN
+            1991       NaN       NaN       NaN  0.881010  0.929460  0.954694  0.968533       NaN       NaN       NaN
+            1992       NaN       NaN  0.801875  0.885976  0.932865  0.956495       NaN       NaN       NaN       NaN
+            1993       NaN  0.663303  0.810639  0.894414  0.939009       NaN       NaN       NaN       NaN       NaN
             1994  0.367530  0.670460  0.814661  0.897244       NaN       NaN       NaN       NaN       NaN       NaN
             1995  0.379650  0.680979  0.821603       NaN       NaN       NaN       NaN       NaN       NaN       NaN
             1996  0.395603  0.688621       NaN       NaN       NaN       NaN       NaN       NaN       NaN       NaN
             1997  0.393820       NaN       NaN       NaN       NaN       NaN       NaN       NaN       NaN       NaN
-            """
+        """
 
         obj: Triangle = self.incr_to_cum() / self.ultimate_.values
         if not obj.is_full:
             obj = obj[obj.valuation <= obj.valuation_date]
-        if hasattr(obj, "w_"):
-            w_ = obj.w_[..., : len(obj.odims), :]
-            obj = obj * w_ if obj.shape == w_.shape else obj
+        if hasattr(obj, "disposal_w_"):
+            obj = obj * obj.disposal_w_
         obj.is_pattern = True
         obj.is_cumulative = True
         obj.is_disposal_rate = True


### PR DESCRIPTION
## Summary of Changes  


## Related GitHub Issue(s)  


## Additional Context for Reviewers  


- [ ] I passed tests locally for both code (`uv run pytest`) and documentation changes (`uv run jb build docs --builder=custom --custom-builder=doctest`)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Renaming and re-plumbing disposal weights touches core reserving paths (`disposal_rate_tri`, fit/transform); behavior should stay equivalent but any external code that relied on `w_` on disposal triangles would break.
> 
> **Overview**
> Disposal-rate estimation and triangles now use **`disposal_w_`** instead of **`w_`** for `TriangleWeight` results, including **`DisposalRate.fit`**, **`transform`** (weights copied onto the output triangle), and **`disposal_rate_tri`** masking. That avoids colliding with development **`w_`** while keeping the same weighting behavior.
> 
> **`DisposalMixin`** gains short docstrings on **`disposal_rate_`** / **`incr_disposal_rate_`** getters and setters. Docs for **`disposal_rate_tri`** are updated to match the new weighted output (e.g. **`12-Ult`** column labels). A test **`test_setting_incr`** asserts scaling **`incr_disposal_rate_`** doubles **`disposal_rate_`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 432158de29d137332558dc28dc759292ae45165e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->