### PR TITLE
Avoiding Pandas 3.0.4

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -54,7 +54,7 @@ jobs:
       - name: Install dependencies
         run: uv sync --extra test
       - name: Run tests
-        run: uv run --with "pandas>=3,<4" pytest --nbmake --cov=chainladder --cov-report=xml
+        run: uv run --with "pandas>=3,<=3.0.3" pytest --nbmake --cov=chainladder --cov-report=xml
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v4
         with:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ classifiers = [
 ]
 keywords = ["actuarial", "reserving", "insurance", "chainladder", "IBNR"]
 dependencies = [
-    "pandas >=2.3.3",
+    "pandas >=2.3.3, <=3.0.3",
     "scikit-learn>1.4.2",
     "sparse>=0.9",
     "numpy>=2.0",


### PR DESCRIPTION
## Summary of Changes  
adding maximum pandas version to avoid bug in 3.0.4

## Related GitHub Issue(s)  
closes #1071

## Additional Context for Reviewers  


- [x] I passed tests locally for both code (`uv run pytest`) and documentation changes (`uv run jb build docs --builder=custom --custom-builder=doctest`)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dependency and CI constraint only; no application logic changes, though users are blocked from pandas 3.0.4+ until the cap is lifted.
> 
> **Overview**
> Caps the **pandas** dependency at **3.0.3** so installs and CI do not pick up **3.0.4**, which is called out as problematic (closes #1071).
> 
> `pyproject.toml` changes the declared range from `pandas >=2.3.3` to `pandas >=2.3.3, <=3.0.3`. The **linux-pandas3** workflow job aligns its `uv run --with` override from `pandas>=3,<4` to `pandas>=3,<=3.0.3` so notebook tests still exercise pandas 3.x without floating to 3.0.4+.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f65d23f4c22d5fed74e8ea57dcf0572a348853a0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->