### PR TITLE
additional tests

### DIFF
--- a/chainladder/utils/tests/test_utilities.py
+++ b/chainladder/utils/tests/test_utilities.py
@@ -1242,3 +1242,33 @@ def test_describe_option_invalid_regex() -> None:
     """
     with pytest.raises(ValueError, match="not a valid regular expression"):
         cl.options.describe_option('[')
+
+
+def test_triangleweight_drop_valuation_all(raa: Triangle) -> None:
+    '''
+    Testing error raising from dropping too many valuations
+    '''
+    with pytest.raises(Exception):
+        _ = cl.TriangleWeight(
+            drop_valuation=[
+                '1981',
+                '1982',
+                '1983',
+                '1984',
+                '1985',
+                '1986',
+                '1987',
+                '1988',
+                '1989',
+                '1990',
+            ]
+        ).fit(raa)
+
+def test_triangleweight_full_triangle(raa: Triangle) -> None:
+    '''
+    Testing new path that allows weights on full triangles
+    '''
+    ult = cl.Chainladder().fit(raa)
+    tw = cl.TriangleWeight(n_periods = 4).fit(raa)
+    tw_full = cl.TriangleWeight(n_periods = 4).fit(ult.full_triangle_)
+    assert tw.w_.iloc[:,:,:,0] == tw_full.w_.iloc[:,:,:,0]


### PR DESCRIPTION
## Summary of Changes  


## Related GitHub Issue(s)  


## Additional Context for Reviewers  


- [ ] I passed tests locally for both code (`uv run pytest`) and documentation changes (`uv run jb build docs --builder=custom --custom-builder=doctest`)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes with no production code modified.
> 
> **Overview**
> Adds **pytest coverage** for `TriangleWeight` in `test_utilities.py`.
> 
> **`test_triangleweight_drop_valuation_all`** asserts that fitting with `drop_valuation` set to every valuation year on the `raa` triangle raises an exception (over-aggressive dropping).
> 
> **`test_triangleweight_full_triangle`** checks that `TriangleWeight(n_periods=4)` applied to a Chainladder **`full_triangle_`** produces the same `w_` slice as fitting on the original triangle—locking in the “weights on full triangles” behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6f78fedc27b8d5272065a12a56780b5801fe64c0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->