### PR TITLE
Disposal rate method (#1022)

### DIFF
--- a/chainladder/__init__.py
+++ b/chainladder/__init__.py
@@ -486,6 +486,7 @@ from chainladder.adjustments import (  # noqa (API import)
     ParallelogramOLF,
     Trend,
     TrendConstant,
+    DisposalRate,
 )
 from chainladder.tails import (  # noqa (API import)
     TailBase,

--- a/chainladder/adjustments/__init__.py
+++ b/chainladder/adjustments/__init__.py
@@ -3,6 +3,7 @@ from chainladder.adjustments.berqsherm import BerquistSherman  # noqa (API impor
 from chainladder.adjustments.parallelogram import ParallelogramOLF  # noqa (API import)
 from chainladder.adjustments.trend import Trend  # noqa (API import)
 from chainladder.adjustments.trend import TrendConstant  # noqa (API import)
+from chainladder.adjustments.disposal import DisposalRate  # noqa (API import)
 
 __all__ = [
     "BootstrapODPSample",
@@ -10,4 +11,5 @@ __all__ = [
     "ParallelogramOLF",
     "Trend",
     "TrendConstant",
+    "DisposalRate"
 ]

--- a/chainladder/adjustments/disposal.py
+++ b/chainladder/adjustments/disposal.py
@@ -1,0 +1,332 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+from __future__ import annotations
+
+from chainladder.methods import Chainladder, MethodBase
+from chainladder.development import DevelopmentBase
+import numpy as np
+import copy
+from chainladder.utils import TriangleWeight, concat
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from chainladder.core import Triangle
+
+class DisposalMixin:
+    '''
+    This class provides attributes for the DisposalRate adjustment method and transformed `Triangle`    
+    '''
+
+    @property
+    def disposal_rate_(self) -> Triangle:
+        '''
+        Gets the estimated disposal rate
+        '''
+        if not hasattr(self, "_disposal_rate_"):
+            x = self.__class__.__name__
+            raise AttributeError("'" + x + "' object has no attribute 'disposal_rate_'")
+        return self._disposal_rate_
+    
+    @disposal_rate_.setter
+    def disposal_rate_(self,value) -> None:
+        '''
+        Sets disposal_rate_
+        '''
+        obj = copy.deepcopy(value)
+        obj.is_pattern = True
+        obj.is_disposal_rate = True
+        obj.is_cumulative = True
+        self._disposal_rate_ = obj
+
+    @property
+    def incr_disposal_rate_(self) -> Triangle:
+        '''
+        Gets the incremental of the estimated disposal rate
+        '''
+        return self.disposal_rate_.cum_to_incr()
+
+    @incr_disposal_rate_.setter
+    def incr_disposal_rate_(self,value) -> None:
+        '''
+        Sets incr_disposal_rate_
+        '''
+        obj = copy.deepcopy(value)
+        obj.is_pattern = True
+        obj.is_disposal_rate = True
+        obj.is_cumulative = False
+        self._disposal_rate_ = obj.incr_to_cum()
+
+class DisposalRate(DevelopmentBase, DisposalMixin):
+    """
+    Calculates the bottom of a fitted full_triangle_ using the Disposal Rate method described
+    by Friedland.
+
+    Parameters
+    ----------
+    n_periods: integer, optional (default = -1)
+        number of origin periods to be used in the ldf average calculation. For
+        all origin periods, set n_periods = -1
+    drop: tuple or list of tuples
+        Drops specific origin/development combination(s). See order of operations
+        below when combined with multiple drop parameters.
+    drop_high: bool, int, list of bools, or list of ints (default = None)
+        Drops highest (by rank) link ratio(s) from LDF calculation
+        If a boolean variable is passed, drop_high is set to 1, dropping only the
+        highest value. Protected by ``preserve``.
+        See order of operations below when combined with multiple drop parameters.
+    drop_low: bool, int, list of bools, or list of ints (default = None)
+        Drops lowest (by rank) link ratio(s) from LDF calculation
+        If a boolean variable is passed, drop_low is set to 1, dropping only the
+        lowest value. Protected by ``preserve``.
+        See order of operations below when combined with multiple drop parameters.
+    drop_above: float or list of floats (default = numpy.inf)
+        Drops all link ratio(s) above the given parameter from the LDF calculation.
+        Protected by ``preserve``.
+        See order of operations below when combined with multiple drop parameters.
+    drop_below: float or list of floats (default = 0.00)
+        Drops all link ratio(s) below the given parameter from the LDF calculation.
+        Protected by ``preserve``.
+        See order of operations below when combined with multiple drop parameters.
+    preserve: int (default = 1)
+        The minimum number of link ratio(s) required for LDF calculation.
+        See order of operations below when combined with multiple drop parameters.
+    drop_valuation: str or list of str (default = None)
+        Drops specific valuation periods. str must be date convertible.
+        See order of operations below when combined with multiple drop parameters.
+
+        .. note ::
+    
+            (Order of Drop Operations)
+            
+            When multiple drop parameters are used together, the weights are built in this order (steps 4 and 5 are reversed from `Development`):
+        
+            1. ``n_periods`` — limit to the most recent origin periods.
+            2. ``drop`` — remove specific origin/development cells.
+            3. ``drop_valuation`` — remove entire valuation diagonal in the triangle.
+            4. ``drop_above`` / ``drop_below`` — remove link ratios outside a range
+               (Protected by``preserve``, which may relax exclusions from this step if too few ratios would remain
+               then this step is skipped).
+            5. ``drop_high`` / ``drop_low`` — remove highest/lowest link ratios by rank
+               (eligible factors from ``n_periods`` are used; protected by ``preserve``,
+               which may relax exclusions from this step if too few ratios would remain then this step is skipped).
+            6. Calculate the loss development factors using ``average`` method.
+
+    Attributes
+    ----------
+    disposal_rate_: Triangle
+        fitted disposal rates
+
+    incr_disposal_rate_: Triangle
+        incremental of disposal_
+
+    Examples
+    --------
+    This adjustment method re-apportions future loss emergence based on a '% of ultimate' emergence pattern. 
+    The ultimate can come from another triangle. A common use case is to forecast payment pattern based on incurred ultimate.
+    
+    .. testsetup::
+
+        import chainladder as cl
+        import numpy as np
+
+    .. testcode::
+
+        clrd = cl.load_sample('clrd').sum()
+        ult = cl.Chainladder().fit(clrd['IncurLoss']).ultimate_
+        dr = cl.DisposalRate().fit_transform(clrd['CumPaidLoss'],sample_weight = ult)
+
+    Once we apply this adjustment method via a `fit_transform`, we can examine the emergence pattern via `disposal_rate_tri`. 
+
+    .. testcode::
+    
+        dr.disposal_rate_tri
+
+    .. testoutput::
+        
+                12        24        36        48        60        72        84        96        108       120
+        1988  0.313923  0.619459  0.774429  0.865377  0.919077  0.948898  0.964643  0.973184  0.980224  0.983063
+        1989  0.321526  0.626023  0.781086  0.872345  0.924842  0.952533  0.967690  0.977373  0.981938       NaN
+        1990  0.329567  0.634056  0.790752  0.880273  0.927029  0.952951  0.968379  0.976049       NaN       NaN
+        1991  0.330035  0.636233  0.791888  0.881010  0.929460  0.954694  0.968533       NaN       NaN       NaN
+        1992  0.342613  0.650521  0.801875  0.885976  0.932865  0.956495       NaN       NaN       NaN       NaN
+        1993  0.353784  0.663303  0.810639  0.894414  0.939009       NaN       NaN       NaN       NaN       NaN
+        1994  0.367530  0.670460  0.814661  0.897244       NaN       NaN       NaN       NaN       NaN       NaN
+        1995  0.379650  0.680979  0.821603       NaN       NaN       NaN       NaN       NaN       NaN       NaN
+        1996  0.395603  0.688621       NaN       NaN       NaN       NaN       NaN       NaN       NaN       NaN
+        1997  0.393820       NaN       NaN       NaN       NaN       NaN       NaN       NaN       NaN       NaN
+
+    The estimated pattern is stored in `disposal_rate_`. 
+
+    .. testcode::
+
+        dr.disposal_rate_
+        
+    .. testoutput::
+
+                12-Ult    24-Ult    36-Ult    48-Ult    60-Ult    72-Ult    84-Ult    96-Ult   108-Ult  120-Ult  132-Ult
+        (All)  0.112105  0.336242  0.545897  0.693774  0.812877  0.905045  0.942998  0.974365  0.990868      1.0      1.0
+
+    `full_triangle_` now reflects the disposal-rate-based forecast. 
+
+    .. testcode::
+
+        dr.full_triangle_
+        
+    .. testoutput::
+
+                12            24            36            48            60            72            84            96            108           120           9999
+        1988  3577780.0  7.059966e+06  8.826151e+06  9.862687e+06  1.047470e+07  1.081458e+07  1.099401e+07  1.109136e+07  1.117159e+07  1.120395e+07  1.139698e+07
+        1989  4090680.0  7.964702e+06  9.937520e+06  1.109859e+07  1.176649e+07  1.211879e+07  1.231163e+07  1.243483e+07  1.249290e+07  1.251646e+07  1.272270e+07
+        1990  4578442.0  8.808486e+06  1.098535e+07  1.222900e+07  1.287854e+07  1.323867e+07  1.345299e+07  1.355956e+07  1.363458e+07  1.366101e+07  1.389229e+07
+        1991  4648756.0  8.961755e+06  1.115424e+07  1.240959e+07  1.309204e+07  1.344748e+07  1.364241e+07  1.375400e+07  1.382878e+07  1.385512e+07  1.408564e+07
+        1992  5139142.0  9.757699e+06  1.202798e+07  1.328948e+07  1.399282e+07  1.434727e+07  1.454438e+07  1.465904e+07  1.473589e+07  1.476295e+07  1.499983e+07
+        1993  5653379.0  1.059942e+07  1.295381e+07  1.429252e+07  1.500514e+07  1.533589e+07  1.553037e+07  1.564351e+07  1.571933e+07  1.574603e+07  1.597976e+07
+        1994  6246447.0  1.139496e+07  1.384576e+07  1.524933e+07  1.593547e+07  1.629529e+07  1.650686e+07  1.662994e+07  1.671242e+07  1.674147e+07  1.699574e+07
+        1995  6473843.0  1.161215e+07  1.401010e+07  1.527961e+07  1.597603e+07  1.634123e+07  1.655597e+07  1.668088e+07  1.676460e+07  1.679409e+07  1.705215e+07
+        1996  6591599.0  1.147391e+07  1.365956e+07  1.491261e+07  1.559998e+07  1.596045e+07  1.617240e+07  1.629570e+07  1.637833e+07  1.640743e+07  1.666215e+07
+        1997  6451896.0  1.106345e+07  1.330436e+07  1.458909e+07  1.529384e+07  1.566342e+07  1.588073e+07  1.600714e+07  1.609186e+07  1.612170e+07  1.638286e+07
+
+    """
+
+    def __init__(
+        self,
+        n_periods: int = -1,
+        average: str | list[str] = 'volume',
+        drop: tuple | list[tuple] | None = None,
+        drop_high: bool | int | list[bool] | list[int] | None = None,
+        drop_low: bool | int | list[bool] | list[int] | None = None,
+        preserve: int = 1,
+        drop_valuation: str | list[str] | None = None,
+        drop_above: float = np.inf,
+        drop_below: float = 0.00,
+    ):
+        self.n_periods = n_periods
+        self.average = average
+        self.drop_high = drop_high
+        self.drop_low = drop_low
+        self.preserve = preserve
+        self.drop_valuation = drop_valuation
+        self.drop_above = drop_above
+        self.drop_below = drop_below
+        self.drop = drop
+
+    def fit(
+            self, 
+            X:Triangle, 
+            y:None=None, 
+            sample_weight:Triangle|None=None
+    ):
+        """
+        Estimate disposal rate for a given Triangle and ultimate
+
+        Parameters
+        ----------
+        X : Triangle
+            Triangle to which the Disposal Rate method is applied
+        y : None
+            Ignored
+        sample_weight : Triangle
+            Ultimate
+
+        Returns
+        -------
+        self : object
+            Returns the instance itself.
+
+        """
+        if sample_weight is None:
+            raise ValueError("sample_weight is required.")
+        #validate dimensions of sample weight
+        MethodBase().validate_weight(X, sample_weight)
+        #set backeneds to numpy
+        if X.array_backend == "sparse":
+            X = X.set_backend("numpy")
+        else:
+            X = X.copy()
+        if sample_weight.array_backend == "sparse":
+            ult = sample_weight.set_backend("numpy")
+        else:
+            ult = sample_weight.copy()
+        #calculate disposal rate triangle
+        self.xp = X.get_array_module()
+        self.X_ = X.incr_to_cum().sort_index()
+        self.X_.ultimate_ = ult
+        #get weights for estimation
+        tw = TriangleWeight(
+            n_periods = self.n_periods,
+            drop_high = self.drop_high,
+            drop_low = self.drop_low,
+            drop_above = self.drop_above,
+            drop_below = self.drop_below,
+            drop_valuation = self.drop_valuation,
+            preserve = self.preserve,
+            drop = self.drop
+        )
+        if hasattr(self.X_, "disposal_w_"):
+            self.disposal_w_ = tw.fit(X=self.X_.disposal_rate_tri * self.X_.disposal_w_).w_.values
+        else:
+            self.disposal_w_ = tw.fit(X=self.X_.disposal_rate_tri).w_.values
+        #calculate factors
+        super().fit(ult.values,self.X_.values,self.disposal_w_)
+        #keep attributes
+        disposal = self._param_property(self.X_.disposal_rate_tri,self.params_.slope_[...,0][..., None, :])
+        self.disposal_rate_ = concat((disposal,(self.X_.latest_diagonal*0 + 1).iloc[:,:,0,:].rename("development", [9999])),axis=3)
+        return self
+
+    def transform(
+            self, 
+            X: Triangle, 
+            sample_weight: Triangle | None = None
+    ) -> Triangle:
+        """ If X and self are of different shapes, align self to X, else
+        return self.
+
+        Parameters
+        ----------
+        X: Triangle
+            The triangle to be transformed
+
+        sample_weight: Triangle
+            Ultimate
+
+        Returns
+        -------
+            X_new: New triangle with transformed attributes.
+        """
+        if sample_weight is None:
+            raise ValueError("sample_weight is required.")
+        X_new = copy.deepcopy(X)
+        #validate dimensions of sample weight
+        MethodBase().validate_weight(X, sample_weight)
+        #align backeneds
+        X_new.disposal_w_ = self.disposal_w_
+        X_new.ultimate_ = sample_weight.set_backend(self.X_.array_backend).latest_diagonal
+        X_new.disposal_rate_ = self.disposal_rate_
+        ibnr_pct = 1 - X_new.disposal_rate_.align_pattern(X_new.disposal_rate_tri)
+        run_off = X_new.incr_disposal_rate_ / ibnr_pct * X_new.ibnr_
+        run_off = run_off[run_off.valuation > X_new.valuation_date]
+        X_new.ldf_ = (X_new.cum_to_incr() + run_off).incr_to_cum().age_to_age
+        return X_new
+    
+    def fit_transform(self, X, y=None, sample_weight=None):
+        """Fit and return transformed full_triangle_ based on the Disposal Rate
+
+        Parameters
+        ----------
+        X : Triangle
+            Loss data to which the model will be applied.
+
+        y : None
+            Ignored
+
+        sample_weight : Triangle, default=None
+            Ultimate
+
+        Returns
+        -------
+        X_new: Triangle
+            Triangle with new full_triangle_
+        """
+        return self.fit(X, y, sample_weight).transform(X, sample_weight=sample_weight)

--- a/chainladder/adjustments/tests/test_disposal.py
+++ b/chainladder/adjustments/tests/test_disposal.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+import chainladder as cl
+import numpy as np
+import pytest
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from chainladder.core import Triangle
+
+def test_friedland_fidelity() -> None:
+    '''
+    Reconciles to Chapter 11 Exhibit 5 of the Friedland reserving textbook
+    '''
+    tri = cl.load_sample('friedland_gl_insurer')
+    ccc_dev = cl.Development(n_periods=3, average='volume').fit_transform(tri['Closed Claim Counts'])
+    ccc_dev.ldf_ = ccc_dev.ldf_.round(3)
+    ccc_dev_wtail = cl.TailConstant(tail = 1.100, projection_period = 0).fit_transform(ccc_dev)
+    ccc_ult = cl.Chainladder().fit(ccc_dev_wtail).ultimate_
+    rcc_dev = cl.Development(n_periods=3, average='volume').fit_transform(tri['Reported Claim Counts'])
+    rcc_dev.ldf_ = rcc_dev.ldf_.round(3)
+    rcc_ult = cl.Chainladder().fit(rcc_dev).ultimate_
+    ult = (ccc_ult + rcc_ult) / 2
+    dr_transformer = cl.DisposalRate(n_periods = 5, average = 'simple', drop_high = 1, drop_low = 1).fit(X=tri['Closed Claim Counts'],sample_weight=ult)
+    dr_transformer.disposal_rate_ = dr_transformer.disposal_rate_.round(3)
+    assert np.all(dr_transformer.disposal_rate_.values.flatten() == [.200,.433,.585,.710,.791,.862,.882,.912,1.000])
+    #Friedland uses rounded ultimates to calculate bottom half of the triangle, which introduces some rounding discrepancies with the implementation
+    dr = dr_transformer.transform(X=tri['Closed Claim Counts'],sample_weight=ult.round(0))
+    lhs = (dr.full_triangle_.cum_to_incr()-tri['Closed Claim Counts'].cum_to_incr()).round(0).values.flatten()
+    rhs = np.array([
+                                                            77.,  
+                                                    24.,    70.,  
+                                            12.,    18.,    54.,  
+                                    46.,    13.,    19.,    57.,  
+                            52.,    45.,    13.,    19.,    56.,  
+                    76.,    49.,    43.,    12.,    18.,    54.,  
+            67.,    55.,    36.,    31.,    9.,     13.,    39.,  
+    140.,   91.,    75.,    49.,    43.,    12.,    18.,    53.
+    ])
+    assert np.all(abs(lhs[~np.isnan(lhs)] - rhs <= 1))
+
+def test_no_weight_exception(raa:Triangle) -> None:
+    '''
+    sample_weight is optional in the default sklearn API. however, we require sample_weight to provide the a priori ultimate. 
+    '''
+    with pytest.raises(ValueError):
+        dr = cl.DisposalRate().fit(raa)
+    ult = cl.Chainladder().fit(raa).ultimate_
+    dr = cl.DisposalRate().fit(raa,sample_weight=ult)
+    with pytest.raises(ValueError):
+        est = dr.transform(raa)
+
+def test_no_disposal_exception(raa:Triangle) -> None:
+    '''
+    disposal attributes are available in Triangle through the mixin, but not available before fitting 
+    '''
+    with pytest.raises(AttributeError):
+        _ = raa.disposal_rate_
+    with pytest.raises(AttributeError):
+        _ = raa.incr_disposal_rate_
+
+def test_cl_parity(raa:Triangle) -> None:
+    """
+    A no-tail, full-triangle, volume-weighted Chainladder estimator coincides with the disposal rate adjustment. 
+    """
+    tri = raa.set_backend('sparse')
+    dev = cl.Development().fit_transform(tri)
+    est = cl.Chainladder().fit(dev)
+    dr = cl.DisposalRate().fit_transform(raa,sample_weight=est.ultimate_)
+    assert np.all(dr.full_triangle_.round(3).values[...,:-1] == est.full_triangle_.round(3).values[...,:-2])
+
+def test_sparse_transform(raa:Triangle) -> None:
+    """
+    if the supplied Triangle is sparse, then the resulting full_triangle_ is also sparse 
+    """
+    raa_sparse = raa.set_backend('sparse')
+    ult = cl.Chainladder().fit(raa_sparse).ultimate_.set_backend('sparse')
+    dr = cl.DisposalRate().fit_transform(raa_sparse,sample_weight=ult)
+    from chainladder.utils.sparse import sp
+    assert isinstance(dr.full_triangle_.values,sp.COO)
+    
+def test_setting_incr(raa:Triangle) -> None:
+    """
+    DisposalMixin allows setting incremental disposal rates. Validating that the setting function works properly. 
+    """
+    ult = cl.Chainladder().fit(raa).ultimate_
+    dr = cl.DisposalRate(n_periods = 4).fit(raa,sample_weight=ult)
+    orig_disposal_rate_ = dr.disposal_rate_
+    dr.incr_disposal_rate_ = dr.incr_disposal_rate_ * 2
+    assert dr.disposal_rate_ == orig_disposal_rate_ * 2

--- a/chainladder/core/base.py
+++ b/chainladder/core/base.py
@@ -27,6 +27,8 @@ from chainladder.utils.cupy import cp
 from chainladder.utils.dask import dp
 from chainladder.utils.sparse import sp
 
+from chainladder.adjustments.disposal import DisposalMixin
+
 from typing import (
     Optional,
     TYPE_CHECKING
@@ -50,7 +52,8 @@ class TriangleBase(
     TriangleDunders,
     TrianglePandas,
     Common,
-    ABC
+    ABC,
+    DisposalMixin
 ):
     """This class handles the initialization of a triangle"""
 

--- a/chainladder/core/triangle.py
+++ b/chainladder/core/triangle.py
@@ -106,8 +106,10 @@ class Triangle(TriangleBase):
         The grain of the development vector ('Y', 'S', 'Q', 'M')
     shape: tuple
         The 4D shape of the triangle instance with axes corresponding to (index, columns, origin, development)
-    link_ratio, age_to_age
+    link_ratio, age_to_age: Triangle
         Displays age-to-age ratios for the triangle.
+    disposal_rate_tri: Triangle
+        Displays actual disposal rates by origin and development; must have ultimate_
     valuation_date : date
         The latest valuation date of the data
     loc: Triangle
@@ -923,6 +925,19 @@ class Triangle(TriangleBase):
     def is_pattern(self, pattern: bool):
         self._pattern = pattern
 
+    @property
+    def is_disposal_rate(self) -> bool:
+        """
+        Indicates whether the Triangle holds disposal rates (additive ratios going from head to tail)
+        """
+        if hasattr(self, "_is_disposal_rate"):
+            return self._is_disposal_rate
+        return False
+
+    @is_disposal_rate.setter
+    def is_disposal_rate(self, is_dr: bool) -> None:
+        self._is_disposal_rate = is_dr
+
     def align_pattern(self, X:Triangle, sample_weight:Triangle|None=None) -> Triangle:
         """ 
         Vertically align a selected pattern to origin period latest diagonal. Triangle must be a selected pattern.
@@ -1134,6 +1149,57 @@ class Triangle(TriangleBase):
         """
         return self.link_ratio
 
+    @property
+    def disposal_rate_tri(self) -> Triangle:
+        """
+        Displays disposal rates for the triangle. Must have ultimate_
+
+        Returns
+        -------
+
+        Triangle
+            Triangle of disposal rates
+
+        Examples
+        --------
+
+        .. testsetup::
+
+            import chainladder as cl
+
+        .. testcode::
+
+            clrd = cl.load_sample('clrd').sum()
+            ult = cl.Chainladder().fit(clrd['IncurLoss']).ultimate_
+            dr = cl.DisposalRate().fit_transform(clrd['CumPaidLoss'],sample_weight = ult)
+            dr.disposal_rate_tri
+
+        .. testoutput::
+            
+                    12-Ult    24-Ult    36-Ult    48-Ult    60-Ult    72-Ult    84-Ult    96-Ult   108-Ult   120-Ult
+            1988       NaN       NaN       NaN       NaN       NaN       NaN  0.964643  0.973184  0.980224  0.983063
+            1989       NaN       NaN       NaN       NaN       NaN  0.952533  0.967690  0.977373  0.981938       NaN
+            1990       NaN       NaN       NaN       NaN  0.927029  0.952951  0.968379  0.976049       NaN       NaN
+            1991       NaN       NaN       NaN  0.881010  0.929460  0.954694  0.968533       NaN       NaN       NaN
+            1992       NaN       NaN  0.801875  0.885976  0.932865  0.956495       NaN       NaN       NaN       NaN
+            1993       NaN  0.663303  0.810639  0.894414  0.939009       NaN       NaN       NaN       NaN       NaN
+            1994  0.367530  0.670460  0.814661  0.897244       NaN       NaN       NaN       NaN       NaN       NaN
+            1995  0.379650  0.680979  0.821603       NaN       NaN       NaN       NaN       NaN       NaN       NaN
+            1996  0.395603  0.688621       NaN       NaN       NaN       NaN       NaN       NaN       NaN       NaN
+            1997  0.393820       NaN       NaN       NaN       NaN       NaN       NaN       NaN       NaN       NaN
+        """
+
+        obj: Triangle = self.incr_to_cum() / self.ultimate_.values
+        if not obj.is_full:
+            obj = obj[obj.valuation <= obj.valuation_date]
+        if hasattr(obj, "disposal_w_"):
+            obj = obj * obj.disposal_w_
+        obj.is_pattern = True
+        obj.is_cumulative = True
+        obj.is_disposal_rate = True
+        obj.values = num_to_nan(obj.values)
+        return obj
+
     def incr_to_cum(self, inplace=False):
         """Method to convert an incremental triangle into a cumulative triangle.
 
@@ -1215,14 +1281,13 @@ class Triangle(TriangleBase):
         if inplace:
             xp = self.get_array_module()
             if not self.is_cumulative:
-                if self.is_pattern:
-                    if hasattr(self, "is_additive"):
-                        if self.is_additive:
-                            values = xp.nan_to_num(self.values[..., ::-1])
-                            values = num_to_value(values, 0)
-                            self.values = (
-                                xp.cumsum(values, -1)[..., ::-1] * self.nan_triangle
-                            )
+                if self.is_pattern & (not self.is_disposal_rate):
+                    if hasattr(self, "is_additive") and self.is_additive:
+                        values = xp.nan_to_num(self.values[..., ::-1])
+                        values = num_to_value(values, 0)
+                        self.values = (
+                            xp.cumsum(values, -1)[..., ::-1] * self.nan_triangle
+                        )
                     else:
                         values = xp.nan_to_num(self.values[..., ::-1])
                         values = num_to_value(values, 1)
@@ -1297,7 +1362,7 @@ class Triangle(TriangleBase):
         if inplace:
             v = self.valuation_date
             if self.is_cumulative or self.is_cumulative is None:
-                if self.is_pattern:
+                if self.is_pattern & (not self.is_disposal_rate):
                     xp = self.get_array_module()
                     self.values = xp.nan_to_num(self.values)
                     values = num_to_value(self.values, 1)

--- a/chainladder/methods/base.py
+++ b/chainladder/methods/base.py
@@ -1,6 +1,8 @@
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
+from __future__ import annotations
+
 import numpy as np
 import pandas as pd
 import warnings
@@ -10,6 +12,10 @@ from chainladder.development import Development
 from chainladder.core.io import EstimatorIO
 from chainladder.core.common import Common
 
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from chainladder.core import Triangle
 
 class MethodBase(BaseEstimator, EstimatorIO, Common):
 
@@ -138,7 +144,14 @@ class MethodBase(BaseEstimator, EstimatorIO, Common):
             process_var = None
         return process_var
 
-    def validate_weight(self, X, sample_weight):
+    @staticmethod
+    def validate_weight(
+            X: Triangle,
+            sample_weight: Triangle
+    ) -> None:
+        '''
+        Checks that the a aprior has valid dimensions
+        '''
         if (
             sample_weight
             and X.shape[:-1] != sample_weight.shape[:-1]

--- a/chainladder/tests/test_public_api.py
+++ b/chainladder/tests/test_public_api.py
@@ -56,6 +56,7 @@ EXPECTED_PUBLIC_API = {
     "ParallelogramOLF",
     "Trend",
     "TrendConstant",
+    "DisposalRate",
     # tails
     "TailBase",
     "TailConstant",


### PR DESCRIPTION
Created a DisposalMixin for the new adjustment estimator and Triangle

Berquist-Sherman also uses disposal rate. will leave harmonization to another PR We may eventually want to split Common into DevelopmentMixin, IncrementalMixin, etc. Added disposal_rate_tri to Triangle, mimicking age_to_age/link_ratio

Added is_disposal_rate to Triangle, in order to differentiate the proper path in incr_to_cum and cum_to_incr

## Summary of Changes  


## Related GitHub Issue(s)  


## Additional Context for Reviewers  


- [ ] I passed tests locally for both code (`uv run pytest`) and documentation changes (`uv run jb build docs --builder=custom --custom-builder=doctest`)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core Triangle cum/incr logic and introduces a new reserving path that depends on external ultimates; behavior is covered by tests but mistakes could affect triangle arithmetic for pattern triangles.
> 
> **Overview**
> Adds **`DisposalRate`**, a Friedland-style adjustment that fits cumulative disposal patterns against a required **`sample_weight`** ultimate and uses them to project the lower triangle via runoff-derived **`ldf_`**.
> 
> **Triangle** gains **`disposal_rate_tri`**, **`is_disposal_rate`**, and **`DisposalMixin`** (`disposal_rate_` / `incr_disposal_rate_`). **`incr_to_cum`** and **`cum_to_incr`** now treat disposal-rate patterns separately from multiplicative link-ratio patterns.
> 
> **`MethodBase.validate_weight`** is a **`@staticmethod`** so **`DisposalRate`** can validate ultimates without a full fit. **`DisposalRate`** is exported in the public API; tests cover Friedland fidelity, chainladder parity, sparse backends, and required weights.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 921bfca1aac6286b335ca268919619d17130bb8c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->