### PR TITLE
refactor swapaxes to object

### DIFF
--- a/chainladder/adjustments/bootstrap.py
+++ b/chainladder/adjustments/bootstrap.py
@@ -258,7 +258,7 @@ class BootstrapODPSample(DevelopmentBase):
         )
         b = xp.repeat(exp_incr_triangle[None, ...], self.n_sims, 0)
         resampled_triangles = (resampled_residual * xp.sqrt(abs(b)) + b).cumsum(2)
-        resampled_triangles = xp.swapaxes(resampled_triangles[None, ...], 0, 1)
+        resampled_triangles = resampled_triangles[None, ...].swapaxes(0, 1)
         obj = X.copy()
         if X.key_labels == ['Total']:
             obj.kdims = np.arange(self.n_sims)

--- a/chainladder/development/clark.py
+++ b/chainladder/development/clark.py
@@ -335,7 +335,7 @@ class ClarkLDF(DevelopmentBase):
         if sample_weight:
             self.elr_ = pd.DataFrame(params[..., 0, 2], index=rows, columns=X.vdims)
         ultimate_ = (
-            xp.swapaxes(self._G(age=(latest_age - age_offset)[::-1]), -1, -2)
+            self._G(age=(latest_age - age_offset)[::-1]).swapaxes(-1, -2)
             * ld.values
         )
         self.incremental_fits_ = X.copy()

--- a/chainladder/development/development.py
+++ b/chainladder/development/development.py
@@ -431,7 +431,7 @@ class Development(DevelopmentBase):
             w_reg = params._w_reg
 
         params = xp.concatenate((params.slope_, params.sigma_, params.std_err_), 3)
-        params = xp.swapaxes(params, 2, 3)
+        params = params.swapaxes(2, 3)
 
         self.ldf_ = self._param_property(obj, params, 0)
         self.sigma_ = self._param_property(obj, params, 1)

--- a/chainladder/development/munich.py
+++ b/chainladder/development/munich.py
@@ -223,7 +223,7 @@ class MunichAdjustment(DevelopmentBase):
         modelsI = modelsI.fit(i, p, 1 / i).sigma_fill(X.sigma_interpolation)
         q_f = self._p_to_i_concate(modelsP.slope_, modelsI.slope_, xp)
         rho_sigma = self._p_to_i_concate(modelsP.sigma_, modelsI.sigma_, xp)
-        return xp.swapaxes(q_f, -1, -2), xp.swapaxes(rho_sigma, -1, -2)
+        return q_f.swapaxes(-1, -2), rho_sigma.swapaxes(-1, -2)
 
     def _get_MCL_resids(self, X):
         xp = X.get_array_module()

--- a/chainladder/development/tests/test_development.py
+++ b/chainladder/development/tests/test_development.py
@@ -35,7 +35,7 @@ class _FutureDevelopment(cl.TriangleWeight):
             params = cl.WeightedRegression(axis=2, thru_orig=True, xp=xp).fit(
                 reg_x, reg_y, self.w_.values, average_param
             )
-            self.ldf_ = self.dev._param_property(X, xp.swapaxes(params.slope_, 2, 3), 0)
+            self.ldf_ = self.dev._param_property(X, params.slope_.swapaxes(2, 3), 0)
         return self
     
 def test_full_slice(genins):

--- a/chainladder/methods/capecod.py
+++ b/chainladder/methods/capecod.py
@@ -251,11 +251,11 @@ class CapeCod(Benktander):
         decay_matrix = self.decay ** xp.abs(
             xp.arange(len_orig)[None].T - xp.arange(len_orig)[None]
         )
-        weighted_exposure = xp.swapaxes(reported_exposure.values, -1, -2) * decay_matrix
+        weighted_exposure = reported_exposure.values.swapaxes(-1, -2) * decay_matrix
         trended_ultimate = (latest.values * trend_array * X_olf_array) / (
             reported_exposure.values * sw_olf_array
         )
-        trended_ultimate = xp.swapaxes(trended_ultimate, -1, -2)
+        trended_ultimate = trended_ultimate.swapaxes(-1, -2)
         apriori = xp.nansum(weighted_exposure * trended_ultimate, -1) / xp.nansum(
             weighted_exposure, -1
         )

--- a/chainladder/utils/weighted_regression.py
+++ b/chainladder/utils/weighted_regression.py
@@ -174,7 +174,7 @@ class WeightedRegression(BaseEstimator):
         self.std_err_ = xp.nan_to_num(self.std_err_) + xp.nan_to_num(
             (1 - xp.nan_to_num(self.std_err_ * 0 + 1))
             * self.sigma_
-            / xp.swapaxes(xp.sqrt(self.x ** (2 - self.exponent_))[..., 0:1, :], -1, -2)
+            / xp.sqrt(self.x ** (2 - self.exponent_))[..., 0:1, :].swapaxes(-1, -2)
         )
         return self
 


### PR DESCRIPTION
## Summary of Changes  
Changing all instance of xp.swapaxes(arr,...) to arr.swapaxes(...) , in order to reduce reliance on xp

## Related GitHub Issue(s)  
refers #1031

## Additional Context for Reviewers  


- [X] I passed tests locally for both code (`uv run pytest`) and documentation changes (`uv run jb build docs --builder=custom --custom-builder=doctest`)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mechanical, behavior-equivalent refactor with no algorithm or API changes; risk is limited to backend parity if a non-NumPy/CuPy array module lacked `.swapaxes`.
> 
> **Overview**
> Replaces **`xp.swapaxes(arr, …)`** with **`arr.swapaxes(…)`** across bootstrap ODP resampling, Clark/Munich development, standard **Development** regression params, Cape Cod apriori weighting, and **WeightedRegression** `std_err_fill`, so axis swaps go through the array API instead of the backend module (issue #1031).
> 
> A test helper in **`test_development.py`** is updated the same way; the only other diff there is a trailing newline at EOF.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 185190015c636003cf6f013f16b5117eda3e14eb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->