### PR TITLE
Various Doctest Fixes

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -75,5 +75,11 @@ jobs:
           python-version: "3.12"
       - name: Install dependencies
         run: uv sync --extra docs
+      - name: Generate autosummary stubs
+        # sphinx-build decides which documents the doctest builder will test
+        # *before* the autosummary extension has generated library/generated/*.rst
+        # (those files are gitignored, so they don't exist on a fresh checkout).
+        # Without this, every class/method docstring page is silently skipped.
+        run: uv run --directory docs sphinx-autogen -o library/generated library/api.md
       - name: Run doctests
         run: uv run --directory docs sphinx-build -b doctest . _build/doctest

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -76,10 +76,6 @@ jobs:
       - name: Install dependencies
         run: uv sync --extra docs
       - name: Generate autosummary stubs
-        # sphinx-build decides which documents the doctest builder will test
-        # *before* the autosummary extension has generated library/generated/*.rst
-        # (those files are gitignored, so they don't exist on a fresh checkout).
-        # Without this, every class/method docstring page is silently skipped.
         run: uv run --directory docs sphinx-autogen -o library/generated library/api.md
       - name: Run doctests
-        run: uv run --directory docs sphinx-build -b doctest . _build/doctest
+        run: uv run --directory docs jb build . --builder=custom --custom-builder=doctest

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -75,7 +75,5 @@ jobs:
           python-version: "3.12"
       - name: Install dependencies
         run: uv sync --extra docs
-      - name: Generate autosummary stubs
-        run: uv run --directory docs sphinx-autogen -o library/generated library/api.md
       - name: Run doctests
         run: uv run --directory docs jb build . --builder=custom --custom-builder=doctest

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -76,4 +76,4 @@ jobs:
       - name: Install dependencies
         run: uv sync --extra docs
       - name: Run doctests
-        run: uv run --directory docs jb build . --builder=custom --custom-builder=doctest
+        run: uv run --directory docs sphinx-build -b doctest . _build/doctest

--- a/chainladder/core/common.py
+++ b/chainladder/core/common.py
@@ -174,6 +174,17 @@ class Common:
         >>> import chainladder as cl
         >>> raa = cl.load_sample('raa')
         >>> raa.pipe(lambda tri: tri.loc[..., 48:])
+                  48       60       72       84       96       108      120
+        1981  11805.0  13539.0  16181.0  18009.0  18608.0  18662.0  18834.0
+        1982  10666.0  13782.0  15599.0  15496.0  16169.0  16704.0      NaN
+        1983  16141.0  18735.0  22214.0  22863.0  23466.0      NaN      NaN
+        1984  21266.0  23425.0  26083.0  27067.0      NaN      NaN      NaN
+        1985  22169.0  25955.0  26180.0      NaN      NaN      NaN      NaN
+        1986  12935.0  15852.0      NaN      NaN      NaN      NaN      NaN
+        1987  12314.0      NaN      NaN      NaN      NaN      NaN      NaN
+        1988      NaN      NaN      NaN      NaN      NaN      NaN      NaN
+        1989      NaN      NaN      NaN      NaN      NaN      NaN      NaN
+        1990      NaN      NaN      NaN      NaN      NaN      NaN      NaN
         """
         return func(self, *args, **kwargs)
 

--- a/chainladder/development/clark.py
+++ b/chainladder/development/clark.py
@@ -142,7 +142,7 @@ class ClarkLDF(DevelopmentBase):
 
         775
                   CumPaidLoss
-        LOB
+        LOB                  
         comauto         1.082
         medmal          1.889
         othliab         1.468
@@ -150,12 +150,12 @@ class ClarkLDF(DevelopmentBase):
         prodliab        1.441
         wkcomp          1.107
                   CumPaidLoss
-        LOB
+        LOB                  
         comauto        20.481
-        medmal         35.128
-        othliab        37.745
+        medmal         35.130
+        othliab        37.746
         ppauto         10.023
-        prodliab       64.352
+        prodliab       64.347
         wkcomp         20.111
 
     """

--- a/chainladder/development/clark.py
+++ b/chainladder/development/clark.py
@@ -134,8 +134,8 @@ class ClarkLDF(DevelopmentBase):
         clrd = cl.load_sample("clrd")[["CumPaidLoss"]]
         print(len(clrd.index))
         m = cl.ClarkLDF(groupby="LOB").fit(clrd)
-        print(m.omega_.round(3))
-        print(m.theta_.round(3))
+        print(m.omega_.round(2))
+        print(m.theta_.round(2))
 
     .. testoutput::
         :options: +NORMALIZE_WHITESPACE
@@ -143,20 +143,20 @@ class ClarkLDF(DevelopmentBase):
         775
                   CumPaidLoss
         LOB                  
-        comauto         1.082
-        medmal          1.889
-        othliab         1.468
-        ppauto          1.149
-        prodliab        1.441
-        wkcomp          1.107
+        comauto         1.08
+        medmal          1.89
+        othliab         1.47
+        ppauto          1.15
+        prodliab        1.44
+        wkcomp          1.11
                   CumPaidLoss
         LOB                  
-        comauto        20.481
-        medmal         35.130
-        othliab        37.746
-        ppauto         10.023
-        prodliab       64.347
-        wkcomp         20.111
+        comauto        20.48
+        medmal         35.13
+        othliab        37.75
+        ppauto         10.02
+        prodliab       64.35
+        wkcomp         20.11
 
     """
 

--- a/chainladder/methods/benktander.py
+++ b/chainladder/methods/benktander.py
@@ -218,6 +218,7 @@ class Benktander(MethodBase):
         current Triangle and a refreshed apriori.
 
         .. testsetup::
+        
             import chainladder as cl
 
         .. testcode::

--- a/chainladder/methods/benktander.py
+++ b/chainladder/methods/benktander.py
@@ -52,9 +52,7 @@ class Benktander(MethodBase):
     .. testcode::
 
         xyz = cl.load_sample("xyz")
-
-        ibnr = cl.Benktander().fit(X=xyz["Paid"], sample_weight=xyz["Premium"].latest_diagonal).ibnr_
-        print(ibnr)
+        cl.Benktander().fit(X=xyz["Paid"], sample_weight=xyz["Premium"].latest_diagonal).ibnr_
 
     .. testoutput::
 
@@ -76,7 +74,6 @@ class Benktander(MethodBase):
     .. testcode::
 
         xyz = cl.load_sample("xyz")
-
         bk_ibnr = (
             cl.Benktander(n_iters=1)
             .fit(X=xyz["Paid"], sample_weight=xyz["Premium"].latest_diagonal)
@@ -87,7 +84,7 @@ class Benktander(MethodBase):
             .fit(X=xyz["Paid"], sample_weight=xyz["Premium"].latest_diagonal)
             .ibnr_
         )
-        print(bk_ibnr - bf_ibnr)
+        bk_ibnr - bf_ibnr
 
     .. testoutput::
 
@@ -109,10 +106,9 @@ class Benktander(MethodBase):
     .. testcode::
 
         xyz = cl.load_sample("xyz")
-
         bk_ibnr = cl.Benktander(n_iters=1000).fit(X=xyz["Paid"], sample_weight=xyz["Premium"].latest_diagonal).ibnr_
         cl_ibnr = cl.Chainladder().fit(xyz["Paid"]).ibnr_
-        print(bk_ibnr - cl_ibnr)
+        bk_ibnr - cl_ibnr
 
     .. testoutput::
 
@@ -165,13 +161,11 @@ class Benktander(MethodBase):
         .. testcode::
 
             xyz = cl.load_sample("xyz")
-
-            ultimate = (
+            (
                 cl.Benktander(apriori=1, n_iters=2)
                 .fit(X=xyz["Paid"], sample_weight=xyz["Premium"].latest_diagonal)
                 .ultimate_
             )
-            print(ultimate)
 
         .. testoutput::
 
@@ -230,8 +224,7 @@ class Benktander(MethodBase):
             model = cl.Benktander(apriori=1.0, n_iters=2).fit(
                 tr_prior, sample_weight=apriori_prior
             )
-
-            print(model.predict(tr, sample_weight=apriori).ultimate_)
+            model.predict(tr, sample_weight=apriori).ultimate_
 
         .. testoutput::
 

--- a/chainladder/methods/benktander.py
+++ b/chainladder/methods/benktander.py
@@ -52,7 +52,8 @@ class Benktander(MethodBase):
     .. testcode::
 
         xyz = cl.load_sample("xyz")
-        cl.Benktander().fit(X=xyz["Paid"], sample_weight=xyz["Premium"].latest_diagonal).ibnr_
+        ibnr = cl.Benktander().fit(X=xyz["Paid"], sample_weight=xyz["Premium"].latest_diagonal).ibnr_
+        print(ibnr)
 
     .. testoutput::
 
@@ -84,7 +85,7 @@ class Benktander(MethodBase):
             .fit(X=xyz["Paid"], sample_weight=xyz["Premium"].latest_diagonal)
             .ibnr_
         )
-        bk_ibnr - bf_ibnr
+        print(bk_ibnr - bf_ibnr)
 
     .. testoutput::
 
@@ -108,7 +109,7 @@ class Benktander(MethodBase):
         xyz = cl.load_sample("xyz")
         bk_ibnr = cl.Benktander(n_iters=1000).fit(X=xyz["Paid"], sample_weight=xyz["Premium"].latest_diagonal).ibnr_
         cl_ibnr = cl.Chainladder().fit(xyz["Paid"]).ibnr_
-        bk_ibnr - cl_ibnr
+        print(bk_ibnr - cl_ibnr)
 
     .. testoutput::
 
@@ -161,11 +162,12 @@ class Benktander(MethodBase):
         .. testcode::
 
             xyz = cl.load_sample("xyz")
-            (
+            ultimate = (
                 cl.Benktander(apriori=1, n_iters=2)
                 .fit(X=xyz["Paid"], sample_weight=xyz["Premium"].latest_diagonal)
                 .ultimate_
             )
+            print(ultimate)
 
         .. testoutput::
 
@@ -224,7 +226,8 @@ class Benktander(MethodBase):
             model = cl.Benktander(apriori=1.0, n_iters=2).fit(
                 tr_prior, sample_weight=apriori_prior
             )
-            model.predict(tr, sample_weight=apriori).ultimate_
+            ultimate = model.predict(tr, sample_weight=apriori).ultimate_
+            print(ultimate)
 
         .. testoutput::
 

--- a/chainladder/methods/bornferg.py
+++ b/chainladder/methods/bornferg.py
@@ -53,9 +53,7 @@ class BornhuetterFerguson(Benktander):
 
         raa = cl.load_sample("raa")
         premium = raa.latest_diagonal * 0 + 40_000  # zero out and add 40,000 to each origin
-
-        ibnr = cl.BornhuetterFerguson(apriori=0.7).fit(X=raa, sample_weight=premium).ibnr_
-        print(ibnr)
+        cl.BornhuetterFerguson(apriori=0.7).fit(X=raa, sample_weight=premium).ibnr_
 
     .. testoutput::
 
@@ -77,9 +75,7 @@ class BornhuetterFerguson(Benktander):
 
         raa = cl.load_sample("raa")
         premium = raa.latest_diagonal * 0 + 40_000 * 0.7  # premium is modified by 70%
-
-        ibnr = cl.BornhuetterFerguson().fit(X=raa, sample_weight=premium).ibnr_
-        print(ibnr)
+        cl.BornhuetterFerguson().fit(X=raa, sample_weight=premium).ibnr_
 
     .. testoutput::
 
@@ -130,7 +126,7 @@ class BornhuetterFerguson(Benktander):
 
             tr = cl.load_sample('ukmotor')
             apriori = cl.Chainladder().fit(tr).ultimate_ * 0 + 14000
-            print(cl.BornhuetterFerguson(apriori=1.0).fit(tr, sample_weight=apriori))
+            cl.BornhuetterFerguson(apriori=1.0).fit(tr, sample_weight=apriori)
 
         .. testoutput::
 
@@ -173,8 +169,7 @@ class BornhuetterFerguson(Benktander):
             model = cl.BornhuetterFerguson(apriori=1.0).fit(
                 tr_prior, sample_weight=apriori_prior
             )
-
-            print(model.predict(tr, sample_weight=apriori).ultimate_)
+            model.predict(tr, sample_weight=apriori).ultimate_
 
         .. testoutput::
 

--- a/chainladder/methods/bornferg.py
+++ b/chainladder/methods/bornferg.py
@@ -123,6 +123,7 @@ class BornhuetterFerguson(Benktander):
         Fit returns the estimator itself, with ``ultimate_`` populated.
 
         .. testsetup::
+        
             import chainladder as cl
 
         .. testcode::
@@ -160,6 +161,7 @@ class BornhuetterFerguson(Benktander):
         current Triangle and a refreshed apriori.
 
         .. testsetup::
+        
             import chainladder as cl
 
         .. testcode::

--- a/chainladder/methods/bornferg.py
+++ b/chainladder/methods/bornferg.py
@@ -53,7 +53,8 @@ class BornhuetterFerguson(Benktander):
 
         raa = cl.load_sample("raa")
         premium = raa.latest_diagonal * 0 + 40_000  # zero out and add 40,000 to each origin
-        cl.BornhuetterFerguson(apriori=0.7).fit(X=raa, sample_weight=premium).ibnr_
+        ibnr = cl.BornhuetterFerguson(apriori=0.7).fit(X=raa, sample_weight=premium).ibnr_
+        print(ibnr)
 
     .. testoutput::
 
@@ -75,7 +76,8 @@ class BornhuetterFerguson(Benktander):
 
         raa = cl.load_sample("raa")
         premium = raa.latest_diagonal * 0 + 40_000 * 0.7  # premium is modified by 70%
-        cl.BornhuetterFerguson().fit(X=raa, sample_weight=premium).ibnr_
+        ibnr = cl.BornhuetterFerguson().fit(X=raa, sample_weight=premium).ibnr_
+        print(ibnr)
 
     .. testoutput::
 
@@ -126,7 +128,8 @@ class BornhuetterFerguson(Benktander):
 
             tr = cl.load_sample('ukmotor')
             apriori = cl.Chainladder().fit(tr).ultimate_ * 0 + 14000
-            cl.BornhuetterFerguson(apriori=1.0).fit(tr, sample_weight=apriori)
+            model = cl.BornhuetterFerguson(apriori=1.0).fit(tr, sample_weight=apriori)
+            print(model)
 
         .. testoutput::
 
@@ -169,7 +172,8 @@ class BornhuetterFerguson(Benktander):
             model = cl.BornhuetterFerguson(apriori=1.0).fit(
                 tr_prior, sample_weight=apriori_prior
             )
-            model.predict(tr, sample_weight=apriori).ultimate_
+            ultimate = model.predict(tr, sample_weight=apriori).ultimate_
+            print(ultimate)
 
         .. testoutput::
 

--- a/chainladder/methods/bornferg.py
+++ b/chainladder/methods/bornferg.py
@@ -176,7 +176,7 @@ class BornhuetterFerguson(Benktander):
 
             print(model.predict(tr, sample_weight=apriori).ultimate_)
 
-        .. testoutput
+        .. testoutput::
 
                           2261
             2007  12690.000000

--- a/chainladder/methods/capecod.py
+++ b/chainladder/methods/capecod.py
@@ -218,7 +218,7 @@ class CapeCod(Benktander):
             exposure = cl.Chainladder().fit(tr).ultimate_ * 0 + 20000
             print(cl.CapeCod(trend=0.05).fit(tr, sample_weight=exposure))
 
-        .. testoutput:
+        .. testoutput::
 
             CapeCod(trend=0.05)
         """

--- a/chainladder/methods/chainladder.py
+++ b/chainladder/methods/chainladder.py
@@ -124,6 +124,7 @@ class Chainladder(MethodBase):
         attribute access.
 
         .. testsetup::
+        
             import chainladder as cl
 
         .. testcode::

--- a/chainladder/methods/chainladder.py
+++ b/chainladder/methods/chainladder.py
@@ -130,7 +130,7 @@ class Chainladder(MethodBase):
         .. testcode::
 
             tr = cl.load_sample('ukmotor')
-            cl.Chainladder().fit(tr)
+            print(cl.Chainladder().fit(tr))
 
         .. testoutput::
 


### PR DESCRIPTION
## Summary of Changes  
Fixing previously un-executed failing doctests

## Related GitHub Issue(s)  
#1089 

## Additional Context for Reviewers  
the doctest setup itself is not modified in this PR, only the doctests themselves. the same changes are also pushed to #1091, and passes actual execution

- [X] I passed tests locally for both code (`uv run pytest`) and documentation changes (`uv run jb build docs --builder=custom --custom-builder=doctest`)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only edits to doctest blocks; no application logic or public API behavior changes.
> 
> **Overview**
> Updates **docstring doctests** so they match actual output when executed via the docs doctest builder (#1089). No runtime or test-setup logic changes.
> 
> **`Common.pipe`** — adds the missing expected triangle printout for the `loc[..., 48:]` example.
> 
> **`ClarkLDF`** — switches `omega_` / `theta_` rounding from 3 to 2 decimals and refreshes the expected grouped `LOB` table layout.
> 
> **IBNR methods** (`Benktander`, `BornhuetterFerguson`, `Chainladder`, `CapeCod`) — small doctest hygiene: remove stray blank lines in `testcode`, assign intermediates before `print` where needed, and fix Sphinx directives (`.. testoutput::` instead of `.. testoutput:`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a568e33ca004a744156c802850841813cfe5afd9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->