### PR TITLE
Loc setter

### DIFF
--- a/chainladder/core/slice.py
+++ b/chainladder/core/slice.py
@@ -367,7 +367,7 @@ class Location(_LocBase):
         # Case scalar, locate position in first level of index.
         else:
             idx = np.where(self.obj.kdims[:, 0]==key)[0]
-        return _LocBase._contig_slice(idx)
+        return idx
 
     def other_key(
             self,
@@ -402,7 +402,7 @@ class Location(_LocBase):
         if type(key) in [slice, list]:
             return obj_idx.loc[key].values
         if not hasattr(key, '__iter__') or type(key) is str:
-            return _LocBase._contig_slice(np.array([obj_idx.loc[key]]))
+            return np.array([obj_idx.loc[key]])
         else:
             raise AttributeError("Unable to slice.")
 
@@ -431,7 +431,9 @@ class Location(_LocBase):
         return out
 
     def __setitem__(self, key: _LabelKey, values: int | float | TriangleSlicer) -> None:
-        super().__setitem__(cast(tuple[_AxisKey, _AxisKey, _AxisKey, _AxisKey], self.key_to_slice(key)), values)
+        raw_slice = self.key_to_slice(key)
+        contig_slice = [_LocBase._contig_slice(x) for x in raw_slice]
+        super().__setitem__(cast(tuple[_AxisKey, _AxisKey, _AxisKey, _AxisKey], contig_slice), values)
 
 class Ilocation(_LocBase):
     """

--- a/chainladder/core/slice.py
+++ b/chainladder/core/slice.py
@@ -367,7 +367,7 @@ class Location(_LocBase):
         # Case scalar, locate position in first level of index.
         else:
             idx = np.where(self.obj.kdims[:, 0]==key)[0]
-        return idx
+        return _LocBase._contig_slice(idx)
 
     def other_key(
             self,
@@ -402,7 +402,7 @@ class Location(_LocBase):
         if type(key) in [slice, list]:
             return obj_idx.loc[key].values
         if not hasattr(key, '__iter__') or type(key) is str:
-            return np.array([obj_idx.loc[key]])
+            return _LocBase._contig_slice(np.array([obj_idx.loc[key]]))
         else:
             raise AttributeError("Unable to slice.")
 

--- a/chainladder/core/tests/test_slicing.py
+++ b/chainladder/core/tests/test_slicing.py
@@ -273,7 +273,29 @@ def test_loc_setitem_triangle_value(clrd: Triangle) -> None:
         tri.loc["Aegis Grp", "comauto"] = sub * 2
         assert tri.loc["Aegis Grp", "comauto"] == sub * 2
 
+def test_loc_setitem_partial_triangles(raa: Triangle) -> None:
+    """
+    Use Triangle.loc to set a few origin or develop period via a TriangleSlicer.
 
+    Parameters
+    ----------
+    raa: Triangle
+        The raa sample data set fixture.
+
+    Returns
+    -------
+    None
+
+    """
+    raa2 = raa * 2
+    raa_new = raa.copy()
+    raa_new.loc[:,:,:,:60] = raa2.loc[:,:,:,:60]
+    raa_new.loc[:,:,:,72:] = raa2.loc[:,:,:,72:]
+    assert raa_new == raa2
+    raa_new = raa.copy()
+    raa_new.loc[:,:,:'1984',:] = raa2.loc[:,:,:'1984',:]
+    raa_new.loc[:,:,'1985':,:] = raa2.loc[:,:,'1985':,:]
+    assert raa_new == raa2
 
 def test_invalid_iloc_sparse_assignment(prism) -> None:
     """


### PR DESCRIPTION
## Summary of Changes  


## Related GitHub Issue(s)  


## Additional Context for Reviewers  


- [ ] I passed tests locally for both code (`uv run pytest`) and documentation changes (`uv run jb build docs --builder=custom --custom-builder=doctest`)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to numpy-backend `.loc` assignment only; behavior aligns with existing read-path slicing and is covered by new tests.
> 
> **Overview**
> **`Triangle.loc[...] =` now normalizes label-based keys through `_contig_slice` before writing**, matching how `.loc` reads already build slices in `get_idx`.
> 
> That fixes assigning a **partial `Triangle`** (or `TriangleSlicer`) along **origin** or **development**—for example development cutoffs like `:60` / `72:` or origin ranges like `:'1984'` / `'1985':`—which previously could fail or mis-assign when `key_to_slice` produced integer index arrays instead of proper slices.
> 
> New tests in `test_slicing.py` assert two multi-step partial assignments reproduce a fully doubled triangle.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1187a52f705e95e04d9ef626a61c0b0cc6a430bf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->