### PR TITLE
adding test

### DIFF
--- a/chainladder/adjustments/tests/test_disposal.py
+++ b/chainladder/adjustments/tests/test_disposal.py
@@ -60,6 +60,26 @@ def test_no_disposal_exception(raa:Triangle) -> None:
     with pytest.raises(AttributeError):
         _ = raa.incr_disposal_rate_
 
+def test_full_disposal_rate_tri(clrd) -> None:
+    '''
+    tests disposal rate for full triangle
+    '''
+    total = clrd.sum()
+    est = cl.Chainladder().fit(total['CumPaidLoss'])
+    ult = est.ultimate_
+    full_tri = est.full_triangle_
+    full_tri.ultimate_ = ult
+    assert full_tri.disposal_rate_tri.iat[-1,-1,-1,-1] == 1.
+
+def test_weighted_disposal_rate_tri(clrd) -> None:
+    '''
+    tests disposal rate triangle when there are weights
+    '''
+    total = clrd.sum()
+    ult = cl.Chainladder().fit(total['CumPaidLoss']).ultimate_
+    dr = cl.DisposalRate(n_periods = 4).fit_transform(total['CumPaidLoss'],sample_weight = ult)
+    assert np.all(np.isnan(dr.disposal_rate_tri.values[:,:,0:6,0:1]))
+
 def test_cl_parity(raa:Triangle) -> None:
     """
     A no-tail, full-triangle, volume-weighted Chainladder estimator coincides with the disposal rate adjustment. 

--- a/chainladder/core/triangle.py
+++ b/chainladder/core/triangle.py
@@ -1159,41 +1159,13 @@ class Triangle(TriangleBase):
 
         Triangle
             Triangle of disposal rates
-
-        Examples
-        --------
-
-        .. testsetup::
-
-            import chainladder as cl
-
-        .. testcode::
-
-            clrd = cl.load_sample('clrd').sum()
-            ult = cl.Chainladder().fit(clrd['IncurLoss']).ultimate_
-            dr = cl.DisposalRate().fit_transform(clrd['CumPaidLoss'],sample_weight = ult)
-            dr.disposal_rate_tri
-
-        .. testoutput::
-            
-                    12-Ult    24-Ult    36-Ult    48-Ult    60-Ult    72-Ult    84-Ult    96-Ult   108-Ult   120-Ult
-            1988       NaN       NaN       NaN       NaN       NaN       NaN  0.964643  0.973184  0.980224  0.983063
-            1989       NaN       NaN       NaN       NaN       NaN  0.952533  0.967690  0.977373  0.981938       NaN
-            1990       NaN       NaN       NaN       NaN  0.927029  0.952951  0.968379  0.976049       NaN       NaN
-            1991       NaN       NaN       NaN  0.881010  0.929460  0.954694  0.968533       NaN       NaN       NaN
-            1992       NaN       NaN  0.801875  0.885976  0.932865  0.956495       NaN       NaN       NaN       NaN
-            1993       NaN  0.663303  0.810639  0.894414  0.939009       NaN       NaN       NaN       NaN       NaN
-            1994  0.367530  0.670460  0.814661  0.897244       NaN       NaN       NaN       NaN       NaN       NaN
-            1995  0.379650  0.680979  0.821603       NaN       NaN       NaN       NaN       NaN       NaN       NaN
-            1996  0.395603  0.688621       NaN       NaN       NaN       NaN       NaN       NaN       NaN       NaN
-            1997  0.393820       NaN       NaN       NaN       NaN       NaN       NaN       NaN       NaN       NaN
         """
 
         obj: Triangle = self.incr_to_cum() / self.ultimate_.values
         if not obj.is_full:
             obj = obj[obj.valuation <= obj.valuation_date]
         if hasattr(obj, "disposal_w_"):
-            obj = obj * obj.disposal_w_
+            obj = obj * obj.disposal_w_ if obj.shape == obj.disposal_w_.shape else obj
         obj.is_pattern = True
         obj.is_cumulative = True
         obj.is_disposal_rate = True


### PR DESCRIPTION
## Summary of Changes  


## Related GitHub Issue(s)  


## Additional Context for Reviewers  


- [ ] I passed tests locally for both code (`uv run pytest`) and documentation changes (`uv run jb build docs --builder=custom --custom-builder=doctest`)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small defensive change in disposal rate display logic plus tests; no auth or data-path changes.
> 
> **Overview**
> **`disposal_rate_tri`** now applies **`disposal_w_`** only when its shape matches the computed rate triangle, mirroring the **`link_ratio`** / **`w_`** guard so mismatched weights (e.g. full **`full_triangle_`** vs. fitted weights) do not break broadcasting.
> 
> The property docstring drops the long doctest example block; behavior is covered by new disposal tests: ultimate cell disposal rate is **1** on a chainladder **full_triangle_** with **`ultimate_`**, and **`DisposalRate`** with **`sample_weight`** leaves the expected NaN pattern in masked development slices of **`disposal_rate_tri`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dc70c24bd1391258b11eabe9f1d90e8daafc0f93. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->