### PR TITLE
initial implementation of TriangleSelector

### DIFF
--- a/chainladder/__init__.py
+++ b/chainladder/__init__.py
@@ -508,6 +508,7 @@ from chainladder.workflow import (  # noqa (API import)
     GridSearch,
     Pipeline,
     VotingChainladder,
+    TriangleSelector,
 )
 
 __version__ = version("chainladder")

--- a/chainladder/tests/test_public_api.py
+++ b/chainladder/tests/test_public_api.py
@@ -75,6 +75,7 @@ EXPECTED_PUBLIC_API = {
     "GridSearch",
     "Pipeline",
     "VotingChainladder",
+    "TriangleSelector",
     # package-level objects
     "Options",
     "options",

--- a/chainladder/workflow/__init__.py
+++ b/chainladder/workflow/__init__.py
@@ -1,8 +1,10 @@
 from chainladder.workflow.gridsearch import GridSearch, Pipeline  # noqa (API import)
 from chainladder.workflow.voting import VotingChainladder  # noqa (API import)
+from chainladder.workflow.voting import TriangleSelector  # noqa (API import)
 
 __all__ = [
     "GridSearch",
     "Pipeline",
     "VotingChainladder",
+    "TriangleSelector"
 ]

--- a/chainladder/workflow/tests/test_voting.py
+++ b/chainladder/workflow/tests/test_voting.py
@@ -1,7 +1,13 @@
+from __future__ import annotations
+
 import numpy as np
 import chainladder as cl
 import pytest
 
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from chainladder import Triangle
 
 @pytest.fixture
 def triangle_data():
@@ -184,3 +190,35 @@ def test_voting(raa):
             21605.83,
         ]
     ).all()
+
+def test_tri_sel(clrd:Triangle) -> None:
+    '''
+    starter test for the TriangleSelector class
+    '''
+    tri = clrd.sum()
+    assert tri['CumPaidLoss'] == cl.TriangleSelector('CumPaidLoss').fit_transform(tri)
+
+def test_mismatching_tri_sel(clrd:Triangle) -> None:
+    '''
+    checking that an error is raised when different number of columns are specified by estimators in a VotingChainladder
+    '''
+    tri = clrd.groupby('LOB').sum().loc['othliab']
+    pipe_p = cl.Pipeline(
+        steps=[
+            ('tri_sel', cl.TriangleSelector('CumPaidLoss')),
+            ('dev', cl.Development()),
+            ('model', cl.Chainladder())
+        ]
+    )
+    pipe_i = cl.Pipeline(
+        steps=[
+            ('dev', cl.Development()),
+            ('model', cl.Chainladder())
+        ]
+    )
+
+    estimators = [('incurred', pipe_i), ('paid', pipe_p)]
+    weights = np.array([[0.5, 0.5]] * 4 + [[0.75, 0.25]] * 3 + [[1, 0]] * 3)
+    vot = cl.VotingChainladder(estimators=estimators, weights=weights)
+    with pytest.raises(ValueError):
+        vot.fit(tri)

--- a/chainladder/workflow/voting.py
+++ b/chainladder/workflow/voting.py
@@ -1,18 +1,31 @@
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
+from __future__ import annotations
+
 from abc import abstractmethod
 
 import numpy as np
 from chainladder.methods.base import MethodBase
 from joblib import Parallel, delayed
-from sklearn.base import clone
+from sklearn.base import (
+    BaseEstimator,
+    clone,
+    TransformerMixin
+)
 from sklearn.ensemble._base import _fit_single_estimator, _BaseHeterogeneousEnsemble
 from sklearn.ensemble._voting import _BaseVoting
 from sklearn.utils import Bunch
 from sklearn.utils.validation import _deprecate_positional_args, check_is_fitted
 
+from chainladder.core.io import EstimatorIO
+
 from ..core.base import is_chainladder
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from chainladder import Triangle
 
 
 class _BaseTriangleEnsemble(_BaseHeterogeneousEnsemble):
@@ -404,11 +417,91 @@ class VotingChainladder(_BaseChainladderVoting, MethodBase):
                     f" and {X.shape[1]} for X."
                 )
             weights = self.weights_
+        
+        ultimates = [est.predict(X, sample_weight).ultimate_ for est in self.estimators_]
 
+        shape_check = list(set([ult.shape for ult in ultimates]))
+        if len(shape_check) > 1:
+            raise ValueError(
+                "Estimators returning ultimate_ of different shapes,"
+                "likely due to a mis-specified TriangleSelector transformer in the pipeline"
+            )
+        #weights are broadcasted to the shape of X. However ultimate_ does not always take the shape of X
+        #use shape_check to redim weights 
         ultimate = sum(
             [
-                est.predict(X, sample_weight).ultimate_ * weights[..., i, :]
-                for i, est in enumerate(self.estimators_)
+                ultimates[i] * weights[...,:shape_check[0][1], :, i, :]
+                for i, _ in enumerate(ultimates)
             ]
-        ) / weights.sum(axis=-2)
+        ) / weights[...,:shape_check[0][1], :, :, :].sum(axis=-2)
         return ultimate
+
+class TriangleSelector(
+    BaseEstimator,
+    TransformerMixin,
+    EstimatorIO,
+):
+    """
+    A transformer to assist with creating VotingChainladder workflows that weights between Incured/Paid or Reported/Closed.
+
+    .. versionadded:: 0.10.0
+
+    Parameters
+    ----------
+    col: str
+        which `column` to perform the subsequent estiamtion on
+
+    Examples
+    --------
+    Actuaries commonly uses both incurred and paid losses, or both reported and closed counts for estimating ultimate loss or ultimate count. We can use this helper class to create a singular VotingChainladder pipeline that weighs between incurred/paid methods, or reported/closed methods.
+    
+    .. testsetup::
+
+        import chainladder as cl
+
+    .. testcode::
+
+        clrd = cl.load_sample('clrd').groupby('LOB').sum().loc['othliab']
+        pipe_p = cl.Pipeline(
+            steps=[
+                ('tri_sel', cl.TriangleSelector('CumPaidLoss')),
+                ('dev', cl.Development()),
+                ('model', cl.Chainladder())
+            ]
+        )
+        pipe_i = cl.Pipeline(
+            steps=[
+                ('tri_sel', cl.TriangleSelector('IncurLoss')),
+                ('dev', cl.Development()),
+                ('model', cl.Chainladder())
+            ]
+        )
+
+        estimators = [('incurred', pipe_i), ('paid', pipe_p)]
+        weights = np.array([[0.5, 0.5]] * 4 + [[0.75, 0.25]] * 3 + [[1, 0]] * 3)
+        vot = cl.VotingChainladder(estimators=estimators, weights=weights)
+        vot.fit(clrd)
+        print(vot.ultimate_)
+
+    .. testoutput::
+
+                    2261
+        1988  323181.000000
+        1989  361191.317646
+        1990  384630.467254
+        1991  468742.807511
+        1992  483699.548213
+        1993  557869.162336
+        1994  625042.216134
+        1995  599845.906651
+        1996  672721.951809
+        1997  664061.404455
+    """
+    def __init__(self, col:str):
+        self.col = col
+
+    def fit(self, X:Triangle, y:None=None):
+        return self
+
+    def transform(self, X:Triangle):
+        return X[[self.col]]


### PR DESCRIPTION
## Summary of Changes  


## Related GitHub Issue(s)  


## Additional Context for Reviewers  


- [ ] I passed tests locally for both code (`uv run pytest`) and documentation changes (`uv run jb build docs --builder=custom --custom-builder=doctest`)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how voting ultimates are weighted and aggregated; incorrect weight slicing could affect ensemble results when pipelines return different column counts, though existing same-shape paths should behave similarly.
> 
> **Overview**
> Adds **`TriangleSelector`**, a sklearn-style pipeline step that keeps a single triangle column (e.g. paid vs incurred) so **`VotingChainladder`** can blend estimators built on different columns from the same multi-column triangle. It is exported on **`chainladder`** and covered by public API tests.
> 
> **`VotingChainladder._get_ultimate`** now gathers each estimator’s **`ultimate_`**, raises **`ValueError`** when shapes disagree (with a hint about misconfigured **`TriangleSelector`**), and slices the weight tensor to the ultimate’s column size instead of assuming it matches the full input **`X`** shape.
> 
> New voting tests cover **`TriangleSelector.fit_transform`** and the mismatch case when one pipeline selects a column and another does not.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4892df93bbeaddc80c4b3f7b82635486d5a6726d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->