### PR TITLE
#588 chapter8

### DIFF
--- a/docs/friedland/chapter_8.ipynb
+++ b/docs/friedland/chapter_8.ipynb
@@ -115,7 +115,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 113,
+      "execution_count": null,
       "id": "ca66fbf5",
       "metadata": {},
       "outputs": [],
@@ -412,7 +412,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 119,
+      "execution_count": null,
       "id": "8c8a4958",
       "metadata": {},
       "outputs": [
@@ -607,7 +607,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 123,
+      "execution_count": null,
       "id": "f204158f",
       "metadata": {},
       "outputs": [
@@ -1404,7 +1404,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 137,
+      "execution_count": null,
       "id": "23c0b4f8",
       "metadata": {},
       "outputs": [
@@ -1597,7 +1597,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 142,
+      "execution_count": null,
       "id": "52f366f0",
       "metadata": {},
       "outputs": [],
@@ -1912,7 +1912,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 148,
+      "execution_count": null,
       "id": "0177483d",
       "metadata": {},
       "outputs": [
@@ -2445,7 +2445,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 158,
+      "execution_count": null,
       "id": "1395fc4a",
       "metadata": {},
       "outputs": [],
@@ -2794,7 +2794,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 165,
+      "execution_count": null,
       "id": "8a9dfaf7",
       "metadata": {},
       "outputs": [
@@ -2809,8 +2809,12 @@
       ],
       "source": [
         "# Page 144, Exhibit III Sheet 1, column 11\n",
-        "# 1998 - 2003, based on average of estimated claim ratios in (10) for these years \n",
         "print(np.round((selected_ultimate / earned_premium).iloc[:,:,0:6,:].mean(), 3))\n",
+        "assert np.isclose(\n",
+        "    np.round((selected_ultimate / earned_premium).iloc[:,:,0:6,:].mean(), 3),\n",
+        "    0.783,\n",
+        "    rtol=1e-3,\n",
+        ")\n",
         "\n",
         "selected_claim_ratio = [\n",
         "    0.783,\n",
@@ -2824,6 +2828,19 @@
         "    0.658, # calculation shown in Exhibit III Sheet 2\n",
         "    0.638, # calculation shown in Exhibit III Sheet 2\n",
         "    0.825, # calculation shown in Exhibit III Sheet 2\n",
+        "]\n",
+        "assert selected_claim_ratio == [\n",
+        "    0.783,\n",
+        "    0.783,\n",
+        "    0.783,\n",
+        "    0.783,\n",
+        "    0.783,\n",
+        "    0.783,\n",
+        "    0.871,\n",
+        "    0.783,\n",
+        "    0.658,\n",
+        "    0.638,\n",
+        "    0.825,\n",
         "]\n",
         "print(selected_claim_ratio)\n"
       ]
@@ -3072,7 +3089,22 @@
         "    },\n",
         "    index=origins,\n",
         ")\n",
-        "np.round(severity_trend_adjustment, 3)\n"
+        "print(np.round(severity_trend_adjustment, 3))\n",
+        "assert np.allclose(\n",
+        "    np.round(severity_trend_adjustment, 3).values,\n",
+        "    np.array(\n",
+        "        [\n",
+        "            [1.070, 1.106, 1.144, 1.183, 1.224],\n",
+        "            [1.034, 1.070, 1.106, 1.144, 1.183],\n",
+        "            [1.000, 1.034, 1.070, 1.106, 1.144],\n",
+        "            [0.967, 1.000, 1.034, 1.070, 1.106],\n",
+        "            [0.935, 0.967, 1.000, 1.034, 1.070],\n",
+        "            [0.904, 0.935, 0.967, 1.000, 1.034],\n",
+        "            [0.874, 0.904, 0.935, 0.967, 1.000],\n",
+        "        ]\n",
+        "    ),\n",
+        "    rtol=1e-3,\n",
+        ")\n"
       ]
     },
     {
@@ -3204,7 +3236,22 @@
         "    },\n",
         "    index=origins,\n",
         ")\n",
-        "np.round(tort_reform_adjustment, 3)\n"
+        "print(np.round(tort_reform_adjustment, 3))\n",
+        "assert np.allclose(\n",
+        "    np.round(tort_reform_adjustment, 3).values,\n",
+        "    np.array(\n",
+        "        [\n",
+        "            [1.000, 1.000, 0.893, 0.67, 0.67],\n",
+        "            [1.000, 1.000, 0.893, 0.67, 0.67],\n",
+        "            [1.000, 1.000, 0.893, 0.67, 0.67],\n",
+        "            [1.000, 1.000, 0.893, 0.67, 0.67],\n",
+        "            [1.119, 1.119, 1.000, 0.75, 0.75],\n",
+        "            [1.493, 1.493, 1.333, 1.00, 1.00],\n",
+        "            [1.493, 1.493, 1.333, 1.00, 1.00],\n",
+        "        ]\n",
+        "    ),\n",
+        "    rtol=1e-3,\n",
+        ")\n"
       ]
     },
     {
@@ -3274,7 +3321,27 @@
       "source": [
         "# Page 145, Exhibit III Sheet 2, column 13\n",
         "earned_premium_view = earned_premium.iloc[:, :, 4:, :]\n",
-        "earned_premium_view\n"
+        "print(earned_premium_view)\n",
+        "assert np.allclose(\n",
+        "    earned_premium_view.values,\n",
+        "    np.array(\n",
+        "        [\n",
+        "            [\n",
+        "                [\n",
+        "                    [61183],\n",
+        "                    [69175],\n",
+        "                    [99322],\n",
+        "                    [138151],\n",
+        "                    [107578],\n",
+        "                    [62438],\n",
+        "                    [47797],\n",
+        "                ]\n",
+        "            ]\n",
+        "        ]\n",
+        "    ),\n",
+        "    rtol=1e-6,\n",
+        "    equal_nan=True,\n",
+        ")\n"
       ]
     },
     {
@@ -3404,7 +3471,22 @@
         "    },\n",
         "    index=origins,\n",
         ")\n",
-        "np.round(rate_level_adjustment, 3)\n"
+        "print(np.round(rate_level_adjustment, 3))\n",
+        "assert np.allclose(\n",
+        "    np.round(rate_level_adjustment, 3).values,\n",
+        "    np.array(\n",
+        "        [\n",
+        "            [1.129, 1.298, 1.428, 1.142, 0.914],\n",
+        "            [1.075, 1.236, 1.360, 1.088, 0.870],\n",
+        "            [1.000, 1.150, 1.265, 1.012, 0.810],\n",
+        "            [0.870, 1.000, 1.100, 0.880, 0.704],\n",
+        "            [0.791, 0.909, 1.000, 0.800, 0.640],\n",
+        "            [0.988, 1.136, 1.250, 1.000, 0.800],\n",
+        "            [1.235, 1.420, 1.562, 1.250, 1.000],\n",
+        "        ]\n",
+        "    ),\n",
+        "    rtol=1e-3,\n",
+        ")\n"
       ]
     },
     {
@@ -3534,7 +3616,22 @@
         "    },\n",
         "    index=list(range(2002, 2009)),\n",
         ")\n",
-        "np.round(adjusted_claim_ratios, 3)\n"
+        "print(np.round(adjusted_claim_ratios, 3))\n",
+        "assert np.allclose(\n",
+        "    np.round(adjusted_claim_ratios, 3).values,\n",
+        "    np.array(\n",
+        "        [\n",
+        "            [0.758, 0.682, 0.573, 0.555, 0.718],\n",
+        "            [0.659, 0.593, 0.498, 0.483, 0.624],\n",
+        "            [0.782, 0.703, 0.591, 0.573, 0.740],\n",
+        "            [0.632, 0.568, 0.477, 0.463, 0.598],\n",
+        "            [0.803, 0.722, 0.606, 0.588, 0.760],\n",
+        "            [1.377, 1.238, 1.040, 1.008, 1.304],\n",
+        "            [1.354, 1.217, 1.022, 0.991, 1.282],\n",
+        "        ]\n",
+        "    ),\n",
+        "    rtol=1e-3,\n",
+        ")\n"
       ]
     },
     {
@@ -3631,7 +3728,19 @@
         "        \"Latest 3 Years\": adjusted_claim_ratios.loc[2006:].mean(),\n",
         "    }\n",
         ").T\n",
-        "np.round(average_claim_ratios, 3)\n"
+        "print(np.round(average_claim_ratios, 3))\n",
+        "assert np.allclose(\n",
+        "    np.round(average_claim_ratios, 3).values,\n",
+        "    np.array(\n",
+        "        [\n",
+        "            [0.909, 0.818, 0.687, 0.666, 0.861],\n",
+        "            [0.871, 0.783, 0.658, 0.638, 0.825],\n",
+        "            [0.989, 0.890, 0.747, 0.725, 0.937],\n",
+        "            [1.178, 1.059, 0.890, 0.863, 1.115],\n",
+        "        ]\n",
+        "    ),\n",
+        "    rtol=1e-3,\n",
+        ")\n"
       ]
     },
     {
@@ -3659,7 +3768,12 @@
       "source": [
         "# Page 145, Exhibit III Sheet 2, item 25\n",
         "selected_expected_claim_ratio = (adjusted_claim_ratios.sum() - adjusted_claim_ratios.max() - adjusted_claim_ratios.min())/5\n",
-        "np.round(selected_expected_claim_ratio, 3)"
+        "print(np.round(selected_expected_claim_ratio, 3))\n",
+        "assert np.allclose(\n",
+        "    np.round(selected_expected_claim_ratio, 3).values,\n",
+        "    [0.871, 0.783, 0.658, 0.638, 0.825],\n",
+        "    rtol=1e-3,\n",
+        ")\n"
       ]
     },
     {
@@ -4629,6 +4743,7 @@
       "source": [
         "# Page 149, Exhibit IV Sheet 1, Steady-State, column 3\n",
         "selected_claim_ratio = 0.70\n",
+        "assert np.isclose(selected_claim_ratio, 0.70, rtol=1e-9)\n",
         "print(selected_claim_ratio)\n"
       ]
     },
@@ -5009,6 +5124,7 @@
       "source": [
         "# Page 149, Exhibit IV Sheet 1, Increasing Claim Ratios, column 3\n",
         "selected_claim_ratio = 0.70\n",
+        "assert np.isclose(selected_claim_ratio, 0.70, rtol=1e-9)\n",
         "print(selected_claim_ratio)\n"
       ]
     },
@@ -5376,7 +5492,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 205,
+      "execution_count": null,
       "id": "f89da050",
       "metadata": {},
       "outputs": [
@@ -5758,7 +5874,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 212,
+      "execution_count": null,
       "id": "743b1285",
       "metadata": {},
       "outputs": [
@@ -6079,25 +6195,26 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 218,
+      "execution_count": 228,
       "id": "9ad60cb9",
       "metadata": {},
       "outputs": [
         {
-          "ename": "KeyError",
-          "evalue": "\"['Earned Premium'] not in index\"",
-          "output_type": "error",
-          "traceback": [
-            "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
-            "\u001b[0;31mKeyError\u001b[0m                                  Traceback (most recent call last)",
-            "Cell \u001b[0;32mIn[218], line 2\u001b[0m\n\u001b[1;32m      1\u001b[0m \u001b[38;5;66;03m# Page 151, Exhibit V, Steady-State (No Change in Product Mix), columns 1-2\u001b[39;00m\n\u001b[0;32m----> 2\u001b[0m friedland_us_auto_steady_state \u001b[38;5;241m=\u001b[39m \u001b[43mcl\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mload_sample\u001b[49m\u001b[43m(\u001b[49m\u001b[38;5;124;43m\"\u001b[39;49m\u001b[38;5;124;43mfriedland_us_auto_steady_state\u001b[39;49m\u001b[38;5;124;43m\"\u001b[39;49m\u001b[43m)\u001b[49m\n\u001b[1;32m      3\u001b[0m earned_premium \u001b[38;5;241m=\u001b[39m friedland_us_auto_steady_state[\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mReported Claims\u001b[39m\u001b[38;5;124m\"\u001b[39m]\u001b[38;5;241m.\u001b[39mlatest_diagonal\u001b[38;5;241m.\u001b[39mcopy()\n\u001b[1;32m      4\u001b[0m earned_premium\u001b[38;5;241m.\u001b[39mvalues \u001b[38;5;241m=\u001b[39m np\u001b[38;5;241m.\u001b[39mround(\u001b[38;5;241m2000000\u001b[39m \u001b[38;5;241m*\u001b[39m (\u001b[38;5;241m1.05\u001b[39m \u001b[38;5;241m*\u001b[39m\u001b[38;5;241m*\u001b[39m np\u001b[38;5;241m.\u001b[39marange(\u001b[38;5;241m10\u001b[39m)), \u001b[38;5;241m0\u001b[39m)\u001b[38;5;241m.\u001b[39mreshape(\n\u001b[1;32m      5\u001b[0m     \u001b[38;5;241m1\u001b[39m, \u001b[38;5;241m1\u001b[39m, \u001b[38;5;241m-\u001b[39m\u001b[38;5;241m1\u001b[39m, \u001b[38;5;241m1\u001b[39m\n\u001b[1;32m      6\u001b[0m )\n",
-            "File \u001b[0;32m~/Documents/GitHub/chainladder-python/chainladder/utils/utility_functions.py:121\u001b[0m, in \u001b[0;36mload_sample\u001b[0;34m(key, *args, **kwargs)\u001b[0m\n\u001b[1;32m    117\u001b[0m development_format \u001b[38;5;241m=\u001b[39m config\u001b[38;5;241m.\u001b[39mget(\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mdevelopment_format\u001b[39m\u001b[38;5;124m\"\u001b[39m, \u001b[38;5;28;01mNone\u001b[39;00m)\n\u001b[1;32m    119\u001b[0m df \u001b[38;5;241m=\u001b[39m pd\u001b[38;5;241m.\u001b[39mread_csv(filepath_or_buffer\u001b[38;5;241m=\u001b[39mdataset_path)\n\u001b[0;32m--> 121\u001b[0m \u001b[38;5;28;01mreturn\u001b[39;00m \u001b[43mTriangle\u001b[49m\u001b[43m(\u001b[49m\n\u001b[1;32m    122\u001b[0m \u001b[43m    \u001b[49m\u001b[43mdata\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43mdf\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m    123\u001b[0m \u001b[43m    \u001b[49m\u001b[43morigin\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43morigin\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m    124\u001b[0m \u001b[43m    \u001b[49m\u001b[43mdevelopment\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43mdevelopment\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m    125\u001b[0m \u001b[43m    \u001b[49m\u001b[43mindex\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43mindex\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m    126\u001b[0m \u001b[43m    \u001b[49m\u001b[43mcolumns\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43mcolumns\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m    127\u001b[0m \u001b[43m    \u001b[49m\u001b[43mcumulative\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43mcumulative\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m    128\u001b[0m \u001b[43m    \u001b[49m\u001b[43mdevelopment_format\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43mdevelopment_format\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m    129\u001b[0m \u001b[43m    \u001b[49m\u001b[38;5;241;43m*\u001b[39;49m\u001b[43margs\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m    130\u001b[0m \u001b[43m    \u001b[49m\u001b[38;5;241;43m*\u001b[39;49m\u001b[38;5;241;43m*\u001b[39;49m\u001b[43mkwargs\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m    131\u001b[0m \u001b[43m\u001b[49m\u001b[43m)\u001b[49m\n",
-            "File \u001b[0;32m~/Documents/GitHub/chainladder-python/chainladder/core/triangle.py:376\u001b[0m, in \u001b[0;36mTriangle.__init__\u001b[0;34m(self, data, origin, development, columns, index, origin_format, development_format, cumulative, array_backend, pattern, trailing, *args, **kwargs)\u001b[0m\n\u001b[1;32m    374\u001b[0m \u001b[38;5;28;01melif\u001b[39;00m \u001b[38;5;129;01mnot\u001b[39;00m \u001b[38;5;28misinstance\u001b[39m(data, pd\u001b[38;5;241m.\u001b[39mDataFrame) \u001b[38;5;129;01mand\u001b[39;00m \u001b[38;5;28mhasattr\u001b[39m(data, \u001b[38;5;124m\"\u001b[39m\u001b[38;5;124m__dataframe__\u001b[39m\u001b[38;5;124m\"\u001b[39m):\n\u001b[1;32m    375\u001b[0m     data \u001b[38;5;241m=\u001b[39m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39m_interchange_dataframe(data)\n\u001b[0;32m--> 376\u001b[0m index, columns, origin, development \u001b[38;5;241m=\u001b[39m \u001b[38;5;28;43mself\u001b[39;49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43m_input_validation\u001b[49m\u001b[43m(\u001b[49m\n\u001b[1;32m    377\u001b[0m \u001b[43m    \u001b[49m\u001b[43mdata\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43mdata\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m    378\u001b[0m \u001b[43m    \u001b[49m\u001b[43mindex\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43mindex\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m    379\u001b[0m \u001b[43m    \u001b[49m\u001b[43mcolumns\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43mcolumns\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m    380\u001b[0m \u001b[43m    \u001b[49m\u001b[43morigin\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43morigin\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m    381\u001b[0m \u001b[43m    \u001b[49m\u001b[43mdevelopment\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43mdevelopment\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m    382\u001b[0m \u001b[43m\u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m    384\u001b[0m \u001b[38;5;66;03m# Store dimension metadata.\u001b[39;00m\n\u001b[1;32m    385\u001b[0m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39morigin_label: \u001b[38;5;28mlist\u001b[39m \u001b[38;5;241m=\u001b[39m origin\n",
-            "File \u001b[0;32m~/Documents/GitHub/chainladder-python/chainladder/core/base.py:109\u001b[0m, in \u001b[0;36mTriangleBase._input_validation\u001b[0;34m(data, index, columns, origin, development)\u001b[0m\n\u001b[1;32m    107\u001b[0m origin \u001b[38;5;241m=\u001b[39m str_to_list(origin)\n\u001b[1;32m    108\u001b[0m development \u001b[38;5;241m=\u001b[39m str_to_list(development)\n\u001b[0;32m--> 109\u001b[0m \u001b[38;5;28;01mif\u001b[39;00m \u001b[38;5;129;01mnot\u001b[39;00m \u001b[38;5;28mall\u001b[39m(pd\u001b[38;5;241m.\u001b[39mapi\u001b[38;5;241m.\u001b[39mtypes\u001b[38;5;241m.\u001b[39mis_numeric_dtype(dt) \u001b[38;5;28;01mfor\u001b[39;00m dt \u001b[38;5;129;01min\u001b[39;00m \u001b[43mdata\u001b[49m\u001b[43m[\u001b[49m\u001b[43mcolumns\u001b[49m\u001b[43m]\u001b[49m\u001b[38;5;241m.\u001b[39mdtypes):\n\u001b[1;32m    110\u001b[0m     \u001b[38;5;28;01mraise\u001b[39;00m \u001b[38;5;167;01mTypeError\u001b[39;00m(\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mcolumn attribute must be numeric.\u001b[39m\u001b[38;5;124m\"\u001b[39m)\n\u001b[1;32m    111\u001b[0m \u001b[38;5;28;01mif\u001b[39;00m data[columns]\u001b[38;5;241m.\u001b[39mshape[\u001b[38;5;241m1\u001b[39m] \u001b[38;5;241m!=\u001b[39m \u001b[38;5;28mlen\u001b[39m(columns):\n",
-            "File \u001b[0;32m/Library/Frameworks/Python.framework/Versions/3.10/lib/python3.10/site-packages/pandas/core/frame.py:4119\u001b[0m, in \u001b[0;36mDataFrame.__getitem__\u001b[0;34m(self, key)\u001b[0m\n\u001b[1;32m   4117\u001b[0m     \u001b[38;5;28;01mif\u001b[39;00m is_iterator(key):\n\u001b[1;32m   4118\u001b[0m         key \u001b[38;5;241m=\u001b[39m \u001b[38;5;28mlist\u001b[39m(key)\n\u001b[0;32m-> 4119\u001b[0m     indexer \u001b[38;5;241m=\u001b[39m \u001b[38;5;28;43mself\u001b[39;49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mcolumns\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43m_get_indexer_strict\u001b[49m\u001b[43m(\u001b[49m\u001b[43mkey\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[38;5;124;43m\"\u001b[39;49m\u001b[38;5;124;43mcolumns\u001b[39;49m\u001b[38;5;124;43m\"\u001b[39;49m\u001b[43m)\u001b[49m[\u001b[38;5;241m1\u001b[39m]\n\u001b[1;32m   4121\u001b[0m \u001b[38;5;66;03m# take() does not accept boolean indexers\u001b[39;00m\n\u001b[1;32m   4122\u001b[0m \u001b[38;5;28;01mif\u001b[39;00m \u001b[38;5;28mgetattr\u001b[39m(indexer, \u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mdtype\u001b[39m\u001b[38;5;124m\"\u001b[39m, \u001b[38;5;28;01mNone\u001b[39;00m) \u001b[38;5;241m==\u001b[39m \u001b[38;5;28mbool\u001b[39m:\n",
-            "File \u001b[0;32m/Library/Frameworks/Python.framework/Versions/3.10/lib/python3.10/site-packages/pandas/core/indexes/base.py:6212\u001b[0m, in \u001b[0;36mIndex._get_indexer_strict\u001b[0;34m(self, key, axis_name)\u001b[0m\n\u001b[1;32m   6209\u001b[0m \u001b[38;5;28;01melse\u001b[39;00m:\n\u001b[1;32m   6210\u001b[0m     keyarr, indexer, new_indexer \u001b[38;5;241m=\u001b[39m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39m_reindex_non_unique(keyarr)\n\u001b[0;32m-> 6212\u001b[0m \u001b[38;5;28;43mself\u001b[39;49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43m_raise_if_missing\u001b[49m\u001b[43m(\u001b[49m\u001b[43mkeyarr\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mindexer\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43maxis_name\u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m   6214\u001b[0m keyarr \u001b[38;5;241m=\u001b[39m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mtake(indexer)\n\u001b[1;32m   6215\u001b[0m \u001b[38;5;28;01mif\u001b[39;00m \u001b[38;5;28misinstance\u001b[39m(key, Index):\n\u001b[1;32m   6216\u001b[0m     \u001b[38;5;66;03m# GH 42790 - Preserve name from an Index\u001b[39;00m\n",
-            "File \u001b[0;32m/Library/Frameworks/Python.framework/Versions/3.10/lib/python3.10/site-packages/pandas/core/indexes/base.py:6264\u001b[0m, in \u001b[0;36mIndex._raise_if_missing\u001b[0;34m(self, key, indexer, axis_name)\u001b[0m\n\u001b[1;32m   6261\u001b[0m     \u001b[38;5;28;01mraise\u001b[39;00m \u001b[38;5;167;01mKeyError\u001b[39;00m(\u001b[38;5;124mf\u001b[39m\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mNone of [\u001b[39m\u001b[38;5;132;01m{\u001b[39;00mkey\u001b[38;5;132;01m}\u001b[39;00m\u001b[38;5;124m] are in the [\u001b[39m\u001b[38;5;132;01m{\u001b[39;00maxis_name\u001b[38;5;132;01m}\u001b[39;00m\u001b[38;5;124m]\u001b[39m\u001b[38;5;124m\"\u001b[39m)\n\u001b[1;32m   6263\u001b[0m not_found \u001b[38;5;241m=\u001b[39m \u001b[38;5;28mlist\u001b[39m(ensure_index(key)[missing_mask\u001b[38;5;241m.\u001b[39mnonzero()[\u001b[38;5;241m0\u001b[39m]]\u001b[38;5;241m.\u001b[39munique())\n\u001b[0;32m-> 6264\u001b[0m \u001b[38;5;28;01mraise\u001b[39;00m \u001b[38;5;167;01mKeyError\u001b[39;00m(\u001b[38;5;124mf\u001b[39m\u001b[38;5;124m\"\u001b[39m\u001b[38;5;132;01m{\u001b[39;00mnot_found\u001b[38;5;132;01m}\u001b[39;00m\u001b[38;5;124m not in index\u001b[39m\u001b[38;5;124m\"\u001b[39m)\n",
-            "\u001b[0;31mKeyError\u001b[0m: \"['Earned Premium'] not in index\""
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "           2008\n",
+            "1999  2000000.0\n",
+            "2000  2100000.0\n",
+            "2001  2205000.0\n",
+            "2002  2315250.0\n",
+            "2003  2431013.0\n",
+            "2004  2552563.0\n",
+            "2005  2680191.0\n",
+            "2006  2814201.0\n",
+            "2007  2954911.0\n",
+            "2008  3102656.0\n",
+            "Total: 25155785.0\n"
           ]
         }
       ],
@@ -6515,7 +6632,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 220,
+      "execution_count": null,
       "id": "4619a419",
       "metadata": {},
       "outputs": [

--- a/docs/friedland/chapter_8.ipynb
+++ b/docs/friedland/chapter_8.ipynb
@@ -1,8 +1,16 @@
 {
   "cells": [
     {
+      "cell_type": "markdown",
+      "id": "12e842f8",
+      "metadata": {},
+      "source": [
+        "# Chapter 8 - Expected Claims Technique"
+      ]
+    },
+    {
       "cell_type": "code",
-      "execution_count": 110,
+      "execution_count": 1,
       "id": "9bf32865",
       "metadata": {},
       "outputs": [],
@@ -14,7 +22,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 111,
+      "execution_count": 2,
       "id": "f84de055",
       "metadata": {},
       "outputs": [
@@ -65,7 +73,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 112,
+      "execution_count": 3,
       "id": "f5519bd6",
       "metadata": {},
       "outputs": [
@@ -115,7 +123,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": null,
+      "execution_count": 4,
       "id": "ca66fbf5",
       "metadata": {},
       "outputs": [],
@@ -147,7 +155,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 114,
+      "execution_count": 5,
       "id": "c74260ee",
       "metadata": {},
       "outputs": [
@@ -201,7 +209,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 115,
+      "execution_count": 6,
       "id": "6f326152",
       "metadata": {},
       "outputs": [
@@ -255,7 +263,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 116,
+      "execution_count": 7,
       "id": "b69357ad",
       "metadata": {},
       "outputs": [
@@ -306,7 +314,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 117,
+      "execution_count": 8,
       "id": "500e2d80",
       "metadata": {},
       "outputs": [
@@ -356,7 +364,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 118,
+      "execution_count": 9,
       "id": "1073813f",
       "metadata": {},
       "outputs": [
@@ -412,7 +420,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": null,
+      "execution_count": 10,
       "id": "8c8a4958",
       "metadata": {},
       "outputs": [
@@ -422,7 +430,7 @@
               "[0.67, 0.67, 0.67, 0.67, 0.75, 1.0, 1.0, 1.0, 1.0]"
             ]
           },
-          "execution_count": null,
+          "execution_count": 10,
           "metadata": {},
           "output_type": "execute_result"
         }
@@ -435,7 +443,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 120,
+      "execution_count": 11,
       "id": "f46a0581",
       "metadata": {},
       "outputs": [
@@ -493,7 +501,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 121,
+      "execution_count": 12,
       "id": "8210791a",
       "metadata": {},
       "outputs": [
@@ -532,7 +540,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 122,
+      "execution_count": 13,
       "id": "a7ba273d",
       "metadata": {},
       "outputs": [
@@ -607,7 +615,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": null,
+      "execution_count": 14,
       "id": "f204158f",
       "metadata": {},
       "outputs": [
@@ -617,7 +625,7 @@
               "0.8"
             ]
           },
-          "execution_count": null,
+          "execution_count": 14,
           "metadata": {},
           "output_type": "execute_result"
         }
@@ -630,7 +638,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 124,
+      "execution_count": 15,
       "id": "812c30df",
       "metadata": {},
       "outputs": [
@@ -652,7 +660,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 125,
+      "execution_count": 16,
       "id": "679b233b",
       "metadata": {},
       "outputs": [
@@ -691,7 +699,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 126,
+      "execution_count": 17,
       "id": "b711cb11",
       "metadata": {},
       "outputs": [],
@@ -777,7 +785,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 127,
+      "execution_count": 18,
       "id": "4d6f4922",
       "metadata": {},
       "outputs": [],
@@ -812,7 +820,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 128,
+      "execution_count": 19,
       "id": "9060f7ce",
       "metadata": {},
       "outputs": [],
@@ -874,7 +882,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 129,
+      "execution_count": 20,
       "id": "9bcc5b3a",
       "metadata": {},
       "outputs": [],
@@ -961,7 +969,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 130,
+      "execution_count": 21,
       "id": "0fe326fc",
       "metadata": {},
       "outputs": [],
@@ -1048,7 +1056,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 131,
+      "execution_count": 22,
       "id": "fa13beb8",
       "metadata": {},
       "outputs": [],
@@ -1108,7 +1116,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 132,
+      "execution_count": 23,
       "id": "c92a5d9a",
       "metadata": {},
       "outputs": [
@@ -1165,7 +1173,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 133,
+      "execution_count": 24,
       "id": "df067c9a",
       "metadata": {},
       "outputs": [
@@ -1225,7 +1233,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 134,
+      "execution_count": 25,
       "id": "0e9b5af1",
       "metadata": {},
       "outputs": [
@@ -1280,7 +1288,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 135,
+      "execution_count": 26,
       "id": "f1c9634a",
       "metadata": {},
       "outputs": [
@@ -1335,7 +1343,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 136,
+      "execution_count": 27,
       "id": "eaaeb2a6",
       "metadata": {},
       "outputs": [
@@ -1404,7 +1412,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": null,
+      "execution_count": 28,
       "id": "23c0b4f8",
       "metadata": {},
       "outputs": [
@@ -1414,7 +1422,7 @@
               "3.5"
             ]
           },
-          "execution_count": null,
+          "execution_count": 28,
           "metadata": {},
           "output_type": "execute_result"
         }
@@ -1427,7 +1435,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 138,
+      "execution_count": 29,
       "id": "20a0d0be",
       "metadata": {},
       "outputs": [
@@ -1451,7 +1459,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 139,
+      "execution_count": 30,
       "id": "39874394",
       "metadata": {},
       "outputs": [
@@ -1492,7 +1500,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 140,
+      "execution_count": 31,
       "id": "c675d8b7",
       "metadata": {},
       "outputs": [
@@ -1545,7 +1553,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 141,
+      "execution_count": 32,
       "id": "04b8e9f3",
       "metadata": {},
       "outputs": [
@@ -1597,7 +1605,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": null,
+      "execution_count": 33,
       "id": "52f366f0",
       "metadata": {},
       "outputs": [],
@@ -1631,7 +1639,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 143,
+      "execution_count": 34,
       "id": "f9ce44a3",
       "metadata": {},
       "outputs": [
@@ -1692,7 +1700,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 144,
+      "execution_count": 35,
       "id": "c92d3608",
       "metadata": {},
       "outputs": [
@@ -1753,7 +1761,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 145,
+      "execution_count": 36,
       "id": "73e04352",
       "metadata": {},
       "outputs": [
@@ -1806,7 +1814,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 146,
+      "execution_count": 37,
       "id": "ca33c0c4",
       "metadata": {},
       "outputs": [
@@ -1859,7 +1867,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 147,
+      "execution_count": 38,
       "id": "c6c03d77",
       "metadata": {},
       "outputs": [
@@ -1912,7 +1920,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": null,
+      "execution_count": 39,
       "id": "0177483d",
       "metadata": {},
       "outputs": [
@@ -1922,7 +1930,7 @@
               "[0.75, 0.75, 0.75, 0.75, 0.75, 0.65, 0.65, 0.65, 0.65, 0.65]"
             ]
           },
-          "execution_count": null,
+          "execution_count": 39,
           "metadata": {},
           "output_type": "execute_result"
         }
@@ -1935,7 +1943,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 149,
+      "execution_count": 40,
       "id": "822d8e0a",
       "metadata": {},
       "outputs": [
@@ -1988,7 +1996,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 150,
+      "execution_count": 41,
       "id": "a51f711f",
       "metadata": {},
       "outputs": [
@@ -2047,7 +2055,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 151,
+      "execution_count": 42,
       "id": "9f7d52a3",
       "metadata": {},
       "outputs": [
@@ -2106,7 +2114,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 152,
+      "execution_count": 43,
       "id": "b60a7ade",
       "metadata": {},
       "outputs": [
@@ -2161,7 +2169,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 153,
+      "execution_count": 44,
       "id": "ceaf53a4",
       "metadata": {},
       "outputs": [
@@ -2220,7 +2228,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 154,
+      "execution_count": 45,
       "id": "df464d39",
       "metadata": {},
       "outputs": [
@@ -2278,7 +2286,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 155,
+      "execution_count": 46,
       "id": "69f12bc6",
       "metadata": {},
       "outputs": [
@@ -2336,7 +2344,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 156,
+      "execution_count": 47,
       "id": "b388a589",
       "metadata": {},
       "outputs": [
@@ -2391,7 +2399,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 157,
+      "execution_count": 48,
       "id": "dbb1cca1",
       "metadata": {},
       "outputs": [
@@ -2445,7 +2453,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": null,
+      "execution_count": 49,
       "id": "1395fc4a",
       "metadata": {},
       "outputs": [],
@@ -2482,7 +2490,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 159,
+      "execution_count": 50,
       "id": "1a11ad1d",
       "metadata": {},
       "outputs": [
@@ -2545,7 +2553,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 160,
+      "execution_count": 51,
       "id": "092b8212",
       "metadata": {},
       "outputs": [
@@ -2608,7 +2616,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 161,
+      "execution_count": 52,
       "id": "7ca02351",
       "metadata": {},
       "outputs": [
@@ -2663,7 +2671,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 162,
+      "execution_count": 53,
       "id": "662206ed",
       "metadata": {},
       "outputs": [
@@ -2718,7 +2726,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 163,
+      "execution_count": 54,
       "id": "721616e6",
       "metadata": {},
       "outputs": [
@@ -2773,7 +2781,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 164,
+      "execution_count": 55,
       "id": "2ded71ce",
       "metadata": {},
       "outputs": [
@@ -2783,7 +2791,7 @@
               "np.float64(0.783)"
             ]
           },
-          "execution_count": null,
+          "execution_count": 55,
           "metadata": {},
           "output_type": "execute_result"
         }
@@ -2794,7 +2802,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": null,
+      "execution_count": 56,
       "id": "8a9dfaf7",
       "metadata": {},
       "outputs": [
@@ -2847,7 +2855,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 166,
+      "execution_count": 57,
       "id": "67ed3577",
       "metadata": {},
       "outputs": [
@@ -2918,7 +2926,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 167,
+      "execution_count": 58,
       "id": "ce9fcd36",
       "metadata": {},
       "outputs": [
@@ -2965,113 +2973,23 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 168,
+      "execution_count": 59,
       "id": "c34f381a",
       "metadata": {},
       "outputs": [
         {
-          "data": {
-            "text/html": [
-              "<div>\n",
-              "<style scoped>\n",
-              "    .dataframe tbody tr th:only-of-type {\n",
-              "        vertical-align: middle;\n",
-              "    }\n",
-              "\n",
-              "    .dataframe tbody tr th {\n",
-              "        vertical-align: top;\n",
-              "    }\n",
-              "\n",
-              "    .dataframe thead th {\n",
-              "        text-align: right;\n",
-              "    }\n",
-              "</style>\n",
-              "<table border=\"1\" class=\"dataframe\">\n",
-              "  <thead>\n",
-              "    <tr style=\"text-align: right;\">\n",
-              "      <th></th>\n",
-              "      <th>2004</th>\n",
-              "      <th>2005</th>\n",
-              "      <th>2006</th>\n",
-              "      <th>2007</th>\n",
-              "      <th>2008</th>\n",
-              "    </tr>\n",
-              "  </thead>\n",
-              "  <tbody>\n",
-              "    <tr>\n",
-              "      <th>2002</th>\n",
-              "      <td>1.070</td>\n",
-              "      <td>1.106</td>\n",
-              "      <td>1.144</td>\n",
-              "      <td>1.183</td>\n",
-              "      <td>1.224</td>\n",
-              "    </tr>\n",
-              "    <tr>\n",
-              "      <th>2003</th>\n",
-              "      <td>1.034</td>\n",
-              "      <td>1.070</td>\n",
-              "      <td>1.106</td>\n",
-              "      <td>1.144</td>\n",
-              "      <td>1.183</td>\n",
-              "    </tr>\n",
-              "    <tr>\n",
-              "      <th>2004</th>\n",
-              "      <td>1.000</td>\n",
-              "      <td>1.034</td>\n",
-              "      <td>1.070</td>\n",
-              "      <td>1.106</td>\n",
-              "      <td>1.144</td>\n",
-              "    </tr>\n",
-              "    <tr>\n",
-              "      <th>2005</th>\n",
-              "      <td>0.967</td>\n",
-              "      <td>1.000</td>\n",
-              "      <td>1.034</td>\n",
-              "      <td>1.070</td>\n",
-              "      <td>1.106</td>\n",
-              "    </tr>\n",
-              "    <tr>\n",
-              "      <th>2006</th>\n",
-              "      <td>0.935</td>\n",
-              "      <td>0.967</td>\n",
-              "      <td>1.000</td>\n",
-              "      <td>1.034</td>\n",
-              "      <td>1.070</td>\n",
-              "    </tr>\n",
-              "    <tr>\n",
-              "      <th>2007</th>\n",
-              "      <td>0.904</td>\n",
-              "      <td>0.935</td>\n",
-              "      <td>0.967</td>\n",
-              "      <td>1.000</td>\n",
-              "      <td>1.034</td>\n",
-              "    </tr>\n",
-              "    <tr>\n",
-              "      <th>2008</th>\n",
-              "      <td>0.874</td>\n",
-              "      <td>0.904</td>\n",
-              "      <td>0.935</td>\n",
-              "      <td>0.967</td>\n",
-              "      <td>1.000</td>\n",
-              "    </tr>\n",
-              "  </tbody>\n",
-              "</table>\n",
-              "</div>"
-            ],
-            "text/plain": [
-              "       2004   2005   2006   2007   2008\n",
-              "2002  1.070  1.106  1.144  1.183  1.224\n",
-              "2003  1.034  1.070  1.106  1.144  1.183\n",
-              "2004  1.000  1.034  1.070  1.106  1.144\n",
-              "2005  0.967  1.000  1.034  1.070  1.106\n",
-              "2006  0.935  0.967  1.000  1.034  1.070\n",
-              "2007  0.904  0.935  0.967  1.000  1.034\n",
-              "2008  0.874  0.904  0.935  0.967  1.000"
-            ]
-          },
-          "execution_count": null,
-          "metadata": {},
-          "output_type": "execute_result"
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "       2004   2005   2006   2007   2008\n",
+            "2002  1.070  1.106  1.144  1.183  1.224\n",
+            "2003  1.034  1.070  1.106  1.144  1.183\n",
+            "2004  1.000  1.034  1.070  1.106  1.144\n",
+            "2005  0.967  1.000  1.034  1.070  1.106\n",
+            "2006  0.935  0.967  1.000  1.034  1.070\n",
+            "2007  0.904  0.935  0.967  1.000  1.034\n",
+            "2008  0.874  0.904  0.935  0.967  1.000\n"
+          ]
         }
       ],
       "source": [
@@ -3109,113 +3027,23 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 169,
+      "execution_count": 60,
       "id": "bbecf6ae",
       "metadata": {},
       "outputs": [
         {
-          "data": {
-            "text/html": [
-              "<div>\n",
-              "<style scoped>\n",
-              "    .dataframe tbody tr th:only-of-type {\n",
-              "        vertical-align: middle;\n",
-              "    }\n",
-              "\n",
-              "    .dataframe tbody tr th {\n",
-              "        vertical-align: top;\n",
-              "    }\n",
-              "\n",
-              "    .dataframe thead th {\n",
-              "        text-align: right;\n",
-              "    }\n",
-              "</style>\n",
-              "<table border=\"1\" class=\"dataframe\">\n",
-              "  <thead>\n",
-              "    <tr style=\"text-align: right;\">\n",
-              "      <th></th>\n",
-              "      <th>2004</th>\n",
-              "      <th>2005</th>\n",
-              "      <th>2006</th>\n",
-              "      <th>2007</th>\n",
-              "      <th>2008</th>\n",
-              "    </tr>\n",
-              "  </thead>\n",
-              "  <tbody>\n",
-              "    <tr>\n",
-              "      <th>2002</th>\n",
-              "      <td>1.000</td>\n",
-              "      <td>1.000</td>\n",
-              "      <td>0.893</td>\n",
-              "      <td>0.67</td>\n",
-              "      <td>0.67</td>\n",
-              "    </tr>\n",
-              "    <tr>\n",
-              "      <th>2003</th>\n",
-              "      <td>1.000</td>\n",
-              "      <td>1.000</td>\n",
-              "      <td>0.893</td>\n",
-              "      <td>0.67</td>\n",
-              "      <td>0.67</td>\n",
-              "    </tr>\n",
-              "    <tr>\n",
-              "      <th>2004</th>\n",
-              "      <td>1.000</td>\n",
-              "      <td>1.000</td>\n",
-              "      <td>0.893</td>\n",
-              "      <td>0.67</td>\n",
-              "      <td>0.67</td>\n",
-              "    </tr>\n",
-              "    <tr>\n",
-              "      <th>2005</th>\n",
-              "      <td>1.000</td>\n",
-              "      <td>1.000</td>\n",
-              "      <td>0.893</td>\n",
-              "      <td>0.67</td>\n",
-              "      <td>0.67</td>\n",
-              "    </tr>\n",
-              "    <tr>\n",
-              "      <th>2006</th>\n",
-              "      <td>1.119</td>\n",
-              "      <td>1.119</td>\n",
-              "      <td>1.000</td>\n",
-              "      <td>0.75</td>\n",
-              "      <td>0.75</td>\n",
-              "    </tr>\n",
-              "    <tr>\n",
-              "      <th>2007</th>\n",
-              "      <td>1.493</td>\n",
-              "      <td>1.493</td>\n",
-              "      <td>1.333</td>\n",
-              "      <td>1.00</td>\n",
-              "      <td>1.00</td>\n",
-              "    </tr>\n",
-              "    <tr>\n",
-              "      <th>2008</th>\n",
-              "      <td>1.493</td>\n",
-              "      <td>1.493</td>\n",
-              "      <td>1.333</td>\n",
-              "      <td>1.00</td>\n",
-              "      <td>1.00</td>\n",
-              "    </tr>\n",
-              "  </tbody>\n",
-              "</table>\n",
-              "</div>"
-            ],
-            "text/plain": [
-              "       2004   2005   2006  2007  2008\n",
-              "2002  1.000  1.000  0.893  0.67  0.67\n",
-              "2003  1.000  1.000  0.893  0.67  0.67\n",
-              "2004  1.000  1.000  0.893  0.67  0.67\n",
-              "2005  1.000  1.000  0.893  0.67  0.67\n",
-              "2006  1.119  1.119  1.000  0.75  0.75\n",
-              "2007  1.493  1.493  1.333  1.00  1.00\n",
-              "2008  1.493  1.493  1.333  1.00  1.00"
-            ]
-          },
-          "execution_count": null,
-          "metadata": {},
-          "output_type": "execute_result"
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "       2004   2005   2006  2007  2008\n",
+            "2002  1.000  1.000  0.893  0.67  0.67\n",
+            "2003  1.000  1.000  0.893  0.67  0.67\n",
+            "2004  1.000  1.000  0.893  0.67  0.67\n",
+            "2005  1.000  1.000  0.893  0.67  0.67\n",
+            "2006  1.119  1.119  1.000  0.75  0.75\n",
+            "2007  1.493  1.493  1.333  1.00  1.00\n",
+            "2008  1.493  1.493  1.333  1.00  1.00\n"
+          ]
         }
       ],
       "source": [
@@ -3256,66 +3084,23 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 170,
+      "execution_count": 61,
       "id": "fb7b2545",
       "metadata": {},
       "outputs": [
         {
-          "data": {
-            "text/html": [
-              "<table border=\"1\" class=\"dataframe\">\n",
-              "  <thead>\n",
-              "    <tr style=\"text-align: right;\">\n",
-              "      <th></th>\n",
-              "      <th>2008</th>\n",
-              "    </tr>\n",
-              "  </thead>\n",
-              "  <tbody>\n",
-              "    <tr>\n",
-              "      <th>2002</th>\n",
-              "      <td>61,183</td>\n",
-              "    </tr>\n",
-              "    <tr>\n",
-              "      <th>2003</th>\n",
-              "      <td>69,175</td>\n",
-              "    </tr>\n",
-              "    <tr>\n",
-              "      <th>2004</th>\n",
-              "      <td>99,322</td>\n",
-              "    </tr>\n",
-              "    <tr>\n",
-              "      <th>2005</th>\n",
-              "      <td>138,151</td>\n",
-              "    </tr>\n",
-              "    <tr>\n",
-              "      <th>2006</th>\n",
-              "      <td>107,578</td>\n",
-              "    </tr>\n",
-              "    <tr>\n",
-              "      <th>2007</th>\n",
-              "      <td>62,438</td>\n",
-              "    </tr>\n",
-              "    <tr>\n",
-              "      <th>2008</th>\n",
-              "      <td>47,797</td>\n",
-              "    </tr>\n",
-              "  </tbody>\n",
-              "</table>"
-            ],
-            "text/plain": [
-              "          2008\n",
-              "2002   61183.0\n",
-              "2003   69175.0\n",
-              "2004   99322.0\n",
-              "2005  138151.0\n",
-              "2006  107578.0\n",
-              "2007   62438.0\n",
-              "2008   47797.0"
-            ]
-          },
-          "execution_count": null,
-          "metadata": {},
-          "output_type": "execute_result"
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "          2008\n",
+            "2002   61183.0\n",
+            "2003   69175.0\n",
+            "2004   99322.0\n",
+            "2005  138151.0\n",
+            "2006  107578.0\n",
+            "2007   62438.0\n",
+            "2008   47797.0\n"
+          ]
         }
       ],
       "source": [
@@ -3346,113 +3131,23 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 171,
+      "execution_count": 62,
       "id": "cfe2b784",
       "metadata": {},
       "outputs": [
         {
-          "data": {
-            "text/html": [
-              "<div>\n",
-              "<style scoped>\n",
-              "    .dataframe tbody tr th:only-of-type {\n",
-              "        vertical-align: middle;\n",
-              "    }\n",
-              "\n",
-              "    .dataframe tbody tr th {\n",
-              "        vertical-align: top;\n",
-              "    }\n",
-              "\n",
-              "    .dataframe thead th {\n",
-              "        text-align: right;\n",
-              "    }\n",
-              "</style>\n",
-              "<table border=\"1\" class=\"dataframe\">\n",
-              "  <thead>\n",
-              "    <tr style=\"text-align: right;\">\n",
-              "      <th></th>\n",
-              "      <th>2004</th>\n",
-              "      <th>2005</th>\n",
-              "      <th>2006</th>\n",
-              "      <th>2007</th>\n",
-              "      <th>2008</th>\n",
-              "    </tr>\n",
-              "  </thead>\n",
-              "  <tbody>\n",
-              "    <tr>\n",
-              "      <th>2002</th>\n",
-              "      <td>1.129</td>\n",
-              "      <td>1.298</td>\n",
-              "      <td>1.428</td>\n",
-              "      <td>1.142</td>\n",
-              "      <td>0.914</td>\n",
-              "    </tr>\n",
-              "    <tr>\n",
-              "      <th>2003</th>\n",
-              "      <td>1.075</td>\n",
-              "      <td>1.236</td>\n",
-              "      <td>1.360</td>\n",
-              "      <td>1.088</td>\n",
-              "      <td>0.870</td>\n",
-              "    </tr>\n",
-              "    <tr>\n",
-              "      <th>2004</th>\n",
-              "      <td>1.000</td>\n",
-              "      <td>1.150</td>\n",
-              "      <td>1.265</td>\n",
-              "      <td>1.012</td>\n",
-              "      <td>0.810</td>\n",
-              "    </tr>\n",
-              "    <tr>\n",
-              "      <th>2005</th>\n",
-              "      <td>0.870</td>\n",
-              "      <td>1.000</td>\n",
-              "      <td>1.100</td>\n",
-              "      <td>0.880</td>\n",
-              "      <td>0.704</td>\n",
-              "    </tr>\n",
-              "    <tr>\n",
-              "      <th>2006</th>\n",
-              "      <td>0.791</td>\n",
-              "      <td>0.909</td>\n",
-              "      <td>1.000</td>\n",
-              "      <td>0.800</td>\n",
-              "      <td>0.640</td>\n",
-              "    </tr>\n",
-              "    <tr>\n",
-              "      <th>2007</th>\n",
-              "      <td>0.988</td>\n",
-              "      <td>1.136</td>\n",
-              "      <td>1.250</td>\n",
-              "      <td>1.000</td>\n",
-              "      <td>0.800</td>\n",
-              "    </tr>\n",
-              "    <tr>\n",
-              "      <th>2008</th>\n",
-              "      <td>1.235</td>\n",
-              "      <td>1.420</td>\n",
-              "      <td>1.562</td>\n",
-              "      <td>1.250</td>\n",
-              "      <td>1.000</td>\n",
-              "    </tr>\n",
-              "  </tbody>\n",
-              "</table>\n",
-              "</div>"
-            ],
-            "text/plain": [
-              "       2004   2005   2006   2007   2008\n",
-              "2002  1.129  1.298  1.428  1.142  0.914\n",
-              "2003  1.075  1.236  1.360  1.088  0.870\n",
-              "2004  1.000  1.150  1.265  1.012  0.810\n",
-              "2005  0.870  1.000  1.100  0.880  0.704\n",
-              "2006  0.791  0.909  1.000  0.800  0.640\n",
-              "2007  0.988  1.136  1.250  1.000  0.800\n",
-              "2008  1.235  1.420  1.562  1.250  1.000"
-            ]
-          },
-          "execution_count": null,
-          "metadata": {},
-          "output_type": "execute_result"
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "       2004   2005   2006   2007   2008\n",
+            "2002  1.129  1.298  1.428  1.142  0.914\n",
+            "2003  1.075  1.236  1.360  1.088  0.870\n",
+            "2004  1.000  1.150  1.265  1.012  0.810\n",
+            "2005  0.870  1.000  1.100  0.880  0.704\n",
+            "2006  0.791  0.909  1.000  0.800  0.640\n",
+            "2007  0.988  1.136  1.250  1.000  0.800\n",
+            "2008  1.235  1.420  1.562  1.250  1.000\n"
+          ]
         }
       ],
       "source": [
@@ -3491,113 +3186,23 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 172,
+      "execution_count": 63,
       "id": "2b5a851c",
       "metadata": {},
       "outputs": [
         {
-          "data": {
-            "text/html": [
-              "<div>\n",
-              "<style scoped>\n",
-              "    .dataframe tbody tr th:only-of-type {\n",
-              "        vertical-align: middle;\n",
-              "    }\n",
-              "\n",
-              "    .dataframe tbody tr th {\n",
-              "        vertical-align: top;\n",
-              "    }\n",
-              "\n",
-              "    .dataframe thead th {\n",
-              "        text-align: right;\n",
-              "    }\n",
-              "</style>\n",
-              "<table border=\"1\" class=\"dataframe\">\n",
-              "  <thead>\n",
-              "    <tr style=\"text-align: right;\">\n",
-              "      <th></th>\n",
-              "      <th>2004</th>\n",
-              "      <th>2005</th>\n",
-              "      <th>2006</th>\n",
-              "      <th>2007</th>\n",
-              "      <th>2008</th>\n",
-              "    </tr>\n",
-              "  </thead>\n",
-              "  <tbody>\n",
-              "    <tr>\n",
-              "      <th>2002</th>\n",
-              "      <td>0.758</td>\n",
-              "      <td>0.682</td>\n",
-              "      <td>0.573</td>\n",
-              "      <td>0.555</td>\n",
-              "      <td>0.718</td>\n",
-              "    </tr>\n",
-              "    <tr>\n",
-              "      <th>2003</th>\n",
-              "      <td>0.659</td>\n",
-              "      <td>0.593</td>\n",
-              "      <td>0.498</td>\n",
-              "      <td>0.483</td>\n",
-              "      <td>0.624</td>\n",
-              "    </tr>\n",
-              "    <tr>\n",
-              "      <th>2004</th>\n",
-              "      <td>0.782</td>\n",
-              "      <td>0.703</td>\n",
-              "      <td>0.591</td>\n",
-              "      <td>0.573</td>\n",
-              "      <td>0.740</td>\n",
-              "    </tr>\n",
-              "    <tr>\n",
-              "      <th>2005</th>\n",
-              "      <td>0.632</td>\n",
-              "      <td>0.568</td>\n",
-              "      <td>0.477</td>\n",
-              "      <td>0.463</td>\n",
-              "      <td>0.598</td>\n",
-              "    </tr>\n",
-              "    <tr>\n",
-              "      <th>2006</th>\n",
-              "      <td>0.803</td>\n",
-              "      <td>0.722</td>\n",
-              "      <td>0.606</td>\n",
-              "      <td>0.588</td>\n",
-              "      <td>0.760</td>\n",
-              "    </tr>\n",
-              "    <tr>\n",
-              "      <th>2007</th>\n",
-              "      <td>1.377</td>\n",
-              "      <td>1.238</td>\n",
-              "      <td>1.040</td>\n",
-              "      <td>1.008</td>\n",
-              "      <td>1.304</td>\n",
-              "    </tr>\n",
-              "    <tr>\n",
-              "      <th>2008</th>\n",
-              "      <td>1.354</td>\n",
-              "      <td>1.217</td>\n",
-              "      <td>1.022</td>\n",
-              "      <td>0.991</td>\n",
-              "      <td>1.282</td>\n",
-              "    </tr>\n",
-              "  </tbody>\n",
-              "</table>\n",
-              "</div>"
-            ],
-            "text/plain": [
-              "       2004   2005   2006   2007   2008\n",
-              "2002  0.758  0.682  0.573  0.555  0.718\n",
-              "2003  0.659  0.593  0.498  0.483  0.624\n",
-              "2004  0.782  0.703  0.591  0.573  0.740\n",
-              "2005  0.632  0.568  0.477  0.463  0.598\n",
-              "2006  0.803  0.722  0.606  0.588  0.760\n",
-              "2007  1.377  1.238  1.040  1.008  1.304\n",
-              "2008  1.354  1.217  1.022  0.991  1.282"
-            ]
-          },
-          "execution_count": null,
-          "metadata": {},
-          "output_type": "execute_result"
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "       2004   2005   2006   2007   2008\n",
+            "2002  0.758  0.682  0.573  0.555  0.718\n",
+            "2003  0.659  0.593  0.498  0.483  0.624\n",
+            "2004  0.782  0.703  0.591  0.573  0.740\n",
+            "2005  0.632  0.568  0.477  0.463  0.598\n",
+            "2006  0.803  0.722  0.606  0.588  0.760\n",
+            "2007  1.377  1.238  1.040  1.008  1.304\n",
+            "2008  1.354  1.217  1.022  0.991  1.282\n"
+          ]
         }
       ],
       "source": [
@@ -3636,86 +3241,20 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 173,
+      "execution_count": 64,
       "id": "e0b8d0cc",
       "metadata": {},
       "outputs": [
         {
-          "data": {
-            "text/html": [
-              "<div>\n",
-              "<style scoped>\n",
-              "    .dataframe tbody tr th:only-of-type {\n",
-              "        vertical-align: middle;\n",
-              "    }\n",
-              "\n",
-              "    .dataframe tbody tr th {\n",
-              "        vertical-align: top;\n",
-              "    }\n",
-              "\n",
-              "    .dataframe thead th {\n",
-              "        text-align: right;\n",
-              "    }\n",
-              "</style>\n",
-              "<table border=\"1\" class=\"dataframe\">\n",
-              "  <thead>\n",
-              "    <tr style=\"text-align: right;\">\n",
-              "      <th></th>\n",
-              "      <th>2004</th>\n",
-              "      <th>2005</th>\n",
-              "      <th>2006</th>\n",
-              "      <th>2007</th>\n",
-              "      <th>2008</th>\n",
-              "    </tr>\n",
-              "  </thead>\n",
-              "  <tbody>\n",
-              "    <tr>\n",
-              "      <th>All Years</th>\n",
-              "      <td>0.909</td>\n",
-              "      <td>0.818</td>\n",
-              "      <td>0.687</td>\n",
-              "      <td>0.666</td>\n",
-              "      <td>0.861</td>\n",
-              "    </tr>\n",
-              "    <tr>\n",
-              "      <th>All Years excl High/Low</th>\n",
-              "      <td>0.871</td>\n",
-              "      <td>0.783</td>\n",
-              "      <td>0.658</td>\n",
-              "      <td>0.638</td>\n",
-              "      <td>0.825</td>\n",
-              "    </tr>\n",
-              "    <tr>\n",
-              "      <th>Latest 5 Years</th>\n",
-              "      <td>0.989</td>\n",
-              "      <td>0.890</td>\n",
-              "      <td>0.747</td>\n",
-              "      <td>0.725</td>\n",
-              "      <td>0.937</td>\n",
-              "    </tr>\n",
-              "    <tr>\n",
-              "      <th>Latest 3 Years</th>\n",
-              "      <td>1.178</td>\n",
-              "      <td>1.059</td>\n",
-              "      <td>0.890</td>\n",
-              "      <td>0.863</td>\n",
-              "      <td>1.115</td>\n",
-              "    </tr>\n",
-              "  </tbody>\n",
-              "</table>\n",
-              "</div>"
-            ],
-            "text/plain": [
-              "                          2004   2005   2006   2007   2008\n",
-              "All Years                0.909  0.818  0.687  0.666  0.861\n",
-              "All Years excl High/Low  0.871  0.783  0.658  0.638  0.825\n",
-              "Latest 5 Years           0.989  0.890  0.747  0.725  0.937\n",
-              "Latest 3 Years           1.178  1.059  0.890  0.863  1.115"
-            ]
-          },
-          "execution_count": null,
-          "metadata": {},
-          "output_type": "execute_result"
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "                          2004   2005   2006   2007   2008\n",
+            "All Years                0.909  0.818  0.687  0.666  0.861\n",
+            "All Years excl High/Low  0.871  0.783  0.658  0.638  0.825\n",
+            "Latest 5 Years           0.989  0.890  0.747  0.725  0.937\n",
+            "Latest 3 Years           1.178  1.059  0.890  0.863  1.115\n"
+          ]
         }
       ],
       "source": [
@@ -3745,24 +3284,21 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 174,
+      "execution_count": 65,
       "id": "8f2d813e",
       "metadata": {},
       "outputs": [
         {
-          "data": {
-            "text/plain": [
-              "2004    0.871\n",
-              "2005    0.783\n",
-              "2006    0.658\n",
-              "2007    0.638\n",
-              "2008    0.825\n",
-              "dtype: float64"
-            ]
-          },
-          "execution_count": null,
-          "metadata": {},
-          "output_type": "execute_result"
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "2004    0.871\n",
+            "2005    0.783\n",
+            "2006    0.658\n",
+            "2007    0.638\n",
+            "2008    0.825\n",
+            "dtype: float64\n"
+          ]
         }
       ],
       "source": [
@@ -3778,7 +3314,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 175,
+      "execution_count": 66,
       "id": "4caa0032",
       "metadata": {},
       "outputs": [
@@ -3839,7 +3375,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 176,
+      "execution_count": 67,
       "id": "4044c420",
       "metadata": {},
       "outputs": [
@@ -3900,7 +3436,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 177,
+      "execution_count": 68,
       "id": "d3088bc5",
       "metadata": {},
       "outputs": [
@@ -3957,7 +3493,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 178,
+      "execution_count": 69,
       "id": "7092dda2",
       "metadata": {},
       "outputs": [
@@ -4019,7 +3555,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 179,
+      "execution_count": 70,
       "id": "b34731ab",
       "metadata": {},
       "outputs": [
@@ -4079,7 +3615,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 180,
+      "execution_count": 71,
       "id": "b5e5cdca",
       "metadata": {},
       "outputs": [
@@ -4139,7 +3675,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 181,
+      "execution_count": 72,
       "id": "c6b83521",
       "metadata": {},
       "outputs": [
@@ -4200,7 +3736,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 182,
+      "execution_count": 73,
       "id": "1a524f49",
       "metadata": {},
       "outputs": [
@@ -4261,7 +3797,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 183,
+      "execution_count": 74,
       "id": "dfc5faeb",
       "metadata": {},
       "outputs": [
@@ -4318,7 +3854,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 184,
+      "execution_count": 75,
       "id": "0551cf38",
       "metadata": {},
       "outputs": [
@@ -4376,7 +3912,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 185,
+      "execution_count": 76,
       "id": "a0f89c78",
       "metadata": {},
       "outputs": [
@@ -4434,7 +3970,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 186,
+      "execution_count": 77,
       "id": "678c3626",
       "metadata": {},
       "outputs": [
@@ -4492,7 +4028,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 187,
+      "execution_count": 78,
       "id": "e9f946b3",
       "metadata": {},
       "outputs": [
@@ -4511,7 +4047,14 @@
             "2005   6006.0\n",
             "2006   9566.0\n",
             "2007  16247.0\n",
-            "2008  28898.0\n",
+            "2008  28898.0"
+          ]
+        },
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "\n",
             "Total: 65304.0\n"
           ]
         }
@@ -4552,7 +4095,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 188,
+      "execution_count": 79,
       "id": "c02025f0",
       "metadata": {},
       "outputs": [
@@ -4612,7 +4155,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 189,
+      "execution_count": 80,
       "id": "87ffe1dd",
       "metadata": {},
       "outputs": [
@@ -4669,7 +4212,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 190,
+      "execution_count": 81,
       "id": "dc19256d",
       "metadata": {},
       "outputs": [
@@ -4728,7 +4271,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 191,
+      "execution_count": 82,
       "id": "0e4e94ba",
       "metadata": {},
       "outputs": [
@@ -4749,7 +4292,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 192,
+      "execution_count": 83,
       "id": "cf619622",
       "metadata": {},
       "outputs": [
@@ -4805,7 +4348,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 193,
+      "execution_count": 84,
       "id": "07458d82",
       "metadata": {},
       "outputs": [
@@ -4861,7 +4404,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 194,
+      "execution_count": 85,
       "id": "9090050a",
       "metadata": {},
       "outputs": [
@@ -4917,7 +4460,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 195,
+      "execution_count": 86,
       "id": "67048d8e",
       "metadata": {},
       "outputs": [
@@ -4992,7 +4535,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 196,
+      "execution_count": 87,
       "id": "41e26642",
       "metadata": {},
       "outputs": [
@@ -5048,7 +4591,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 197,
+      "execution_count": 88,
       "id": "b77c54b8",
       "metadata": {},
       "outputs": [
@@ -5109,7 +4652,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 198,
+      "execution_count": 89,
       "id": "f2034e4d",
       "metadata": {},
       "outputs": [
@@ -5130,7 +4673,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 199,
+      "execution_count": 90,
       "id": "133af1e7",
       "metadata": {},
       "outputs": [
@@ -5186,7 +4729,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 200,
+      "execution_count": 91,
       "id": "e7c8c419",
       "metadata": {},
       "outputs": [
@@ -5244,7 +4787,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 201,
+      "execution_count": 92,
       "id": "368492ef",
       "metadata": {},
       "outputs": [
@@ -5300,7 +4843,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 202,
+      "execution_count": 93,
       "id": "e268f485",
       "metadata": {},
       "outputs": [
@@ -5375,7 +4918,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 203,
+      "execution_count": 94,
       "id": "0ce7e4c6",
       "metadata": {},
       "outputs": [
@@ -5431,7 +4974,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 204,
+      "execution_count": 95,
       "id": "f6beb461",
       "metadata": {},
       "outputs": [
@@ -5492,7 +5035,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": null,
+      "execution_count": 96,
       "id": "f89da050",
       "metadata": {},
       "outputs": [
@@ -5512,7 +5055,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 206,
+      "execution_count": 97,
       "id": "59a09b15",
       "metadata": {},
       "outputs": [
@@ -5568,7 +5111,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 207,
+      "execution_count": 98,
       "id": "064bf690",
       "metadata": {},
       "outputs": [
@@ -5626,7 +5169,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 208,
+      "execution_count": 99,
       "id": "f9121f01",
       "metadata": {},
       "outputs": [
@@ -5682,7 +5225,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 209,
+      "execution_count": 100,
       "id": "3d91b615",
       "metadata": {},
       "outputs": [
@@ -5757,7 +5300,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 210,
+      "execution_count": 101,
       "id": "cd6cd2d9",
       "metadata": {},
       "outputs": [
@@ -5813,7 +5356,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 211,
+      "execution_count": 102,
       "id": "fe4972f8",
       "metadata": {},
       "outputs": [
@@ -5874,7 +5417,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": null,
+      "execution_count": 103,
       "id": "743b1285",
       "metadata": {},
       "outputs": [
@@ -5894,7 +5437,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 213,
+      "execution_count": 104,
       "id": "c5bf7b59",
       "metadata": {},
       "outputs": [
@@ -5950,7 +5493,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 214,
+      "execution_count": 105,
       "id": "dcf81b36",
       "metadata": {},
       "outputs": [
@@ -6008,7 +5551,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 215,
+      "execution_count": 106,
       "id": "55d16960",
       "metadata": {},
       "outputs": [
@@ -6064,7 +5607,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 216,
+      "execution_count": 107,
       "id": "8731c332",
       "metadata": {},
       "outputs": [
@@ -6139,7 +5682,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 217,
+      "execution_count": 108,
       "id": "b0d7230d",
       "metadata": {},
       "outputs": [
@@ -6195,7 +5738,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 228,
+      "execution_count": 109,
       "id": "9ad60cb9",
       "metadata": {},
       "outputs": [
@@ -6254,7 +5797,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": null,
+      "execution_count": 110,
       "id": "47e2cc64",
       "metadata": {},
       "outputs": [
@@ -6274,7 +5817,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": null,
+      "execution_count": 111,
       "id": "b5db598a",
       "metadata": {},
       "outputs": [
@@ -6330,7 +5873,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": null,
+      "execution_count": 112,
       "id": "e6a6d0fb",
       "metadata": {},
       "outputs": [
@@ -6386,7 +5929,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": null,
+      "execution_count": 113,
       "id": "069a6bd6",
       "metadata": {},
       "outputs": [
@@ -6442,7 +5985,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": null,
+      "execution_count": 114,
       "id": "b6a4127f",
       "metadata": {},
       "outputs": [
@@ -6517,7 +6060,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": null,
+      "execution_count": 115,
       "id": "2d304465",
       "metadata": {},
       "outputs": [
@@ -6573,7 +6116,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 219,
+      "execution_count": 116,
       "id": "8b80529d",
       "metadata": {},
       "outputs": [
@@ -6632,7 +6175,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": null,
+      "execution_count": 117,
       "id": "4619a419",
       "metadata": {},
       "outputs": [
@@ -6652,7 +6195,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 221,
+      "execution_count": 118,
       "id": "5a6dec9f",
       "metadata": {},
       "outputs": [
@@ -6708,7 +6251,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 224,
+      "execution_count": 119,
       "id": "d9140d47",
       "metadata": {},
       "outputs": [
@@ -6764,7 +6307,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 225,
+      "execution_count": 120,
       "id": "e9be5074",
       "metadata": {},
       "outputs": [
@@ -6820,7 +6363,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 226,
+      "execution_count": 121,
       "id": "2b4b1b5b",
       "metadata": {},
       "outputs": [
@@ -6895,7 +6438,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 227,
+      "execution_count": 122,
       "id": "648a4b4f",
       "metadata": {},
       "outputs": [


### PR DESCRIPTION
## Summary of Changes  


## Related GitHub Issue(s)  


## Additional Context for Reviewers  


- [ ] I passed tests locally for both code (`uv run pytest`) and documentation changes (`uv run jb build docs --builder=custom --custom-builder=doctest`)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only notebook edits with no changes to library code or runtime behavior outside doctest/notebook execution.
> 
> **Overview**
> Updates **`docs/friedland/chapter_8.ipynb`** so Chapter 8 (Expected Claims Technique) is easier to validate and runs cleanly end-to-end.
> 
> Adds a **chapter title** markdown cell and **resets cell execution counts** (1–122) after a full run. Across Friedland exhibits, cells that only displayed DataFrames now **`print` results and `assert`** against book values—especially **Exhibit III Sheet 2** (severity/tort/rate adjustments, adjusted claim ratios, and selected ratios) and related **selected claim ratio** checks.
> 
> **Fixes Exhibit V steady-state**: earned premium is read from `friedland_us_auto_steady_state["Earned Premium"]` instead of synthesizing values from reported claims, which had caused a **`KeyError`** on load. A few small assertion additions (e.g. steady-state **0.70** claim ratio) and minor stdout formatting round out the change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 198bff6c324c718f46c61430a92153fd7ad8c95c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->