### PR TITLE
Remove Triangle min/max passthroughs

### DIFF
--- a/chainladder/core/pandas.py
+++ b/chainladder/core/pandas.py
@@ -1090,7 +1090,7 @@ df_passthru = (
 for method in df_passthru:
     add_df_passthru(TrianglePandas, method)
 
-agg_funcs = ["sum", "mean", "median", "max", "min", "prod", "var"]
+agg_funcs = ["sum", "mean", "median", "prod", "var"]
 agg_funcs = agg_funcs + ["std", "cumsum", "quantile"]
 for func in agg_funcs:
     add_groupby_agg_func(TriangleGroupBy, func, func)

--- a/chainladder/core/tests/test_triangle.py
+++ b/chainladder/core/tests/test_triangle.py
@@ -185,6 +185,22 @@ def test_quantile_vs_median(clrd):
     )
 
 
+def test_min_max_not_registered_as_agg_passthroughs(clrd: Triangle) -> None:
+    """
+    Triangle.min/max are intentionally not exposed via aggregate passthroughs.
+    """
+    groupby = clrd.groupby("LOB")
+
+    for method in ("min", "max"):
+        with pytest.raises(AttributeError):
+            getattr(clrd, method)
+        with pytest.raises(AttributeError):
+            getattr(groupby, method)
+
+    assert callable(getattr(clrd, "mean"))
+    assert callable(getattr(groupby, "mean"))
+
+
 def test_base_minimum_exposure_triangle(raa):
     d = (
         (raa.latest_diagonal * 0 + 50000)


### PR DESCRIPTION
## Summary of Changes

- Remove `min` and `max` from the aggregate passthrough registration so `Triangle.min()` and `Triangle.max()` are no longer exposed.
- Add regression coverage confirming `min`/`max` are absent from the passthrough API while neighboring aggregate passthroughs remain registered.

## Related GitHub Issue(s)

Fixes #1064

## Additional Context for Reviewers

Local validation:

- `TMPDIR=/tmp uv run pytest chainladder/core/tests/test_triangle.py -k 'min_max_not_registered_as_agg_passthroughs' -s` - 2 passed\n- `TMPDIR=/tmp uv run pytest chainladder/core/tests/test_triangle.py::test_min_max_not_registered_as_agg_passthroughs chainladder/core/tests/test_triangle.py::test_quantile_vs_median chainladder/core/tests/test_triangle.py::test_multilevel_index_groupby_sum1 chainladder/core/tests/test_triangle.py::test_multilevel_index_groupby_sum2 chainladder/core/tests/test_triangle.py::test_groupby_axis1 chainladder/core/tests/test_triangle.py::test_groupby_agg_auto_sparse -s` - 11 passed\n- `TMPDIR=/tmp uv run pytest chainladder/core/tests/test_triangle.py -k 'not auto_sparse_disabled_returns_self' -s` - 241 passed, 1 skipped, 1 deselected\n- `git diff --check`\n\nI also attempted the full `test_triangle.py` run, but `test_auto_sparse_disabled_returns_self[normal_run]` failed locally while trying to allocate a 14.7 GiB dense array from the `prism` fixture. That appears unrelated to this change.\n\n- [ ] I passed tests locally for both code (`uv run pytest`) and documentation changes (`uv run jb build docs --builder=custom --custom-builder=doctest`)\n

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> This is a breaking API change for any code that relied on `Triangle.min()`/`max()` or groupby equivalents; behavior of other aggregates is untouched.
> 
> **Overview**
> Stops registering **`min`** and **`max`** as pandas-style aggregate passthroughs on **`Triangle`** and **`TriangleGroupBy`**, so callers can no longer use axis-reducing `Triangle.min()` / `Triangle.max()` (or the same on grouped objects). Other aggregates such as **`mean`**, **`sum`**, and **`median`** are unchanged.
> 
> Element-wise **`minimum()`** / **`maximum()`** (and **`cl.minimum`** / **`cl.maximum`**) remain the supported way to take mins/maxes between triangles or scalars. Regression tests assert **`min`**/**`max`** raise **`AttributeError`** while **`mean`** still works on triangles and groupbys.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7223378373e3544ff09170352b81355df2a0cbaa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->