### PR TITLE
Apply lognormal fix for apriori draws and add tests

### DIFF
--- a/chainladder/methods/benktander.py
+++ b/chainladder/methods/benktander.py
@@ -254,7 +254,11 @@ class Benktander(MethodBase):
         xp = X.get_array_module()
         if self.apriori_sigma != 0:
             random_state = xp.random.RandomState(self.random_state)
-            apriori = random_state.normal(self.apriori, self.apriori_sigma, X.shape[0])
+            # Draw from lognormal with E[apriori] = self.apriori and SD = self.apriori_sigma.
+            cov = self.apriori_sigma / self.apriori
+            sigma_log = np.sqrt(np.log1p(cov ** 2))
+            mu_log = np.log(self.apriori) - 0.5 * sigma_log ** 2
+            apriori = random_state.lognormal(mu_log, sigma_log, X.shape[0])
             apriori = apriori.reshape(X.shape[0], -1)[..., None, None]
             apriori = sample_weight * apriori
             apriori.kdims = X.kdims

--- a/chainladder/methods/tests/test_benktander.py
+++ b/chainladder/methods/tests/test_benktander.py
@@ -76,3 +76,36 @@ def test_odd_shaped_triangle():
     ult1 = cl.Benktander(apriori = 1,n_iters=10000).fit(cl.Development(average="volume").fit_transform(atr),sample_weight = atr.latest_diagonal).ultimate_.sum()
     ult2 = cl.Benktander(apriori = 1,n_iters=10000).fit(cl.Development(average="volume").fit_transform(tr),sample_weight = tr.latest_diagonal).ultimate_.grain("OYDQ").sum()
     assert abs(ult1 - ult2) < 1e-5
+
+
+def test_bf_apriori_sigma_is_lognormal():
+    """apriori_sigma must draw a strictly-positive lognormal apriori (issue #1143)."""
+    tri = cl.load_sample("genins")
+    boot = cl.BootstrapODPSample(n_sims=50000, random_state=42).fit_transform(tri)
+    w = boot.latest_diagonal.copy()
+    w.values = np.ones_like(w.values)   # sample_weight=1 -> expectation_ == raw multiplier
+
+    sigma = 0.8
+    bf = cl.BornhuetterFerguson(
+        apriori=1.0, apriori_sigma=sigma, random_state=7
+    ).fit(boot, sample_weight=w)
+
+    mult = np.nanmean(bf.expectation_.values[:, 0, :, 0], axis=1)
+    mult = mult[np.isfinite(mult)]
+
+    assert (mult > 0).all()                 # strictly positive -> lognormal, not normal
+    assert abs(mult.mean() - 1.0) < 0.02    # mean preserved (E = apriori)
+    assert abs(mult.std() - sigma) < 0.03   # SD preserved (== apriori_sigma)
+
+
+def test_capecod_apriori_sigma_is_positive():
+    """CapeCod scatters aprioris through the same sampler; must stay positive (#1143)."""
+    tri = cl.load_sample("genins")
+    boot = cl.BootstrapODPSample(n_sims=10000, random_state=42).fit_transform(tri)
+    premium = boot.latest_diagonal * 0 + 8e6
+
+    cc = cl.CapeCod(apriori_sigma=0.8, random_state=7).fit(boot, sample_weight=premium)
+
+    vals = cc.expectation_.values
+    vals = vals[np.isfinite(vals)]
+    assert (vals > 0).all()                 # ~10% would be negative under the old normal


### PR DESCRIPTION
## Summary of Changes  
Switches the stochastic apriori sampler in Benktander._get_benktander_aprioris from a normal to a lognormal distribution.

- Bug: aprioris were drawn with random_state.normal(apriori, apriori_sigma, …). This is producing negative expected ultimates — which are meaningless for a loss reserve.
- Fix: draw from a lognormal instead, parametrized by method-of-moments so the mean stays apriori and the SD stays apriori_sigma
- Scope: BornhuetterFerguson and CapeCod both subclass Benktander and route their apriori scatter through this same method, so the one-line fix covers all three stochastic-apriori methods.
- Tests: adds two regression tests in test_benktander.py:
  - test_bf_apriori_sigma_is_lognormal — asserts BF draws are strictly positive and the approximate equality of empirical mean = apriori and SD = apriori_sigma.
  - test_capecod_apriori_sigma_is_positive — asserts CapeCod aprioris stay positive (around 10% would be negative under the old normal draw).
  
Currently the fix assumes apriori > 0 but it may be worth adding a guard.

## Related GitHub Issue(s)  
Fixes #1143.

## Additional Context for Reviewers  

- [x] I passed tests locally for both code (`uv run pytest`) and documentation changes (`uv run jb build docs --builder=custom --custom-builder=doctest`)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes stochastic reserve math used by BF, Benktander, and CapeCod when apriori_sigma is set; deterministic paths (sigma=0) are unchanged.
> 
> **Overview**
> **Stochastic apriori draws** in `_get_benktander_aprioris` no longer use a normal distribution (which could yield negative loss expectations). They now use a **lognormal** draw with method-of-moments parameters so the mean stays `apriori` and the standard deviation stays `apriori_sigma`.
> 
> Because **BornhuetterFerguson** and **CapeCod** inherit Benktander and share this sampler, the behavior change applies to all three methods when `apriori_sigma != 0` (e.g. bootstrap workflows).
> 
> **Tests** add regression coverage: BF multipliers are strictly positive with approximate mean/SD matching `apriori` / `apriori_sigma`, and CapeCod `expectation_` values stay positive.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 69a84b669c9a5ee773130df8f6ffeca12ee02997. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->