### PR TITLE
Fix Triangle display crash when stored in a DataFrame cell (#142)

### DIFF
--- a/chainladder/core/dunders.py
+++ b/chainladder/core/dunders.py
@@ -290,6 +290,16 @@ class TriangleDunders:
     def __len__(self):
         return self.shape[0]
 
+    # A Triangle is a 4-D container, not a 1-D sequence. Without this, Python
+    # falls back to the legacy iteration protocol (repeatedly calling
+    # __getitem__(0), __getitem__(1), ...), which treats the integer as a
+    # column label and raises. That also makes libraries such as pandas
+    # misclassify a Triangle as a sequence (see is_sequence) and attempt to
+    # iterate it when formatting a Triangle stored in a DataFrame cell,
+    # crashing the display. Declaring the type non-iterable makes pandas fall
+    # back to str(triangle) and render the summary instead (GH #142).
+    __iter__ = None
+
     def __neg__(self):
         obj = self.copy()
         obj.values = -obj.values

--- a/chainladder/core/tests/test_display.py
+++ b/chainladder/core/tests/test_display.py
@@ -8,6 +8,7 @@ import pytest
 import sys
 
 
+from collections.abc import Iterable
 from chainladder.core.display import TriangleDisplay
 from lxml import etree, html as lxml_html
 from unittest import mock
@@ -257,6 +258,49 @@ def test_repr_format_semi_annual(prism: Triangle) -> None:
     semi = prism.grain("OSDM")
     df = semi._repr_format()
     assert any("H1" in str(i) or "H2" in str(i) for i in df.index)
+
+
+def test_triangle_not_iterable(raa: Triangle) -> None:
+    """
+    A Triangle is a 4-D container, not a 1-D sequence, so it must not be
+    iterable (GH #142). This prevents pandas from misclassifying it as a
+    sequence and iterating it while formatting a DataFrame cell.
+
+    Parameters
+    ----------
+    raa: Triangle
+        The raa sample data set.
+
+    Returns
+    -------
+    None
+
+    """
+    assert not isinstance(raa, Iterable)
+    with pytest.raises(TypeError):
+        iter(raa)
+
+
+def test_triangle_in_dataframe_cell_display(clrd: Triangle) -> None:
+    """
+    Storing a Triangle in a DataFrame cell and displaying the DataFrame must
+    not crash (GH #142).
+
+    Parameters
+    ----------
+    clrd: Triangle
+        The clrd sample data set.
+
+    Returns
+    -------
+    None
+
+    """
+    df = pd.DataFrame(data=[["clrd", clrd]], columns=["name", "cl_triangle"])
+    # Both the text and HTML representations previously raised because pandas
+    # iterated the Triangle stored in the cell.
+    assert isinstance(repr(df), str)
+    assert isinstance(df._repr_html_(), str)
 
 
 def test_heatmap_multi_raises(clrd: Triangle) -> None:


### PR DESCRIPTION
## Summary of Changes

storing a triangle in a dataframe cell used to crash the display (both text and html repr).

the triangle is a 4d container, but pandas' `is_sequence()` treated it as a 1d sequence. the legacy `__getitem__` iteration protocol plus `__len__` made `iter()` succeed, so pandas tried to iterate the triangle while formatting the cell. that hit `__getitem__(0)`, which reads the int as a column label and raises.

fix is to declare the triangle non-iterable with `__iter__ = None` in `core/dunders.py`. pandas then falls back to `str(triangle)` and renders the summary. nothing in the codebase iterates a triangle directly so it's safe, and `np.asarray()` still works.

added two regression tests in `core/tests/test_display.py`:
- `test_triangle_not_iterable`
- `test_triangle_in_dataframe_cell_display` (the exact case from the issue)

## Related GitHub Issue(s)

fixes #142

## Additional Context for Reviewers

no code iterated triangles directly, so making it non-iterable has no downstream impact. verified the exact repro from the issue works for `repr(df)`, `df._repr_html_()` and the individual cell, `np.asarray(tri)` still returns the full `(775, 6, 10, 10)` array, and all 39 display tests plus the full 515 core tests pass locally.

- [x] I passed tests locally for both code (`uv run pytest`) and documentation changes (`uv run jb build docs --builder=custom --custom-builder=doctest`)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small protocol change on Triangle display/iteration with no in-repo consumers that iterate Triangle directly; behavior change is limited to failing `iter(triangle)` where iteration was already incorrect.
> 
> **Overview**
> Fixes **GH #142** by setting **`__iter__ = None`** on `Triangle` in `core/dunders.py`, so Python no longer uses the legacy `__getitem__(0), …` iteration path (which misread indices as column labels and raised). Pandas then treats a cell `Triangle` as non-sequence and formats it via **`str`/`repr`** instead of iterating.
> 
> Adds **`test_triangle_not_iterable`** and **`test_triangle_in_dataframe_cell_display`** in `core/tests/test_display.py` to lock in `iter()` failure and safe `repr` / `_repr_html_` for DataFrames holding a `Triangle`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 418c1679c5174515ff85e4734d1a52c097a22edc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->