### PR TITLE
Sparse test fixture

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -57,12 +57,14 @@ def _sample_fixture(
     """
 
     # Set the backend to sparse for a sparse-only-run.
+    cl.options.set_option("AUTO_SPARSE", False)
     cl.options.set_option("ARRAY_BACKEND", "sparse" if request.param == "sparse_only_run" else "numpy")
     # Load the sample data.
     tri = cl.load_sample(sample)
     # Apply a transformation if supplied, then yield the triangle to the test.
     yield transform(tri) if transform else tri
     # After the test, reset the backend to default numpy.
+    cl.options.set_option("AUTO_SPARSE", True)
     cl.options.set_option("ARRAY_BACKEND", "numpy")
 
 

--- a/conftest.py
+++ b/conftest.py
@@ -28,7 +28,7 @@ def pytest_generate_tests(metafunc):
             "prism_dense", ["normal_run", "sparse_only_run"], indirect=True
         )
     if "prism" in metafunc.fixturenames:
-        metafunc.parametrize("prism", ["normal_run"], indirect=True)
+        metafunc.parametrize("prism", ["sparse_only_run"], indirect=True)
     if "xyz" in metafunc.fixturenames:
         metafunc.parametrize("xyz", ["normal_run", "sparse_only_run"], indirect=True)
 

--- a/conftest.py
+++ b/conftest.py
@@ -56,16 +56,12 @@ def _sample_fixture(
 
     """
 
-    # Set the backend to sparse for a sparse-only-run.
-    cl.options.set_option("AUTO_SPARSE", False)
-    cl.options.set_option("ARRAY_BACKEND", "sparse" if request.param == "sparse_only_run" else "numpy")
     # Load the sample data.
     tri = cl.load_sample(sample)
-    # Apply a transformation if supplied, then yield the triangle to the test.
-    yield transform(tri) if transform else tri
-    # After the test, reset the backend to default numpy.
-    cl.options.set_option("AUTO_SPARSE", True)
-    cl.options.set_option("ARRAY_BACKEND", "numpy")
+    # Apply a transformation if supplied
+    tri = transform(tri) if transform else tri
+    # Set the backend to sparse for a sparse-only-run, then yield the triangle to the test.
+    yield tri.set_backend("sparse" if request.param == "sparse_only_run" else "numpy")
 
 
 @pytest.fixture


### PR DESCRIPTION
## Summary of Changes  


## Related GitHub Issue(s)  


## Additional Context for Reviewers  


- [ ] I passed tests locally for both code (`uv run pytest`) and documentation changes (`uv run jb build docs --builder=custom --custom-builder=doctest`)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes affect only pytest configuration in `conftest.py`; no production code or runtime backend defaults are modified.
> 
> **Overview**
> **Test fixtures** now set the array backend on each sample `Triangle` via `set_backend` instead of toggling the global `ARRAY_BACKEND` option around each test, and no longer reset the option to numpy after yield.
> 
> The shared `_sample_fixture` still parametrizes most samples with both `normal_run` and `sparse_only_run`, but the **`prism`** fixture is limited to **`sparse_only_run`** only (replacing the previous numpy-only `normal_run` case).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b4da81b31ff809aec67d68c58a42fa29f58b477c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->