### PR TITLE
Sparse test fixture

### DIFF
--- a/chainladder/core/tests/test_triangle.py
+++ b/chainladder/core/tests/test_triangle.py
@@ -302,8 +302,7 @@ def test_dropna_latest_diagonal(raa: Triangle) -> None:
     None
     """
     t = raa.copy()
-    xp = t.get_array_module()
-    t.values[:, :, 0, :] = xp.nan
+    t.values[:, :, 0, :] = np.nan
     result = t.latest_diagonal.dropna()
     assert result.shape == (1, 1, 9, 1)
     assert result.origin.min().year == 1982

--- a/chainladder/core/tests/test_triangle.py
+++ b/chainladder/core/tests/test_triangle.py
@@ -164,8 +164,7 @@ def test_printer(raa):
 def test_value_order(clrd):
     a = clrd[["CumPaidLoss", "BulkLoss"]]
     b = clrd[["BulkLoss", "CumPaidLoss"]]
-    xp = a.get_array_module()
-    xp.testing.assert_array_equal(a.values[:, -1], b.values[:, 0])
+    assert a.iloc[:, -1] == b.iloc[:, 0]
 
 
 def test_trend(raa, atol):
@@ -303,7 +302,8 @@ def test_dropna_latest_diagonal(raa: Triangle) -> None:
     None
     """
     t = raa.copy()
-    t.values[:, :, 0, :] = np.nan
+    xp = t.get_array_module()
+    t.values[:, :, 0, :] = xp.nan
     result = t.latest_diagonal.dropna()
     assert result.shape == (1, 1, 9, 1)
     assert result.origin.min().year == 1982
@@ -436,7 +436,7 @@ def test_groupby_agg_auto_sparse(prism: Triangle) -> None:
     assert result_default == result_no_sparse
 
 
-def test_auto_sparse_disabled_returns_self(prism: Triangle) -> None:
+def test_auto_sparse_disabled_returns_self(prism_convert: Triangle) -> None:
     """
     When cl.options.AUTO_SPARSE is False, _auto_sparse() returns the triangle
     unchanged without switching backends.
@@ -450,7 +450,7 @@ def test_auto_sparse_disabled_returns_self(prism: Triangle) -> None:
     -------
     None
     """
-    dense = prism.set_backend("numpy")
+    dense = prism_convert.set_backend("numpy")
     cl.options.set_option("AUTO_SPARSE", False)
     try:
         result = dense._auto_sparse()

--- a/chainladder/development/learning.py
+++ b/chainladder/development/learning.py
@@ -250,12 +250,14 @@ class DevelopmentML(DevelopmentBase):
         return df
 
     def _prep_w_ml(self,X,sample_weight=None):
-        weight_base = (~np.isnan(X.values)).astype(float)
+        #scikit-learn requires a dense sample_weight
+        backend = "cupy" if X.array_backend == "cupy" else "numpy"
+        obj = X.set_backend(backend)
+        weight_base = (~np.isnan(obj.values)).astype(float)
         weight = weight_base.copy()
-        weight = weight * TriangleWeight(drop=self.drop,drop_valuation=self.drop_valuation).fit(X).w_.fillzero().values
+        weight = weight * TriangleWeight(drop=self.drop,drop_valuation=self.drop_valuation).fit(obj).w_.fillzero().values
         if sample_weight is not None:
-            weight = weight * sample_weight.values 
-        idx = np.where(weight_base.flatten()>0) if X.array_backend != 'sparse' else (weight_base.flatten()>0).coords[0]
+            weight = weight * sample_weight.set_backend(backend).values 
         return weight.flatten()[weight_base.flatten()>0]
 
     def fit(self, X, y=None, sample_weight=None):

--- a/chainladder/development/learning.py
+++ b/chainladder/development/learning.py
@@ -255,6 +255,7 @@ class DevelopmentML(DevelopmentBase):
         weight = weight * TriangleWeight(drop=self.drop,drop_valuation=self.drop_valuation).fit(X).w_.fillzero().values
         if sample_weight is not None:
             weight = weight * sample_weight.values 
+        idx = np.where(weight_base.flatten()>0) if X.array_backend != 'sparse' else (weight_base.flatten()>0).coords[0]
         return weight.flatten()[weight_base.flatten()>0]
 
     def fit(self, X, y=None, sample_weight=None):

--- a/chainladder/development/tests/test_development.py
+++ b/chainladder/development/tests/test_development.py
@@ -24,20 +24,21 @@ class _FutureDevelopment(cl.TriangleWeight):
         if hasattr(X,'age_to_age'):
             #following precedent _set_fit_groups() from DevelopmentBase
             backend = "numpy" if X.array_backend in ["sparse", "numpy"] else "cupy"
-            super().fit(X.set_backend(backend).incr_to_cum().age_to_age)
-            xp = X.get_array_module()
-            indices = X.values.shape[0]
-            columns = X.values.shape[1]
-            origins = X.age_to_age.values.shape[2]
-            reg_x = X.incr_to_cum().values[...,:origins,:-1]
-            reg_y = X.incr_to_cum().values[...,:origins,1:]
+            obj = X.set_backend(backend)
+            super().fit(obj.incr_to_cum().age_to_age)
+            xp = obj.get_array_module()
+            indices = obj.values.shape[0]
+            columns = obj.values.shape[1]
+            origins = obj.age_to_age.values.shape[2]
+            reg_x = obj.incr_to_cum().values[...,:origins,:-1]
+            reg_y = obj.incr_to_cum().values[...,:origins,1:]
             dev_len = reg_x.shape[3]
             average_param = self._cascade_param(dev_len, self.average, "volume")
             average_param = np.tile(average_param,(indices,columns,1,1))
             params = cl.WeightedRegression(axis=2, thru_orig=True, xp=xp).fit(
                 reg_x, reg_y, self.w_.values, average_param
             )
-            self.ldf_ = self.dev._param_property(X, params.slope_.swapaxes(2, 3), 0)
+            self.ldf_ = self.dev._param_property(obj, params.slope_.swapaxes(2, 3), 0)
         return self
     
 def test_full_slice(genins):

--- a/chainladder/development/tests/test_development.py
+++ b/chainladder/development/tests/test_development.py
@@ -22,7 +22,9 @@ class _FutureDevelopment(cl.TriangleWeight):
     
     def fit(self, X, y: None = None, sample_weight: None = None):
         if hasattr(X,'age_to_age'):
-            super().fit(X.incr_to_cum().age_to_age)
+            #following precedent _set_fit_groups() from DevelopmentBase
+            backend = "numpy" if X.array_backend in ["sparse", "numpy"] else "cupy"
+            super().fit(X.set_backend(backend).incr_to_cum().age_to_age)
             xp = X.get_array_module()
             indices = X.values.shape[0]
             columns = X.values.shape[1]

--- a/conftest.py
+++ b/conftest.py
@@ -57,12 +57,14 @@ def _sample_fixture(
     """
 
     # Set the backend to sparse for a sparse-only-run.
+    cl.options.set_option("AUTO_SPARSE", False)
     cl.options.set_option("ARRAY_BACKEND", "sparse" if request.param == "sparse_only_run" else "numpy")
     # Load the sample data.
     tri = cl.load_sample(sample)
     # Apply a transformation if supplied, then yield the triangle to the test.
     yield transform(tri) if transform else tri
     # After the test, reset the backend to default numpy.
+    cl.options.set_option("AUTO_SPARSE", True)
     cl.options.set_option("ARRAY_BACKEND", "numpy")
 
 

--- a/conftest.py
+++ b/conftest.py
@@ -23,6 +23,10 @@ def pytest_generate_tests(metafunc):
         metafunc.parametrize("clrd", ["normal_run", "sparse_only_run"], indirect=True)
     if "genins" in metafunc.fixturenames:
         metafunc.parametrize("genins", ["normal_run", "sparse_only_run"], indirect=True)
+    if "prism_convert" in metafunc.fixturenames:
+        metafunc.parametrize(
+            "prism_convert", ["normal_run", "sparse_only_run"], indirect=True
+        )
     if "prism_dense" in metafunc.fixturenames:
         metafunc.parametrize(
             "prism_dense", ["normal_run", "sparse_only_run"], indirect=True
@@ -88,6 +92,9 @@ def genins(request):
 def prism(request):
     yield from _sample_fixture(request, "prism")
 
+@pytest.fixture
+def prism_convert(request):
+    yield from _sample_fixture(request, "prism", transform=lambda t: t.iloc[:10000])
 
 @pytest.fixture
 def prism_dense(request):

--- a/conftest.py
+++ b/conftest.py
@@ -94,7 +94,7 @@ def prism(request):
 
 @pytest.fixture
 def prism_convert(request):
-    yield from _sample_fixture(request, "prism", transform=lambda t: t.iloc[:10000])
+    yield from _sample_fixture(request, "prism", transform=lambda t: t.iloc[:5000])
 
 @pytest.fixture
 def prism_dense(request):

--- a/conftest.py
+++ b/conftest.py
@@ -28,7 +28,7 @@ def pytest_generate_tests(metafunc):
             "prism_dense", ["normal_run", "sparse_only_run"], indirect=True
         )
     if "prism" in metafunc.fixturenames:
-        metafunc.parametrize("prism", ["normal_run"], indirect=True)
+        metafunc.parametrize("prism", ["sparse_only_run"], indirect=True)
     if "xyz" in metafunc.fixturenames:
         metafunc.parametrize("xyz", ["normal_run", "sparse_only_run"], indirect=True)
 

--- a/conftest.py
+++ b/conftest.py
@@ -56,16 +56,12 @@ def _sample_fixture(
 
     """
 
-    # Set the backend to sparse for a sparse-only-run.
-    cl.options.set_option("AUTO_SPARSE", False)
-    cl.options.set_option("ARRAY_BACKEND", "sparse" if request.param == "sparse_only_run" else "numpy")
     # Load the sample data.
     tri = cl.load_sample(sample)
-    # Apply a transformation if supplied, then yield the triangle to the test.
-    yield transform(tri) if transform else tri
-    # After the test, reset the backend to default numpy.
-    cl.options.set_option("AUTO_SPARSE", True)
-    cl.options.set_option("ARRAY_BACKEND", "numpy")
+    # Apply a transformation if supplied
+    tri = transform(tri) if transform else tri
+    # Set the backend to sparse for a sparse-only-run, then yield the triangle to the test.
+    yield tri.set_backend("sparse" if request.param == "sparse_only_run" else "numpy")
 
 
 @pytest.fixture


### PR DESCRIPTION
## Summary of Changes  


## Related GitHub Issue(s)  


## Additional Context for Reviewers  


- [ ] I passed tests locally for both code (`uv run pytest`) and documentation changes (`uv run jb build docs --builder=custom --custom-builder=doctest`)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are confined to pytest fixtures and test/ML prep paths for sparse backends; no production API changes beyond existing `set_backend` usage in development ML weight prep.
> 
> **Overview**
> Test fixtures now set **numpy vs sparse** with `Triangle.set_backend` on each sample triangle instead of toggling the global `ARRAY_BACKEND` option, and the default **`prism`** fixture runs only under the sparse parametrization. A new **`prism_convert`** fixture (first 5000 rows) replaces full **`prism`** in the `_auto_sparse` disabled test.
> 
> **DevelopmentML** `_prep_w_ml` and the **`_FutureDevelopment`** test helper temporarily move sparse (or cupy) triangles to **numpy/cupy** before building dense `sample_weight` arrays for scikit-learn and weighted regression.
> 
> `test_value_order` compares reordered columns via **`iloc`** equality instead of raw `values` array checks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 07cd3c37d8737a7ec0d6151f572ef7b932808b0c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->