### PR TITLE
remove dead backend-reset code in _prep_columns (#1045)

### DIFF
--- a/chainladder/core/dunders.py
+++ b/chainladder/core/dunders.py
@@ -111,8 +111,6 @@ class TriangleDunders:
         return x, y
 
     def _prep_columns(self, x, y):
-        x_backend, y_backend = x.array_backend, y.array_backend
-        
         if len(x.columns) == 1 and len(y.columns) > 1:
             x.vdims = y.vdims
         elif len(y.columns) == 1 and len(x.columns) > 1:
@@ -141,13 +139,7 @@ class TriangleDunders:
             # Ensure both triangles have the same column order
             x = x[new_x_cols]
             y = y[new_x_cols]
-        
-        # Reset backends only if they've changed
-        if x.array_backend != x_backend:
-            x = x.set_backend(x_backend, inplace=True)
-        if y.array_backend != y_backend:
-            y = y.set_backend(y_backend, inplace=True)
-        
+
         return x, y
 
     def _prep_origin_development(self, obj, other):


### PR DESCRIPTION
## Summary of Changes

removes dead code in `TriangleDunders._prep_columns()` in `dunders.py`. the method captured `x_backend, y_backend` at the top and had a trailing block that reset the backends "only if they've changed", but those branches are never reachable.

`_prep_columns` always runs after `_compatibility_check`, which calls `set_common_backend` to align both triangles to the same backend first. none of the ops inside `_prep_columns` (vdims assignment, reindex, column slicing) change the backend, checked with a monkey-patch on `set_backend` that never fires. so `x.array_backend != x_backend` and `y.array_backend != y_backend` are always false and the reset lines can't execute.

## Related GitHub Issue(s)

closes #1045

## Additional Context for Reviewers

behavior-preserving cleanup, no functional change. companion to #1044 / #1046 which removed similar dead code in `_prep_index`. all 48 tests in `chainladder/core/tests/test_arithmetic.py` pass locally.

- [x] I passed tests locally for both code (`uv run pytest`) and documentation changes (`uv run jb build docs --builder=custom --custom-builder=doctest`)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dead-code removal only in triangle arithmetic prep; no change to runtime behavior or security-sensitive paths.
> 
> **Overview**
> Removes unreachable backend bookkeeping from **`TriangleDunders._prep_columns`** in `dunders.py`.
> 
> The method no longer stores `x_backend` / `y_backend` at entry or calls **`set_backend`** at the end when backends “changed.” Triangle arithmetic already runs **`set_common_backend`** in **`_compatibility_check`** before **`_prep_columns`**, and column alignment (`vdims`, `reindex`, slicing) does not switch backends, so those reset branches never ran.
> 
> Behavior-preserving cleanup aligned with similar dead-code removal in **`_prep_index`** (#1044 / #1046).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d43f4a60f37f29e92cae1c9ec59731fc1c7e42ba. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->