### PR TITLE
Sparse fixture

### DIFF
--- a/chainladder/methods/mack.py
+++ b/chainladder/methods/mack.py
@@ -335,6 +335,7 @@ class MackChainladder(Chainladder):
 
     def _mack_recursion(self, est, X=None):
         obj = X.copy()
+        backend = X.array_backend
         xp = obj.get_array_module()
         risk_arr = xp.zeros((*X.shape[:3], 1))
         if est == "total_parameter_risk_":
@@ -343,14 +344,16 @@ class MackChainladder(Chainladder):
             future_std_err = (
                 X._full_triangle_ - X[X.valuation < X.valuation_date]
             ).iloc[:, :, :, : X.shape[3]] * X.std_err_.values
-            t1_t = xp.nan_to_num(future_std_err.sum("origin").values)
+            #sum applies auto_sparse, so backend needs to be forced
+            t1_t = xp.nan_to_num(future_std_err.sum("origin").set_backend(backend).values)
             obj.odims = obj.odims[0:1]
         else:
             nans = xp.nan_to_num(X.nan_triangle[None, None])
             nans = 1 - xp.concatenate((nans, xp.zeros((1, 1, X.shape[2], 1))), 3)
             full_tri = X._full_triangle_.values[..., : len(X.ddims)]
             if est == "parameter_risk_":
-                t1_t = xp.nan_to_num(full_tri) * obj.std_err_.values
+                #std_err_ is always numpy
+                t1_t = xp.nan_to_num(full_tri) * obj.std_err_.set_backend(backend).values
             else:
                 t1_t = xp.nan_to_num(full_tri) * self._get_full_std_err_(X).values
         extend = X.ldf_.shape[-1] - X.shape[-1] + 1
@@ -490,11 +493,12 @@ class MackChainladder(Chainladder):
         """
         # This might be better as a dataframe
         obj = self.ultimate_.copy()
+        backend = obj.array_backend
         cols = (
-            self.X_.latest_diagonal.values,
-            self.ibnr_.values,
-            self.ultimate_.values,
-            self.mack_std_err_.values[..., -1:],
+            self.X_.latest_diagonal.set_backend(backend).values,
+            self.ibnr_.set_backend(backend).values,
+            self.ultimate_.set_backend(backend).values,
+            self.mack_std_err_.set_backend(backend).values[..., -1:],
         )
         obj.values = obj.get_array_module().concatenate(cols, 3)
         obj.ddims = ["Latest", "IBNR", "Ultimate", "Mack Std Err"]

--- a/chainladder/methods/tests/test_capecod.py
+++ b/chainladder/methods/tests/test_capecod.py
@@ -35,7 +35,7 @@ def test_groupby(clrd):
 
 def test_capecod_zero_tri(raa):
     premium = raa.latest_diagonal * 0 + 50000
-    raa.loc[:,:,'1987',48] = 0
+    raa.at['Total','values','1987',48] = 0
     assert cl.CapeCod().fit(raa, sample_weight=premium).ultimate_.loc[:,:,'1987'].sum() > 0
 
 

--- a/chainladder/methods/tests/test_mack.py
+++ b/chainladder/methods/tests/test_mack.py
@@ -15,11 +15,10 @@ def test_mack_to_triangle():
         .summary_
     )
 
-def test_mack_malformed():
-    a  = cl.load_sample('raa')
-    b = a.iloc[:, :, :-1]
-    x = cl.MackChainladder().fit(a) 
-    y = cl.MackChainladder().fit(b)
+def test_mack_malformed(raa):
+    raa_alt = raa.copy().iloc[:, :, :-1]
+    x = cl.MackChainladder().fit(raa) 
+    y = cl.MackChainladder().fit(raa_alt)
     assert x.process_risk_.iloc[:,:,:-1] == y.process_risk_
 
 def test_multi_triangle_mack(clrd,atol):

--- a/conftest.py
+++ b/conftest.py
@@ -25,7 +25,7 @@ def pytest_generate_tests(metafunc):
         metafunc.parametrize("genins", ["normal_run", "sparse_only_run"], indirect=True)
     if "prism_convert" in metafunc.fixturenames:
         metafunc.parametrize(
-            "prism_convert", ["normal_run", "sparse_only_run"], indirect=True
+            "prism_convert", ["sparse_only_run"], indirect=True
         )
     if "prism_dense" in metafunc.fixturenames:
         metafunc.parametrize(
@@ -94,7 +94,7 @@ def prism(request):
 
 @pytest.fixture
 def prism_convert(request):
-    yield from _sample_fixture(request, "prism", transform=lambda t: t.iloc[:5000])
+    yield from _sample_fixture(request, "prism", transform=lambda t: t.iloc[:200])
 
 @pytest.fixture
 def prism_dense(request):


### PR DESCRIPTION
## Summary of Changes  


## Related GitHub Issue(s)  


## Additional Context for Reviewers  


- [ ] I passed tests locally for both code (`uv run pytest`) and documentation changes (`uv run jb build docs --builder=custom --custom-builder=doctest`)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes Mack reserve uncertainty math on sparse backends where backend mismatches could have produced wrong recursion inputs; test-only conftest changes reduce normal numpy coverage for some prism tests.
> 
> **Overview**
> **Mack on sparse triangles** now keeps intermediate arrays on the input triangle’s backend instead of letting `sum`/`std_err_` paths flip backends via auto-sparse. `_mack_recursion` and `summary_` call `set_backend(backend)` before pulling `.values` for `future_std_err.sum("origin")`, `std_err_`, and the summary columns.
> 
> **Tests and fixtures** run more work under sparse-only `prism`/`prism_convert` (smaller `prism_convert` slice), use the parametrized `raa` fixture in Mack malformed tests, and set a zero cell with `raa.at[...]` instead of `loc` for CapeCod zero-triangle coverage.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 06f01a67014e513da7855cb61acf569f0e355777. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->