### PR TITLE
Sparse fixture

### DIFF
--- a/chainladder/core/tests/test_grain.py
+++ b/chainladder/core/tests/test_grain.py
@@ -6,8 +6,8 @@ import pytest
 
 
 def test_grain(qtr):
+    #this is a dense only test, as grain() follows auto_sparse
     actual = qtr.iloc[0, 0].grain("OYDY")
-    xp = actual.get_array_module()
     nan = xp.nan
     expected = xp.array(
         [
@@ -25,7 +25,7 @@ def test_grain(qtr):
             [13, nan, nan, nan, nan, nan, nan, nan, nan, nan, nan, nan],
         ]
     )
-    xp.testing.assert_array_equal(actual.values[0, 0, :, :], expected)
+    np.testing.assert_array_equal(actual.values[0, 0, :, :], expected)
 
 
 def test_grain_returns_valid_tri(qtr):

--- a/chainladder/core/tests/test_grain.py
+++ b/chainladder/core/tests/test_grain.py
@@ -8,8 +8,8 @@ import pytest
 def test_grain(qtr):
     #this is a dense only test, as grain() follows auto_sparse
     actual = qtr.iloc[0, 0].grain("OYDY")
-    nan = xp.nan
-    expected = xp.array(
+    nan = np.nan
+    expected = np.array(
         [
             [44, 621, 950, 1020, 1070, 1069, 1089, 1094, 1097, 1099, 1100, 1100],
             [42, 541, 1052, 1169, 1238, 1249, 1266, 1269, 1296, 1300, 1300, nan],

--- a/chainladder/core/tests/test_triangle.py
+++ b/chainladder/core/tests/test_triangle.py
@@ -179,9 +179,7 @@ def test_shift(qtr):
 
 def test_quantile_vs_median(clrd):
     xp = clrd.get_array_module()
-    xp.testing.assert_array_equal(
-        clrd.quantile(q=0.5)["CumPaidLoss"].values, clrd.median()["CumPaidLoss"].values
-    )
+    assert clrd.quantile(q=0.5)["CumPaidLoss"] == clrd.median()["CumPaidLoss"]
 
 
 def test_base_minimum_exposure_triangle(raa):

--- a/chainladder/development/tests/test_development.py
+++ b/chainladder/development/tests/test_development.py
@@ -822,9 +822,8 @@ def test_pipeline(clrd):
 
 def test_pct_reported_and_unreported(raa):
     dev = cl.Development().fit(raa)
-    xp = dev.cdf_.get_array_module()
-    xp.testing.assert_array_equal(dev.pct_reported_.values, (1 / dev.cdf_).values)
-    xp.testing.assert_array_equal(dev.pct_unreported_.values, (1 - 1 / dev.cdf_).values)
+    np.testing.assert_array_equal(dev.pct_reported_.values, (1 / dev.cdf_).values)
+    np.testing.assert_array_equal(dev.pct_unreported_.values, (1 - 1 / dev.cdf_).values)
     # reported + unreported percentages sum to one where defined
     total = (dev.pct_reported_ + dev.pct_unreported_).values
     assert np.allclose(np.nan_to_num(total), np.nan_to_num(dev.cdf_.values * 0 + 1))

--- a/chainladder/methods/mack.py
+++ b/chainladder/methods/mack.py
@@ -335,6 +335,7 @@ class MackChainladder(Chainladder):
 
     def _mack_recursion(self, est, X=None):
         obj = X.copy()
+        backend = X.array_backend
         xp = obj.get_array_module()
         risk_arr = xp.zeros((*X.shape[:3], 1))
         if est == "total_parameter_risk_":
@@ -343,14 +344,16 @@ class MackChainladder(Chainladder):
             future_std_err = (
                 X._full_triangle_ - X[X.valuation < X.valuation_date]
             ).iloc[:, :, :, : X.shape[3]] * X.std_err_.values
-            t1_t = xp.nan_to_num(future_std_err.sum("origin").values)
+            #sum applies auto_sparse, so backend needs to be forced
+            t1_t = xp.nan_to_num(future_std_err.sum("origin").set_backend(backend).values)
             obj.odims = obj.odims[0:1]
         else:
             nans = xp.nan_to_num(X.nan_triangle[None, None])
             nans = 1 - xp.concatenate((nans, xp.zeros((1, 1, X.shape[2], 1))), 3)
             full_tri = X._full_triangle_.values[..., : len(X.ddims)]
             if est == "parameter_risk_":
-                t1_t = xp.nan_to_num(full_tri) * obj.std_err_.values
+                #std_err_ is always numpy
+                t1_t = xp.nan_to_num(full_tri) * obj.std_err_.set_backend(backend).values
             else:
                 t1_t = xp.nan_to_num(full_tri) * self._get_full_std_err_(X).values
         extend = X.ldf_.shape[-1] - X.shape[-1] + 1
@@ -490,11 +493,12 @@ class MackChainladder(Chainladder):
         """
         # This might be better as a dataframe
         obj = self.ultimate_.copy()
+        backend = obj.array_backend
         cols = (
-            self.X_.latest_diagonal.values,
-            self.ibnr_.values,
-            self.ultimate_.values,
-            self.mack_std_err_.values[..., -1:],
+            self.X_.latest_diagonal.set_backend(backend).values,
+            self.ibnr_.set_backend(backend).values,
+            self.ultimate_.set_backend(backend).values,
+            self.mack_std_err_.set_backend(backend).values[..., -1:],
         )
         obj.values = obj.get_array_module().concatenate(cols, 3)
         obj.ddims = ["Latest", "IBNR", "Ultimate", "Mack Std Err"]

--- a/chainladder/methods/tests/test_capecod.py
+++ b/chainladder/methods/tests/test_capecod.py
@@ -35,7 +35,7 @@ def test_groupby(clrd):
 
 def test_capecod_zero_tri(raa):
     premium = raa.latest_diagonal * 0 + 50000
-    raa.loc[:,:,'1987',48] = 0
+    raa.at['Total','values','1987',48] = 0
     assert cl.CapeCod().fit(raa, sample_weight=premium).ultimate_.loc[:,:,'1987'].sum() > 0
 
 

--- a/chainladder/methods/tests/test_mack.py
+++ b/chainladder/methods/tests/test_mack.py
@@ -15,11 +15,10 @@ def test_mack_to_triangle():
         .summary_
     )
 
-def test_mack_malformed():
-    a  = cl.load_sample('raa')
-    b = a.iloc[:, :, :-1]
-    x = cl.MackChainladder().fit(a) 
-    y = cl.MackChainladder().fit(b)
+def test_mack_malformed(raa):
+    raa_alt = raa.copy().iloc[:, :, :-1]
+    x = cl.MackChainladder().fit(raa) 
+    y = cl.MackChainladder().fit(raa_alt)
     assert x.process_risk_.iloc[:,:,:-1] == y.process_risk_
 
 def test_multi_triangle_mack(clrd,atol):

--- a/chainladder/utils/sparse.py
+++ b/chainladder/utils/sparse.py
@@ -33,7 +33,83 @@ def nansum(a, axis=None, keepdims=None, *args, **kwargs):
         axis=axis, keepdims=keepdims, *args, **kwargs
     )
 
+def nanquantile(a:COO, q:float, axis:int=0, keepdims:bool=False):
+    """
+    mimics np.nanquantile
 
+    Parameters
+    ----------
+    x : COO
+        input sparse array.
+    q : float
+        quantiles in [0, 1].
+    axis : int
+        Axis over which the quantile is applied.
+    keepdims : bool
+        Match NumPy keepdims behavior.
+
+    Returns
+    -------
+    out : COO
+        result cast back to COO for consistency.
+    """
+
+    # coordinates that survive the reduction
+    keep_axes = tuple(i for i in range(a.ndim) if i != axis)
+    keep_shape = tuple(a.shape[i] for i in keep_axes)
+
+    if not keep_axes:
+        out = np.nanquantile(a.data, q)
+        if keepdims:
+            out = np.asarray(out).reshape(
+                tuple(1 for _ in range(a.ndim))
+            )
+        return COO(out)
+
+    # map every stored value to an output location
+    keep_coords = a.coords[list(keep_axes)]
+    group_ids = np.ravel_multi_index(keep_coords, keep_shape)
+    
+    # sort by group
+    order = np.argsort(group_ids)
+    group_ids = group_ids[order]
+    values = a.data[order]
+
+    out = np.full(np.prod(keep_shape), np.nan)
+
+    starts = np.r_[0, np.flatnonzero(np.diff(group_ids)) + 1]
+    ends = np.r_[starts[1:], len(group_ids)]
+
+    for start, end in zip(starts, ends):
+        gid = group_ids[start]
+        out[gid] = np.nanquantile(values[start:end], q)
+
+    out = out.reshape(keep_shape)
+
+    if keepdims:
+        out = np.expand_dims(out,axis)
+
+    return COO(out)
+
+def nanmedian(a:COO, axis:int=0, keepdims:bool=False):
+    """
+    mimics np.nanmean
+
+    Parameters
+    ----------
+    x : COO
+        input sparse array.
+    axis : int
+        Axis over which the median is applied.
+    keepdims : bool
+        Match NumPy keepdims behavior.
+
+    Returns
+    -------
+    out : COO
+        result cast back to COO for consistency.
+    """
+    return nanquantile(a,0.5,axis,keepdims)
 
 def nanmean(a, axis=None, keepdims=None):
     n = nansum(a, axis=axis, keepdims=keepdims)
@@ -85,3 +161,5 @@ sp.cumprod = cumprod
 COO.cumprod = cumprod
 sp.nanmean = nanmean
 sp.sum = COO.sum
+sp.nanquantile = nanquantile
+sp.nanmedian = nanmedian

--- a/chainladder/utils/sparse.py
+++ b/chainladder/utils/sparse.py
@@ -15,13 +15,13 @@ sp.exp = np.exp
 sp.abs = np.abs
 
 
-def nan_to_num(a):
+def nan_to_num(a,nan=0.0):
     if type(a) in [int, float, np.int64, np.float64]:
         return np.nan_to_num(a)
     if hasattr(a, "fill_value"):
         a = a.copy()
-        a.data[np.isnan(a.data)] = 0.0
-    return COO(coords=a.coords, data=a.data, fill_value=0.0, shape=a.shape)
+        a.data[np.isnan(a.data)] = nan
+    return COO(coords=a.coords, data=a.data, fill_value=nan, shape=a.shape)
 
 
 def ones(*args, **kwargs):

--- a/chainladder/utils/tests/test_utilities.py
+++ b/chainladder/utils/tests/test_utilities.py
@@ -61,11 +61,11 @@ class _FakeDaskBag:
 def test_triangle_json_io(clrd):
     xp = clrd.get_array_module()
     clrd2 = cl.read_json(clrd.to_json(), array_backend=clrd.array_backend)
-    xp.testing.assert_array_equal(clrd.values, clrd2.values)
-    xp.testing.assert_array_equal(clrd.kdims, clrd2.kdims)
-    xp.testing.assert_array_equal(clrd.vdims, clrd2.vdims)
-    xp.testing.assert_array_equal(clrd.odims, clrd2.odims)
-    xp.testing.assert_array_equal(clrd.ddims, clrd2.ddims)
+    assert clrd == clrd2
+    assert np.all(clrd.kdims == clrd2.kdims)
+    assert np.all(clrd.vdims == clrd2.vdims)
+    assert np.all(clrd.odims == clrd2.odims)
+    assert np.all(clrd.ddims == clrd2.ddims)
     assert np.all(clrd.valuation == clrd2.valuation)
 
 
@@ -222,16 +222,20 @@ def test_to_pickle_read_pickle(raa):
         os.remove(path)
 
 
-def test_maximum(raa):
+def test_maximum_minimum_1(raa):
     ult_vol = cl.Chainladder().fit(
         cl.Development(average="volume").fit_transform(raa)
     ).ultimate_
     ult_sim = cl.Chainladder().fit(
         cl.Development(average="simple").fit_transform(raa)
     ).ultimate_
-    high_side = cl.maximum(ult_vol, ult_sim)
+    high_side = maximum(ult_vol, ult_sim)
+    low_side = minimum(ult_vol, ult_sim)
     np.testing.assert_array_almost_equal(
         high_side.values, np.maximum(ult_vol.values, ult_sim.values)
+    )
+    np.testing.assert_array_almost_equal(
+        low_side.values, np.minimum(ult_vol.values, ult_sim.values)
     )
 
 
@@ -596,7 +600,7 @@ def test_concat_axis1_duplicate_columns(raa: Triangle) -> None:
         cl.concat([raa, raa], axis=1)
 
 
-def test_maximum(raa: Triangle) -> None:
+def test_maximum_2(raa: Triangle) -> None:
     """
     Run cl.maximum(raa, 5000) and check if each element in the resulting triangle is at least 5000.
 
@@ -615,7 +619,7 @@ def test_maximum(raa: Triangle) -> None:
     assert xp.all(xp.nan_to_num(result.values, nan=5000) >= 5000)
 
 
-def test_minimum(raa):
+def test_minimum_2(raa):
     """
     Run cl.minimum(raa, 5000) and check if each element in the resulting triangle is at most 5000.
 

--- a/conftest.py
+++ b/conftest.py
@@ -25,7 +25,7 @@ def pytest_generate_tests(metafunc):
         metafunc.parametrize("genins", ["normal_run", "sparse_only_run"], indirect=True)
     if "prism_convert" in metafunc.fixturenames:
         metafunc.parametrize(
-            "prism_convert", ["normal_run", "sparse_only_run"], indirect=True
+            "prism_convert", ["sparse_only_run"], indirect=True
         )
     if "prism_dense" in metafunc.fixturenames:
         metafunc.parametrize(
@@ -94,7 +94,7 @@ def prism(request):
 
 @pytest.fixture
 def prism_convert(request):
-    yield from _sample_fixture(request, "prism", transform=lambda t: t.iloc[:5000])
+    yield from _sample_fixture(request, "prism", transform=lambda t: t.iloc[:200])
 
 @pytest.fixture
 def prism_dense(request):


### PR DESCRIPTION
## Summary of Changes  


## Related GitHub Issue(s)  


## Additional Context for Reviewers  


- [ ] I passed tests locally for both code (`uv run pytest`) and documentation changes (`uv run jb build docs --builder=custom --custom-builder=doctest`)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes Mack recursion and sparse statistical reductions used in production paths; risk is moderate due to backend-mixing fixes and new sparse quantile logic, mitigated by broad parametrized tests.
> 
> **Overview**
> Extends **sparse** test coverage by running many fixtures under both `numpy` and `sparse` backends (`sparse_only_run` in `conftest`), while **prism** and **prism_convert** run only on sparse to keep CI tractable; **prism_convert** is trimmed to 200 rows instead of 5000.
> 
> Adds **`nanquantile`** / **`nanmedian`** (and a configurable **`nan_to_num`**) on sparse COO arrays so median/quantile paths work when triangles stay sparse. **`MackChainladder`** now **`set_backend`** on operands before sums and **`summary_`** concatenation so reductions that trigger **auto_sparse** do not mix backends with **`std_err_`** (numpy) and sparse triangles.
> 
> Tests are adjusted to use **`np.testing`**, **Triangle equality**, or **`at`** assignment where backend-agnostic checks are enough; **`test_grain`** is documented as dense-only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7003aee69479045706e3f638cd425e4133eb72df. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->