### PR TITLE
Allow Triangle.drop() to drop origin levels

### DIFF
--- a/chainladder/core/pandas.py
+++ b/chainladder/core/pandas.py
@@ -682,6 +682,42 @@ class TrianglePandas(_TrianglePandasBase):
             ['1988', '1989', '1990']
             ['1987', '1988', '1989']
 
+        Dropping an origin period also trims any development periods that are
+        left entirely NaN, so the triangle is trimmed rather than left with
+        empty development columns.
+
+        .. testcode::
+
+            tri = cl.Triangle(
+                data={
+                    'origin': [1985, 1985, 1985, 1986, 1986, 1987],
+                    'development': [1985, 1986, 1987, 1986, 1987, 1987],
+                    'paid': [300, 400, 500, 500, 600, 500],
+                },
+                origin='origin',
+                development='development',
+                columns=['paid'],
+                cumulative=True
+            )
+            print(tri)
+
+        .. testoutput::
+
+                     12     24     36
+            1985  300.0  400.0  500.0
+            1986  500.0  600.0    NaN
+            1987  500.0    NaN    NaN
+
+        .. testcode::
+
+            print(tri.drop(origin='1985'))
+
+        .. testoutput::
+
+                     12     24
+            1986  500.0  600.0
+            1987  500.0    NaN
+
         """
         alternatives = {0: index, 1: columns, 2: origin, 3: development}
         if any(value is not None for value in alternatives.values()):
@@ -725,6 +761,24 @@ class TrianglePandas(_TrianglePandasBase):
                         "dropping an interior origin period would leave a gap."
                     )
                 result = result[keep]
+                # Trim any development periods that were left entirely NaN by
+                # the origin drop, so dropping origins trims the triangle
+                # rather than leaving empty development columns behind. This is
+                # what makes origin dropping more useful than plain 4D slicing
+                # (gh-1055).
+                if result.shape[-1] > 1:
+                    xp = result.get_array_module()
+                    agg = result.sum(axis=0).sum(axis=1)
+                    dev_has_data = list(
+                        (xp.nansum(agg.values[0, 0, :], -2) != 0).astype("int")
+                    )
+                    dev_labels = agg.development[
+                        pd.Series(dev_has_data).astype(bool)
+                    ]
+                    result = result[
+                        (result.development >= dev_labels.min())
+                        & (result.development <= dev_labels.max())
+                    ]
             else:
                 raise NotImplementedError(
                     "Triangle.drop() only implemented for the column and "

--- a/chainladder/core/pandas.py
+++ b/chainladder/core/pandas.py
@@ -698,7 +698,9 @@ class TrianglePandas(_TrianglePandasBase):
         result = self
         for ax, ax_labels in to_drop.items():
             ax_labels = (
-                [ax_labels] if np.isscalar(ax_labels) else list(ax_labels)
+                list(ax_labels)
+                if ax_labels is None or pd.api.types.is_list_like(ax_labels)
+                else [ax_labels]
             )
             if ax == 1:
                 result = result[

--- a/chainladder/core/pandas.py
+++ b/chainladder/core/pandas.py
@@ -668,6 +668,20 @@ class TrianglePandas(_TrianglePandasBase):
 
             ['BulkLoss', 'EarnedPremDIR', 'EarnedPremCeded', 'EarnedPremNet']
 
+        Origin periods can be dropped with ``origin`` (or ``axis=2``), but only
+        the first or last period may be removed so the triangle stays contiguous.
+
+        .. testcode::
+
+            raa = cl.load_sample('raa')
+            print(raa.origin.astype(str).tolist()[-3:])
+            print(raa.drop(origin='1990').origin.astype(str).tolist()[-3:])
+
+        .. testoutput::
+
+            ['1988', '1989', '1990']
+            ['1987', '1988', '1989']
+
         """
         alternatives = {0: index, 1: columns, 2: origin, 3: development}
         if any(value is not None for value in alternatives.values()):
@@ -690,9 +704,29 @@ class TrianglePandas(_TrianglePandasBase):
                 result = result[
                     [item for item in result.columns if item not in ax_labels]
                 ]
+            elif ax == 2:
+                origin_labels = np.array(result.origin.astype(str))
+                drop_labels = [str(label) for label in ax_labels]
+                missing = [
+                    label for label in drop_labels if label not in origin_labels
+                ]
+                if missing:
+                    raise KeyError(f"{missing} not found in the origin axis.")
+                keep = ~np.isin(origin_labels, drop_labels)
+                kept_positions = np.flatnonzero(keep)
+                if len(kept_positions) and not np.array_equal(
+                    kept_positions,
+                    np.arange(kept_positions[0], kept_positions[-1] + 1),
+                ):
+                    raise ValueError(
+                        "Only the first or last origin periods may be dropped; "
+                        "dropping an interior origin period would leave a gap."
+                    )
+                result = result[keep]
             else:
                 raise NotImplementedError(
-                    "Triangle.drop() only implemented for column axis."
+                    "Triangle.drop() only implemented for the column and "
+                    "origin axes."
                 )
         return result
 

--- a/chainladder/core/tests/test_triangle.py
+++ b/chainladder/core/tests/test_triangle.py
@@ -360,11 +360,9 @@ def test_drop_labels_and_alternative_raises(clrd):
 
 
 def test_drop_index_origin_development_alternatives_raise(clrd):
-    """index/origin/development alternatives route to unimplemented axes."""
+    """index/development alternatives route to unimplemented axes."""
     with pytest.raises(NotImplementedError):
         clrd.drop(index="commauto")
-    with pytest.raises(NotImplementedError):
-        clrd.drop(origin="1995")
     with pytest.raises(NotImplementedError):
         clrd.drop(development="12")
 
@@ -382,6 +380,52 @@ def test_drop_columns_alternative_index_like(clrd):
     assert all(label not in result.columns for label in labels)
     assert result == clrd.drop(columns=list(labels))
     assert result == clrd.drop(columns=labels.values)
+
+
+@pytest.fixture
+def origin_tri():
+    return cl.Triangle(
+        data={
+            "origin": [1985, 1985, 1985, 1986, 1986, 1987],
+            "development": [1985, 1986, 1987, 1986, 1987, 1987],
+            "paid": [300, 400, 500, 500, 600, 500],
+        },
+        origin="origin",
+        development="development",
+        columns=["paid"],
+        cumulative=True,
+    )
+
+
+def test_drop_origin_last(origin_tri):
+    """origin= should drop the last origin period."""
+    result = origin_tri.drop(origin="1987")
+    assert result.origin.astype(str).tolist() == ["1985", "1986"]
+
+
+def test_drop_origin_first(origin_tri):
+    """origin= should drop the first origin period."""
+    result = origin_tri.drop(origin="1985")
+    assert result.origin.astype(str).tolist() == ["1986", "1987"]
+
+
+def test_drop_origin_axis_equivalents(origin_tri):
+    """labels + axis=2/'origin' should equal the origin= alternative."""
+    expected = origin_tri.drop(origin="1987")
+    assert expected == origin_tri.drop(labels="1987", axis=2)
+    assert expected == origin_tri.drop(labels="1987", axis="origin")
+
+
+def test_drop_origin_interior_raises(origin_tri):
+    """Dropping an interior origin period should raise ValueError."""
+    with pytest.raises(ValueError):
+        origin_tri.drop(origin="1986")
+
+
+def test_drop_origin_missing_raises(origin_tri):
+    """Dropping an origin label that does not exist should raise KeyError."""
+    with pytest.raises(KeyError):
+        origin_tri.drop(origin="1999")
 
 
 def test_exposure_tri():

--- a/chainladder/core/tests/test_triangle.py
+++ b/chainladder/core/tests/test_triangle.py
@@ -401,12 +401,32 @@ def test_drop_origin_last(origin_tri):
     """origin= should drop the last origin period."""
     result = origin_tri.drop(origin="1987")
     assert result.origin.astype(str).tolist() == ["1985", "1986"]
+    # The oldest origin (1985) still populates the latest development period,
+    # so nothing should be trimmed off the development axis.
+    assert result.development.tolist() == origin_tri.development.tolist()
 
 
 def test_drop_origin_first(origin_tri):
     """origin= should drop the first origin period."""
     result = origin_tri.drop(origin="1985")
     assert result.origin.astype(str).tolist() == ["1986", "1987"]
+
+
+def test_drop_origin_trims_empty_development(origin_tri):
+    """Dropping an origin should trim development periods left all NaN."""
+    # Dropping the oldest origin (1985) empties the latest development period,
+    # which should be trimmed automatically (gh-1055).
+    result = origin_tri.drop(origin="1985")
+    assert result.development.tolist() == origin_tri.development.tolist()[:-1]
+    assert result.shape[-1] == origin_tri.shape[-1] - 1
+
+
+def test_drop_origin_keeps_populated_development(origin_tri):
+    """Dropping an origin should keep development periods that still have data."""
+    # Dropping the newest origin (1987) leaves every development period
+    # populated, so the development axis should be unchanged.
+    result = origin_tri.drop(origin="1987")
+    assert result.development.tolist() == origin_tri.development.tolist()
 
 
 def test_drop_origin_axis_equivalents(origin_tri):

--- a/chainladder/core/tests/test_triangle.py
+++ b/chainladder/core/tests/test_triangle.py
@@ -428,6 +428,12 @@ def test_drop_origin_missing_raises(origin_tri):
         origin_tri.drop(origin="1999")
 
 
+def test_drop_origin_period_label(origin_tri):
+    """origin= should accept a pd.Period, the origin axis's native label type."""
+    result = origin_tri.drop(origin=origin_tri.origin[-1])
+    assert result.origin.astype(str).tolist() == ["1985", "1986"]
+
+
 def test_exposure_tri():
     x = cl.load_sample("auto")
     x = x[x.development == 12]


### PR DESCRIPTION
## summary of changes

adds origin-level dropping to `Triangle.drop()` via `origin=` or `axis=2` / `axis='origin'`, building on #1131.

- `tri.drop(origin='1990')` and `tri.drop(labels='1990', axis=2)` are equivalent
- only the first or last origin period(s) can be dropped, interior drops raise `ValueError`
- dropping an origin also trims any dev periods left entirely NaN, so it trims the triangle instead of leaving empty dev columns
- unknown origin labels raise `KeyError`
- added tests and doctest examples covering the above

## related github issue(s)

closes #1055, part of #1052

## additional context for reviewers

- the origin / `axis=2` path from #1131 used to raise `NotImplementedError`, now implemented. updated that test to only assert it for the still-unimplemented index and development axes
- dev-trimming reuses the same all-NaN edge detection as `dropna()`. if every dev period still has data (e.g. dropping the latest origin), the dev axis is left alone
- development-axis dropping (#1057) is a planned follow-up

- [x] i passed tests locally for code (`pytest`)