### PR TITLE
Using uv for docs & adding automated docs generating in PR

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -6,5 +6,5 @@
 
 ## Additional Context for Reviewers  
 
-
-- [ ] I passed tests locally for both code (`uv run pytest`) and documentation changes (`uv run jb build docs --builder=custom --custom-builder=doctest`)
+## Checklist
+- [ ] I passed tests locally for both code (`uv run pytest`) and documentation changes (`uv run --directory docs jb build . --builder=custom --custom-builder=doctest`)

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -6,5 +6,10 @@
 
 ## Additional Context for Reviewers  
 
+
+
+
+<!-- Do not edit anything below this. -->
+
 ## Checklist
 - [ ] I passed tests locally for both code (`uv run pytest`) and documentation changes (`uv run --directory docs jb build . --builder=custom --custom-builder=doctest`)

--- a/docs/README.md
+++ b/docs/README.md
@@ -9,9 +9,8 @@ If you only want to read the docs, use the published site. This README is for co
 From the repository root:
 
 ```bash
-pip install -e .[docs]
-cd docs
-jb build .
+uv sync --extra docs
+uv run --directory docs jb build .
 ```
 
 The rendered site is written to `docs/_build/html/`. Open `docs/_build/html/index.html` in a browser to review changes.

--- a/docs/intro.md
+++ b/docs/intro.md
@@ -1,6 +1,6 @@
 # {octicon}`home` Welcome
 
-Hello and welcome! NEW MESSAGE TEST! 2
+Hello and welcome! NEW MESSAGE TEST! 3
 
 The `chainladder-python` package was built to be able to handle all of your actuarial reserving needs in python. It consists of popular actuarial tools, such as **triangle data manipulation**, **link ratios calculation**, and **IBNR estimates** using both deterministic and stochastic models. We build this package so you no longer have to rely on outdated softwares and tools when performing actuarial pricing or reserving indications.
 

--- a/docs/intro.md
+++ b/docs/intro.md
@@ -1,6 +1,6 @@
 # {octicon}`home` Welcome
 
-Hello and welcome! NEW MESSAGE TEST!
+Hello and welcome! NEW MESSAGE TEST! 2
 
 The `chainladder-python` package was built to be able to handle all of your actuarial reserving needs in python. It consists of popular actuarial tools, such as **triangle data manipulation**, **link ratios calculation**, and **IBNR estimates** using both deterministic and stochastic models. We build this package so you no longer have to rely on outdated softwares and tools when performing actuarial pricing or reserving indications.
 

--- a/docs/intro.md
+++ b/docs/intro.md
@@ -1,6 +1,6 @@
 # {octicon}`home` Welcome
 
-Hello and welcome!
+Hello and welcome! NEW MESSAGE TEST!
 
 The `chainladder-python` package was built to be able to handle all of your actuarial reserving needs in python. It consists of popular actuarial tools, such as **triangle data manipulation**, **link ratios calculation**, and **IBNR estimates** using both deterministic and stochastic models. We build this package so you no longer have to rely on outdated softwares and tools when performing actuarial pricing or reserving indications.
 

--- a/docs/intro.md
+++ b/docs/intro.md
@@ -1,6 +1,6 @@
 # {octicon}`home` Welcome
 
-Hello and welcome! NEW MESSAGE TEST! 3
+Hello and welcome!
 
 The `chainladder-python` package was built to be able to handle all of your actuarial reserving needs in python. It consists of popular actuarial tools, such as **triangle data manipulation**, **link ratios calculation**, and **IBNR estimates** using both deterministic and stochastic models. We build this package so you no longer have to rely on outdated softwares and tools when performing actuarial pricing or reserving indications.
 

--- a/readthedocs.yaml
+++ b/readthedocs.yaml
@@ -16,5 +16,5 @@ python:
   install:
     - method: uv
       command: sync
-      groups:
+      extras:
         - docs

--- a/readthedocs.yaml
+++ b/readthedocs.yaml
@@ -14,7 +14,7 @@ build:
 
 python:
   install:
-    - method: pip
-      path: .
-      extra_requirements:
+    - method: uv
+      command: sync
+      extras:
         - docs

--- a/readthedocs.yaml
+++ b/readthedocs.yaml
@@ -16,5 +16,5 @@ python:
   install:
     - method: uv
       command: sync
-      extras:
+      groups:
         - docs


### PR DESCRIPTION
## Summary of Changes  

- Migrate RTC to use uv (#976)
- There's no code changes on GitHub to address #1151, it's all done on the RTC admin. It's basically setting up a new webhook. See the automated check below, there's no a new "docs/readthedocs.org:chainladder-python" build. (#1151)

## Related GitHub Issue(s)  
Closes #976 
Closes #1151

## Additional Context for Reviewers  
The [new doc site](https://chainladder-python--1171.org.readthedocs.build/1171/intro.html) built this way doesn't seem to have the double search or pancake icon bugs

- [ ] I passed tests locally for both code (`uv run pytest`) and documentation changes (`uv run jb build docs --builder=custom --custom-builder=doctest`)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Tooling-only changes to docs build and RTC install; no application or library runtime code is modified.
> 
> **Overview**
> **Docs and CI workflow** now use **uv** instead of **pip** for installing the project with the `docs` extra and running Jupyter Book builds.
> 
> On **Read the Docs**, `readthedocs.yaml` replaces `pip install` with `uv sync` and the `docs` extra. **Contributor docs** in `docs/README.md` show `uv sync --extra docs` and `uv run --directory docs jb build .` from the repo root. The **PR template** checklist matches that path and adds a “do not edit below” section so the checklist stays consistent.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a6fc39e6c2a033803f3fe1d9e7f28e9981c7f8a9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->