### PR TITLE
[DOC] fixing link in user_guide/index & fixing section heading in triangle.py

### DIFF
--- a/chainladder/core/triangle.py
+++ b/chainladder/core/triangle.py
@@ -396,6 +396,7 @@ class Triangle(TriangleBase):
 
     .. testcode::
 
+        import pandas as pd
         df = pd.DataFrame(
             data={
                 'origin': pd.to_datetime(['1981-01-01', '1982-01-01']),

--- a/chainladder/core/triangle.py
+++ b/chainladder/core/triangle.py
@@ -350,8 +350,10 @@ class Triangle(TriangleBase):
         2024Q3   160.0
         2024Q4   140.0
 
-    Triangles with ultimate values
-    ------------------------------
+    Notes
+    -----
+
+    **Triangles with ultimate values**
 
     Triangles produced by reserving methods carry ultimate projections at the
     sentinel valuation date ``options.ULT_VAL`` (default December 31, 2261).

--- a/docs/user_guide/index.md
+++ b/docs/user_guide/index.md
@@ -18,7 +18,7 @@ Data object to manage and manipulate reserving data
 ```{image} ../images/plot_triangle_from_pandas.png
 ```
 +++
-**Classes**: **{py:class}`chainladder.Triangle`**, ...
+**Classes**: {ref}`Triangle <triangle:triangle>`, …
 ````
 
 ````{grid-item-card}

--- a/docs/user_guide/index.md
+++ b/docs/user_guide/index.md
@@ -18,7 +18,7 @@ Data object to manage and manipulate reserving data
 ```{image} ../images/plot_triangle_from_pandas.png
 ```
 +++
-**Classes**: {ref}`Triangle <triangle:triangle>`, …
+**Classes**: {ref}`Triangle <triangle>`, …
 ````
 
 ````{grid-item-card}

--- a/docs/user_guide/index.md
+++ b/docs/user_guide/index.md
@@ -18,7 +18,7 @@ Data object to manage and manipulate reserving data
 ```{image} ../images/plot_triangle_from_pandas.png
 ```
 +++
-**Classes**: {ref}`Triangle <triangle>`, …
+**Classes**: {ref}`Triangle <triangle:structure>`, …
 ````
 
 ````{grid-item-card}


### PR DESCRIPTION
## Summary of Changes  
updating a link in the user guide index
updating an unrecognized numpydoc section in `triangle.py` 

but mostly to test out the new rtd webhook

## Related GitHub Issue(s)  


## Additional Context for Reviewers  
see [here](https://chainladder-python--1175.org.readthedocs.build/1175/user_guide/index.html)

- [X] I passed tests locally for both code (`uv run pytest`) and documentation changes (`uv run jb build docs --builder=custom --custom-builder=doctest`)



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Doc and doctest markup only; no runtime or API behavior changes.
> 
> **Overview**
> Documentation-only updates for Sphinx/Read the Docs.
> 
> In **`triangle.py`**, the ultimate-values narrative is moved under a proper **Notes** section (replacing a heading style numpydoc did not recognize). The ultimate-values subsection is labeled with bold text, and the long-format ultimate example doctest now includes **`import pandas as pd`**.
> 
> On the **user guide index**, the Triangles card **Classes** line switches from a broken **`py:class`** reference to a Sphinx **`{ref}`** to **`triangle:structure`**, matching how other cards link to doc sections.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 692453c91c394e375f7c5f5363061203899e0ea4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->