### PR TITLE
Loc setter

### DIFF
--- a/chainladder/core/slice.py
+++ b/chainladder/core/slice.py
@@ -367,7 +367,7 @@ class Location(_LocBase):
         # Case scalar, locate position in first level of index.
         else:
             idx = np.where(self.obj.kdims[:, 0]==key)[0]
-        return _LocBase._contig_slice(idx)
+        return idx
 
     def other_key(
             self,
@@ -402,7 +402,7 @@ class Location(_LocBase):
         if type(key) in [slice, list]:
             return obj_idx.loc[key].values
         if not hasattr(key, '__iter__') or type(key) is str:
-            return _LocBase._contig_slice(np.array([obj_idx.loc[key]]))
+            return np.array([obj_idx.loc[key]])
         else:
             raise AttributeError("Unable to slice.")
 
@@ -431,7 +431,9 @@ class Location(_LocBase):
         return out
 
     def __setitem__(self, key: _LabelKey, values: int | float | TriangleSlicer) -> None:
-        super().__setitem__(cast(tuple[_AxisKey, _AxisKey, _AxisKey, _AxisKey], self.key_to_slice(key)), values)
+        raw_slice = self.key_to_slice(key)
+        contig_slice = [_LocBase._contig_slice(x) for x in raw_slice]
+        super().__setitem__(cast(tuple[_AxisKey, _AxisKey, _AxisKey, _AxisKey], contig_slice), values)
 
 class Ilocation(_LocBase):
     """

--- a/chainladder/core/slice.py
+++ b/chainladder/core/slice.py
@@ -367,7 +367,7 @@ class Location(_LocBase):
         # Case scalar, locate position in first level of index.
         else:
             idx = np.where(self.obj.kdims[:, 0]==key)[0]
-        return idx
+        return _LocBase._contig_slice(idx)
 
     def other_key(
             self,
@@ -402,7 +402,7 @@ class Location(_LocBase):
         if type(key) in [slice, list]:
             return obj_idx.loc[key].values
         if not hasattr(key, '__iter__') or type(key) is str:
-            return np.array([obj_idx.loc[key]])
+            return _LocBase._contig_slice(np.array([obj_idx.loc[key]]))
         else:
             raise AttributeError("Unable to slice.")
 

--- a/chainladder/core/slice.py
+++ b/chainladder/core/slice.py
@@ -154,7 +154,14 @@ class _LocBase:
         key = tuple(
             [slice(item, item + 1) if isinstance(item, int) else item for item in key]
         )
-        cast(np.ndarray, cast(object, self.obj.values)).__setitem__(self._normalize_index(key), values)
+        norm_key = self._normalize_index(key)
+        if type(norm_key[2]) != slice or type(norm_key[3]) != slice:
+            raise ValueError("Setting while fancy indexing on origin/development is not supported.")
+        if type(norm_key[0]) is slice or type(norm_key[1]) is slice:
+            cast(np.ndarray, cast(object, self.obj.values)).__setitem__(norm_key, values)    
+        else:
+            #the getter uses arr[idx,:][:,idx] to get the Cartesian product, using np.ix_ on the setter to match
+            cast(np.ndarray, cast(object, self.obj.values)).__setitem__(np.ix_(norm_key[0], norm_key[1])+(norm_key[2], norm_key[3]), values)
 
     def _normalize_index(self, key: IndexExpression) -> tuple[_AxisKey, _AxisKey, _AxisKey, _AxisKey]:
         """
@@ -431,7 +438,23 @@ class Location(_LocBase):
         return out
 
     def __setitem__(self, key: _LabelKey, values: int | float | TriangleSlicer) -> None:
+        """
+        Supports the .loc[] for setting Triangle values. Only supported for numpy backend.
+
+        Parameters
+        ----------
+        key: _LabelKey
+            Indicates the location of the Triangle you want to set values for.
+        values: int | float | TriangleSlicer
+            The value(s) you want to assign to the slice of the Triangle.
+
+        Returns
+        -------
+        None
+
+        """
         raw_slice = self.key_to_slice(key)
+        # _LocBase expects key to be contiguous if possible
         contig_slice = [_LocBase._contig_slice(x) for x in raw_slice]
         super().__setitem__(cast(tuple[_AxisKey, _AxisKey, _AxisKey, _AxisKey], contig_slice), values)
 

--- a/chainladder/core/tests/test_slicing.py
+++ b/chainladder/core/tests/test_slicing.py
@@ -273,7 +273,29 @@ def test_loc_setitem_triangle_value(clrd: Triangle) -> None:
         tri.loc["Aegis Grp", "comauto"] = sub * 2
         assert tri.loc["Aegis Grp", "comauto"] == sub * 2
 
+def test_loc_setitem_partial_triangles(raa: Triangle) -> None:
+    """
+    Use Triangle.loc to set a few origin or develop period via a TriangleSlicer.
 
+    Parameters
+    ----------
+    raa: Triangle
+        The raa sample data set fixture.
+
+    Returns
+    -------
+    None
+
+    """
+    raa2 = raa * 2
+    raa_new = raa.copy()
+    raa_new.loc[:,:,:,:60] = raa2.loc[:,:,:,:60]
+    raa_new.loc[:,:,:,72:] = raa2.loc[:,:,:,72:]
+    assert raa_new == raa2
+    raa_new = raa.copy()
+    raa_new.loc[:,:,:'1984',:] = raa2.loc[:,:,:'1984',:]
+    raa_new.loc[:,:,'1985':,:] = raa2.loc[:,:,'1985':,:]
+    assert raa_new == raa2
 
 def test_invalid_iloc_sparse_assignment(prism) -> None:
     """

--- a/chainladder/core/tests/test_slicing.py
+++ b/chainladder/core/tests/test_slicing.py
@@ -289,13 +289,16 @@ def test_loc_setitem_partial_triangles(raa: Triangle) -> None:
     """
     raa2 = raa * 2
     raa_new = raa.copy()
-    raa_new.loc[:,:,:,:60] = raa2.loc[:,:,:,:60]
-    raa_new.loc[:,:,:,72:] = raa2.loc[:,:,:,72:]
-    assert raa_new == raa2
-    raa_new = raa.copy()
-    raa_new.loc[:,:,:'1984',:] = raa2.loc[:,:,:'1984',:]
-    raa_new.loc[:,:,'1985':,:] = raa2.loc[:,:,'1985':,:]
-    assert raa_new == raa2
+    if raa_new.array_backend == "sparse":
+        pytest.skip("Test is specific to the numpy backend.")
+    else:
+        raa_new.loc[:,:,:,:60] = raa2.loc[:,:,:,:60]
+        raa_new.loc[:,:,:,72:] = raa2.loc[:,:,:,72:]
+        assert raa_new == raa2
+        raa_new = raa.copy()
+        raa_new.loc[:,:,:'1984',:] = raa2.loc[:,:,:'1984',:]
+        raa_new.loc[:,:,'1985':,:] = raa2.loc[:,:,'1985':,:]
+        assert raa_new == raa2
 
 def test_invalid_iloc_sparse_assignment(prism) -> None:
     """
@@ -350,6 +353,25 @@ def test_get_idx_fancy_origin_raises(raa: Triangle) -> None:
     with pytest.raises(ValueError, match="Fancy indexing on origin/development is not supported"):
         _= raa.iloc[0, 0, [0, 1, 5], :]
 
+def test_set_fancy_origin_raises(raa: Triangle) -> None:
+    """
+    Attempt setting with fancy indexing on origin axis, raise an error.
+
+    Parameters
+    ----------
+    raa: Triangle
+        The raa sample data set fixture.
+
+    Returns
+    -------
+    None
+
+    """
+    if raa.array_backend == "sparse":
+        pytest.skip("Test is specific to the numpy backend.")
+    else:
+        with pytest.raises(ValueError, match="Setting while fancy indexing on origin/development is not supported."):
+            raa.iloc[0, 0, [0, 1, 5], :] = raa.iloc[0, 0, :3, :]
 
 def test_get_idx_fancy_development_raises(raa: Triangle) -> None:
     """
@@ -368,6 +390,25 @@ def test_get_idx_fancy_development_raises(raa: Triangle) -> None:
     with pytest.raises(ValueError, match="Fancy indexing on origin/development is not supported"):
         _= raa.iloc[0, 0, :, [0, 1, 5]]
 
+def test_set_fancy_development_raises(raa: Triangle) -> None:
+    """
+    Attempt setting with fancy indexing on development axis, raise an error.
+
+    Parameters
+    ----------
+    raa: Triangle
+        The raa sample data set fixture.
+
+    Returns
+    -------
+    None
+
+    """
+    if raa.array_backend == "sparse":
+        pytest.skip("Test is specific to the numpy backend.")
+    else:
+        with pytest.raises(ValueError, match="Setting while fancy indexing on origin/development is not supported."):
+            raa.iloc[0, 0, :, [0, 1, 5]] = raa.iloc[0, 0, :, :3]
 
 def test_get_idx_non_contiguous_index_and_columns(clrd: Triangle) -> None:
     """
@@ -393,6 +434,45 @@ def test_get_idx_non_contiguous_index_and_columns(clrd: Triangle) -> None:
     assert result.index.values.tolist() == expected_index
     assert result.columns.tolist() == ['IncurLoss', 'CumPaidLoss', 'EarnedPremNet']
 
+def test_setting_non_contiguous_index_and_columns(clrd: Triangle) -> None:
+    """
+    Set lists of non-contiguous indexes and column through Triangle.loc. Check the values
+    of the index and columns returned.
+
+    Parameters
+    ----------
+    clrd: Triangle
+        The clrd sample data set fixture.
+
+    Returns
+    -------
+    None
+
+    """
+    if clrd.array_backend == "sparse":
+        pytest.skip("Test is specific to the numpy backend.")
+    else:
+        dest_index = [
+            ['Adriatic Ins Co', 'othliab'],
+            ['Adriatic Ins Co', 'ppauto'],
+            ['Agency Ins Co Of MD Inc', 'ppauto'],
+        ]
+        val_index = [
+            ['Adriatic Ins Co', 'ppauto'],
+            ['Aegis Grp', 'comauto'],
+            ['Agency Ins Co Of MD Inc', 'ppauto'],
+        ]
+        dest_col = ['CumPaidLoss', 'BulkLoss', 'EarnedPremNet']
+        val_col = ['IncurLoss', 'CumPaidLoss', 'EarnedPremNet']
+        clrd_copy = clrd.copy()
+        clrd_copy.loc[dest_index] = clrd.loc[val_index]
+        assert clrd_copy.loc[dest_index] == clrd.loc[val_index]
+        clrd_copy = clrd.copy()
+        clrd_copy.loc[:,dest_col] = clrd.loc[:,val_col]
+        assert clrd_copy.loc[:,dest_col] == clrd.loc[:,val_col]
+        clrd_copy = clrd.copy()
+        clrd_copy.loc[dest_index,dest_col] = clrd.loc[val_index,val_col]
+        assert clrd_copy.loc[dest_index,dest_col] == clrd.loc[val_index,val_col]
 
 def test_sparse_at_iat1(prism):
     t = prism.copy()


### PR DESCRIPTION
## Summary of Changes  


## Related GitHub Issue(s)  


## Additional Context for Reviewers  


- [ ] I passed tests locally for both code (`uv run pytest`) and documentation changes (`uv run jb build docs --builder=custom --custom-builder=doctest`)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core indexing write paths for Triangle values; incorrect assignment could corrupt actuarial data shapes or cell values, though scope is limited to numpy backend and disallowed fancy origin/development sets.
> 
> **Overview**
> **Triangle assignment** on the numpy backend now mirrors how **get** slicing works, especially when index and column selectors are **lists of non-contiguous positions**.
> 
> `_LocBase.__setitem__` rejects **fancy indexing on origin and development** when setting (same idea as read), and uses **`np.ix_`** on the index and column axes when both are array indexers so writes land in the same Cartesian product of rows/columns that `.iloc` reads return.
> 
> **`.loc[]` assignment** routes labels through `key_to_slice`, normalizes with `_contig_slice`, then delegates to the base setter. Tests cover non-contiguous `.loc` writes and guard numpy-only cases behind skips for the sparse backend.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 992d5a21039775545253c132212885d015026ce1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->