### PR TITLE
generalizing across iloc

### DIFF
--- a/chainladder/core/slice.py
+++ b/chainladder/core/slice.py
@@ -150,11 +150,13 @@ class _LocBase:
             raise ValueError('Setting values with sparse backend requires .at or .iat')
         if isinstance(values, TriangleSlicer):
             values = values.values
+        # attempt to make keys contig
+        contig_key = tuple([_LocBase._contig_slice(x) for x in key])
         # Create a slice for any key elements that are integers, otherwise preserve the slice or array.
-        key = tuple(
-            [slice(item, item + 1) if isinstance(item, int) else item for item in key]
+        tuple_key = tuple(
+            [slice(item, item + 1) if isinstance(item, int) else item for item in contig_key]
         )
-        norm_key = self._normalize_index(key)
+        norm_key = self._normalize_index(tuple_key)
         if type(norm_key[2]) != slice or type(norm_key[3]) != slice:
             raise ValueError("Setting while fancy indexing on origin/development is not supported.")
         if type(norm_key[0]) is slice or type(norm_key[1]) is slice:
@@ -453,10 +455,7 @@ class Location(_LocBase):
         None
 
         """
-        raw_slice = self.key_to_slice(key)
-        # _LocBase expects key to be contiguous if possible
-        contig_slice = [_LocBase._contig_slice(x) for x in raw_slice]
-        super().__setitem__(cast(tuple[_AxisKey, _AxisKey, _AxisKey, _AxisKey], contig_slice), values)
+        super().__setitem__(cast(tuple[_AxisKey, _AxisKey, _AxisKey, _AxisKey], self.key_to_slice(key)), values)
 
 class Ilocation(_LocBase):
     """

--- a/chainladder/core/tests/test_slicing.py
+++ b/chainladder/core/tests/test_slicing.py
@@ -367,11 +367,15 @@ def test_set_fancy_origin_raises(raa: Triangle) -> None:
     None
 
     """
+    raa_copy = raa.copy()
     if raa.array_backend == "sparse":
         pytest.skip("Test is specific to the numpy backend.")
     else:
         with pytest.raises(ValueError, match="Setting while fancy indexing on origin/development is not supported."):
-            raa.iloc[0, 0, [0, 1, 5], :] = raa.iloc[0, 0, :3, :]
+            raa_copy.iloc[0, 0, [0, 1, 5], :] = raa.iloc[0, 0, :3, :]
+        with pytest.raises(ValueError, match="Setting while fancy indexing on origin/development is not supported."):
+            raa_copy.loc['Total', 'values', ['1983', '1984', '1986'], :] = raa.iloc[0, 0, :3, :]
+
 
 def test_get_idx_fancy_development_raises(raa: Triangle) -> None:
     """
@@ -404,11 +408,15 @@ def test_set_fancy_development_raises(raa: Triangle) -> None:
     None
 
     """
+    raa_copy = raa.copy()
     if raa.array_backend == "sparse":
         pytest.skip("Test is specific to the numpy backend.")
     else:
         with pytest.raises(ValueError, match="Setting while fancy indexing on origin/development is not supported."):
-            raa.iloc[0, 0, :, [0, 1, 5]] = raa.iloc[0, 0, :, :3]
+            raa_copy.iloc[0, 0, :, [0, 1, 5]] = raa.iloc[0, 0, :, :3]
+        with pytest.raises(ValueError, match="Setting while fancy indexing on origin/development is not supported."):
+            raa_copy.loc['Total', 'values', :, [12, 24, 48]] = raa.iloc[0, 0, :, :3]
+
 
 def test_get_idx_non_contiguous_index_and_columns(clrd: Triangle) -> None:
     """
@@ -434,10 +442,10 @@ def test_get_idx_non_contiguous_index_and_columns(clrd: Triangle) -> None:
     assert result.index.values.tolist() == expected_index
     assert result.columns.tolist() == ['IncurLoss', 'CumPaidLoss', 'EarnedPremNet']
 
-def test_setting_non_contiguous_index_and_columns(clrd: Triangle) -> None:
+def test_loc_setting_non_contiguous_index_and_columns(clrd: Triangle) -> None:
     """
     Set lists of non-contiguous indexes and column through Triangle.loc. Check the values
-    of the index and columns returned.
+    of the assigned triangles.
 
     Parameters
     ----------
@@ -473,6 +481,38 @@ def test_setting_non_contiguous_index_and_columns(clrd: Triangle) -> None:
         clrd_copy = clrd.copy()
         clrd_copy.loc[dest_index,dest_col] = clrd.loc[val_index,val_col]
         assert clrd_copy.loc[dest_index,dest_col] == clrd.loc[val_index,val_col]
+
+def test_iloc_setting_non_contiguous_index_and_columns(clrd: Triangle) -> None:
+    """
+    Set lists of non-contiguous indexes and column through Triangle.iloc. Check the values
+    of the assigned triangles.
+
+    Parameters
+    ----------
+    clrd: Triangle
+        The clrd sample data set fixture.
+
+    Returns
+    -------
+    None
+
+    """
+    if clrd.array_backend == "sparse":
+        pytest.skip("Test is specific to the numpy backend.")
+    else:
+        dest_index = [0,1,5]
+        val_index = [1,4,6]
+        dest_col = [2,3,5]
+        val_col = [1,2,4]
+        clrd_copy = clrd.copy()
+        clrd_copy.iloc[dest_index] = clrd.iloc[val_index]
+        assert clrd_copy.iloc[dest_index] == clrd.iloc[val_index]
+        clrd_copy = clrd.copy()
+        clrd_copy.iloc[:,dest_col] = clrd.iloc[:,val_col]
+        assert clrd_copy.iloc[:,dest_col] == clrd.iloc[:,val_col]
+        clrd_copy = clrd.copy()
+        clrd_copy.iloc[dest_index,dest_col] = clrd.iloc[val_index,val_col]
+        assert clrd_copy.iloc[dest_index,dest_col] == clrd.iloc[val_index,val_col]
 
 def test_sparse_at_iat1(prism):
     t = prism.copy()


### PR DESCRIPTION
## Summary of Changes  


## Related GitHub Issue(s)  


## Additional Context for Reviewers  


- [ ] I passed tests locally for both code (`uv run pytest`) and documentation changes (`uv run jb build docs --builder=custom --custom-builder=doctest`)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core indexing assignment for numpy-backed Triangles; behavior shifts for non-contiguous iloc/loc writes but is covered by new tests and existing fancy-origin/development guards.
> 
> **Overview**
> **Triangle assignment** via `.loc` and `.iloc` now share one code path: `_LocBase.__setitem__` applies `_contig_slice` on each axis of the key before normalization and ndarray assignment (including `np.ix_` when index and column axes are non-contiguous arrays).
> 
> `Location.__setitem__` no longer applies contiguous slicing locally; it passes integer keys from `key_to_slice` straight to the base setter, so **`.iloc` with non-contiguous row/column lists** is covered by the same logic as `.loc`.
> 
> Tests copy fixtures before failed assignments, add **`.loc` fancy origin/development set** error cases, rename the contiguous **`.loc` set** test, and add **`test_iloc_setting_non_contiguous_index_and_columns`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4618748f81e202b47e5463512f04641e5357577e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->