### PR TITLE
[ENH] Support cumulative on-level factors in ParallelogramOLF

### DIFF
--- a/chainladder/adjustments/parallelogram.py
+++ b/chainladder/adjustments/parallelogram.py
@@ -292,7 +292,9 @@ class ParallelogramOLF(BaseEstimator, TransformerMixin, EstimatorIO):
     def _combine_duplicate_dates(self, r):
         """Collapse multiple rate entries sharing an effective date."""
         if self.cumulative:
-            return r.groupby(self.date_col)[self.change_col].prod().reset_index()
+            # Cumulative factors are absolute rate levels, not compounding
+            # increments, so the last factor stated for a date wins.
+            return r.groupby(self.date_col)[self.change_col].last().reset_index()
         r[self.change_col] = r[self.change_col] + 1
         return (r.groupby(self.date_col)[self.change_col].prod() - 1).reset_index()
 

--- a/chainladder/adjustments/parallelogram.py
+++ b/chainladder/adjustments/parallelogram.py
@@ -42,6 +42,12 @@ class ParallelogramOLF(BaseEstimator, TransformerMixin, EstimatorIO):
         parallelogram OLFs. If True, Parallelograms become squares.  This is
         commonly seen in Workers Compensation with benefit on-leveling or if
         the premium origin is also stated on an effective date basis.
+    cumulative: bool (default=False)
+        By default, `change_col` holds incremental rate changes.  If True, it
+        instead holds cumulative on-level factors stated relative to one
+        another, which avoids having to back into the incremental changes.
+        Each factor is in force from its effective date until the next one,
+        and the earliest factor is extended backwards.
 
     Attributes
     ----------
@@ -212,6 +218,7 @@ class ParallelogramOLF(BaseEstimator, TransformerMixin, EstimatorIO):
         approximation_grain="M",
         policy_length=12,
         vertical_line=False,
+        cumulative=False,
     ):
         self.rate_history = rate_history
         self.change_col = change_col
@@ -219,6 +226,7 @@ class ParallelogramOLF(BaseEstimator, TransformerMixin, EstimatorIO):
         self.approximation_grain = approximation_grain
         self.policy_length = policy_length
         self.vertical_line = vertical_line
+        self.cumulative = cumulative
 
     def fit(self, X, y=None, sample_weight=None):
         """Fit the model with X.
@@ -256,14 +264,14 @@ class ParallelogramOLF(BaseEstimator, TransformerMixin, EstimatorIO):
             policy_length=self.policy_length,
             vertical_line=self.vertical_line,
             approximation_grain=self.approximation_grain,
+            cumulative=self.cumulative,
         )
 
         if len(groups) > 0:
             tris = []
             for item in idx.index.set_index(groups).iterrows():
                 r = self.rate_history.set_index(groups).loc[item[0]].copy()
-                r[self.change_col] = r[self.change_col] + 1
-                r = (r.groupby(self.date_col)[self.change_col].prod() - 1).reset_index()
+                r = self._combine_duplicate_dates(r)
                 date = r[self.date_col]
                 values = r[self.change_col]
                 olf = parallelogram_olf(values=values, dates=date, **kw).values[
@@ -274,14 +282,19 @@ class ParallelogramOLF(BaseEstimator, TransformerMixin, EstimatorIO):
                 tris.append((idx.loc[item[0]] * 0 + 1) * olf)
             self.olf_ = concat(tris, 0).latest_diagonal
         else:
-            r = self.rate_history.copy()
-            r[self.change_col] = r[self.change_col] + 1
-            r = (r.groupby(self.date_col)[self.change_col].prod() - 1).reset_index()
+            r = self._combine_duplicate_dates(self.rate_history.copy())
             date = r[self.date_col]
             values = r[self.change_col]
             olf = parallelogram_olf(values=values, dates=date, **kw)
             self.olf_ = ((idx * 0 + 1) * olf.values[None, None]).latest_diagonal
         return self
+
+    def _combine_duplicate_dates(self, r):
+        """Collapse multiple rate entries sharing an effective date."""
+        if self.cumulative:
+            return r.groupby(self.date_col)[self.change_col].prod().reset_index()
+        r[self.change_col] = r[self.change_col] + 1
+        return (r.groupby(self.date_col)[self.change_col].prod() - 1).reset_index()
 
     def transform(self, X, y=None, sample_weight=None):
         """If X and self are of different shapes, align self to X, else

--- a/chainladder/adjustments/tests/test_parallelogram.py
+++ b/chainladder/adjustments/tests/test_parallelogram.py
@@ -450,3 +450,60 @@ def test_cumulative_matches_incremental():
 def test_cumulative_rejects_non_positive():
     with pytest.raises(ValueError, match="positive"):
         cl.parallelogram_olf([1.0, 0.0], ["2010-01-01", "2011-01-01"], cumulative=True)
+
+
+def test_cumulative_factor_predates_window():
+    """A factor in force before the triangle window is honored, not dropped.
+
+    The earliest factor's effective date (2000) predates the triangle's
+    lookback window (origins start 2003), so it must still apply to the first
+    origins rather than being backfilled with a later factor. See GH #922.
+    """
+    data = pd.DataFrame({"Year": list(range(2003, 2009)), "EarnedPremium": [1000] * 6})
+    prem_tri = cl.Triangle(
+        data, origin="Year", columns="EarnedPremium", cumulative=True
+    )
+    factors = pd.DataFrame(
+        {"EffDate": ["2000-01-01", "2005-01-01"], "Factor": [0.5, 1.0]}
+    )
+    olf = (
+        cl.ParallelogramOLF(
+            rate_history=factors,
+            change_col="Factor",
+            date_col="EffDate",
+            approximation_grain="M",
+            vertical_line=True,
+            cumulative=True,
+        )
+        .fit_transform(prem_tri)
+        .olf_
+    )
+    assert np.all(
+        np.round(olf.to_frame().values.flatten(), 6) == [0.5, 0.5, 1.0, 1.0, 1.0, 1.0]
+    )
+
+
+def test_cumulative_duplicate_date_last_wins():
+    """Duplicate effective dates keep the last cumulative factor, not a product."""
+    dup = pd.DataFrame(
+        {
+            "EffDate": ["1998-01-01", "2003-01-01", "2003-01-01", "2004-01-01"],
+            "Factor": [0.67, 0.67, 0.75, 1.00],
+        }
+    )
+    olf = (
+        cl.ParallelogramOLF(
+            rate_history=dup,
+            change_col="Factor",
+            date_col="EffDate",
+            approximation_grain="M",
+            vertical_line=True,
+            cumulative=True,
+        )
+        .fit_transform(cl.load_sample("friedland_gl_self_insurer")["Reported Claims"])
+        .olf_
+    )
+    assert np.all(
+        np.round(olf.to_frame().values.flatten(), 6)
+        == [0.67, 0.67, 0.67, 0.67, 0.67, 0.75, 1.0, 1.0, 1.0, 1.0, 1.0]
+    )

--- a/chainladder/adjustments/tests/test_parallelogram.py
+++ b/chainladder/adjustments/tests/test_parallelogram.py
@@ -382,3 +382,71 @@ def test_rate_impact_beginning_of_year():
         np.where(monthly > daily, ">", np.where(monthly == daily, "=", "<")),
         np.array([">", ">", ">", "=", "="]),
     )  # this is true becuase there are less "days" in the first half of the year (from Jan - Jun) compared to (Jul - Dec), and only the first three origins would need to be brought to current rate level
+
+
+def test_cumulative_tort_reform():
+    """Cumulative on-level factors can be supplied directly. See GH #922."""
+    tort = pd.DataFrame(
+        {
+            "EffDate": ["1998-01-01", "2003-01-01", "2004-01-01"],
+            "Factor": [0.67, 0.75, 1.00],
+        }
+    )
+    olf = (
+        cl.ParallelogramOLF(
+            rate_history=tort,
+            change_col="Factor",
+            date_col="EffDate",
+            policy_length=12,
+            approximation_grain="M",
+            vertical_line=True,
+            cumulative=True,
+        )
+        .fit_transform(cl.load_sample("friedland_gl_self_insurer")["Reported Claims"])
+        .olf_
+    )
+    assert np.all(
+        np.round(olf.to_frame().values.flatten(), 6)
+        == [0.67, 0.67, 0.67, 0.67, 0.67, 0.75, 1.0, 1.0, 1.0, 1.0, 1.0]
+    )
+
+
+def test_cumulative_matches_incremental():
+    """Cumulative factors and their incremental equivalent agree."""
+    data = pd.DataFrame(
+        {"Year": list(range(2006, 2016)), "EarnedPremium": [10_000] * 10}
+    )
+    prem_tri = cl.Triangle(
+        data, origin="Year", columns="EarnedPremium", cumulative=True
+    )
+    dates = ["2006-01-01", "2010-07-01", "2011-01-01", "2012-07-01", "2013-04-01"]
+    changes = [0.0, 0.035, 0.05, 0.10, -0.01]
+    levels = np.cumprod(np.array(changes) + 1)
+    factors = levels[-1] / levels
+
+    for grain in ["M", "D"]:
+        for vertical_line in [True, False]:
+            kw = dict(
+                date_col="EffDate",
+                approximation_grain=grain,
+                vertical_line=vertical_line,
+            )
+            incremental = cl.ParallelogramOLF(
+                pd.DataFrame({"EffDate": dates, "RateChange": changes}),
+                change_col="RateChange",
+                **kw,
+            ).fit_transform(prem_tri)
+            cumulative = cl.ParallelogramOLF(
+                pd.DataFrame({"EffDate": dates, "Factor": factors}),
+                change_col="Factor",
+                cumulative=True,
+                **kw,
+            ).fit_transform(prem_tri)
+            assert np.allclose(
+                incremental.olf_.values, cumulative.olf_.values
+            ), (grain, vertical_line)
+
+
+def test_cumulative_rejects_non_positive():
+    with pytest.raises(ValueError, match="positive"):
+        cl.parallelogram_olf([1.0, 0.0], ["2010-01-01", "2011-01-01"], cumulative=True)

--- a/chainladder/utils/utility_functions.py
+++ b/chainladder/utils/utility_functions.py
@@ -465,12 +465,21 @@ def parallelogram_olf(
     )
 
     if cumulative:
-        factors = pd.Series(np.array(values, dtype="float64"), np.array(dates))
+        factors = pd.Series(
+            np.array(values, dtype="float64"), pd.to_datetime(np.array(dates))
+        ).sort_index()
         if (factors <= 0).any():
             raise ValueError("cumulative on-level factors must be positive")
-        # An on-level factor is the current rate level divided by the rate
-        # level in force, so the implied rate level is its reciprocal.
-        cum_rate_changes = (1 / factors).reindex(date_idx).ffill().bfill()
+        # An on-level factor is the current rate level divided by the rate level
+        # in force, so the implied rate level is its reciprocal. Each factor is
+        # in force from its effective date until the next (a backward/asof match,
+        # so off-grid or pre-window dates are honored); dates before the first
+        # factor take the earliest, extending it back over the lookback window.
+        level = 1 / factors
+        pos = np.searchsorted(level.index.values, date_idx.values, side="right") - 1
+        cum_rate_changes = pd.Series(
+            level.values[np.clip(pos, 0, None)], index=date_idx
+        )
     else:
         rate_changes = pd.Series(np.array(values), np.array(dates)).reindex(
             date_idx, fill_value=0

--- a/chainladder/utils/utility_functions.py
+++ b/chainladder/utils/utility_functions.py
@@ -433,8 +433,16 @@ def parallelogram_olf(
     policy_length=12,
     approximation_grain="M",
     vertical_line=False,
+    cumulative=False,
 ):
-    """Parallelogram approach to on-leveling."""
+    """Parallelogram approach to on-leveling.
+
+    When ``cumulative`` is False (default), ``values`` are incremental rate
+    changes expressed as decimals.  When True, ``values`` are cumulative
+    on-level factors already stated relative to one another, and each value is
+    in force from its effective date until the next one.  The earliest value is
+    extended backwards to cover the lookback window.
+    """
     if approximation_grain not in ["M", "D"]:
         raise ValueError("approximation_grain must be M or D")
 
@@ -456,12 +464,20 @@ def parallelogram_olf(
         freq={"M": "MS", "D": "D"}[approximation_grain],
     )
 
-    rate_changes = pd.Series(np.array(values), np.array(dates)).reindex(
-        date_idx, fill_value=0
-    )
-    cum_rate_changes = pd.Series(
-        np.cumprod(1 + rate_changes.values), rate_changes.index
-    )
+    if cumulative:
+        factors = pd.Series(np.array(values, dtype="float64"), np.array(dates))
+        if (factors <= 0).any():
+            raise ValueError("cumulative on-level factors must be positive")
+        # An on-level factor is the current rate level divided by the rate
+        # level in force, so the implied rate level is its reciprocal.
+        cum_rate_changes = (1 / factors).reindex(date_idx).ffill().bfill()
+    else:
+        rate_changes = pd.Series(np.array(values), np.array(dates)).reindex(
+            date_idx, fill_value=0
+        )
+        cum_rate_changes = pd.Series(
+            np.cumprod(1 + rate_changes.values), rate_changes.index
+        )
     crl = cum_rate_changes.iloc[-1]
 
     rolling_num_base = {


### PR DESCRIPTION
## Summary of Changes
Adds a `cumulative` flag to `ParallelogramOLF` and `parallelogram_olf` so a rate history can be given as cumulative on-level factors instead of incremental rate changes.

- `cumulative=False` (default) is the current behavior, fully backwards compatible.
- `cumulative=True` reads `change_col` as cumulative factors: each is in force from its effective date to the next, the earliest extends back over the lookback window, and the rate level is `1/factor`. Rolling average, `vertical_line`, and leap-year handling are unchanged. Non-positive factors raise a `ValueError`.

So the tort example drops the gymnastics:
```python
# before
"RateChange": [(0.67 / 0.75) - 1, 0.75 - 1, 0.00]
# after
"Factor": [0.67, 0.75, 1.00]  # cumulative=True
```

## Related GitHub Issue(s)
closes #922

Also completes a follow-up from #1180 (Chapter 10): its Exhibit II tort step can drop the `[-0.1067, -0.25]` conversion for a clean `[0.67, 0.75, 1.0]` with `cumulative=True`.

## Additional Context for Reviewers
New tests in `test_parallelogram.py`: the issue's tort example, a cumulative-vs-incremental equivalence check across `M`/`D` grain and `vertical_line` True/False, and a non-positive-factor guard.

- [x] I passed tests locally for both code (`uv run pytest`) and documentation changes (`uv run jb build docs --builder=custom --custom-builder=doctest`)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches actuarial on-leveling math in a shared utility, but the new path is gated behind `cumulative=True` with broad regression tests; incorrect factor interpretation would still affect premium leveling workflows.
> 
> **Overview**
> Adds **`cumulative`** (default `False`) to **`ParallelogramOLF`** and **`parallelogram_olf`**, so rate history can use **cumulative on-level factors** instead of incremental decimal rate changes—e.g. tort reform factors `[0.67, 0.75, 1.00]` without converting to increments.
> 
> With **`cumulative=True`**, each factor applies from its effective date until the next; the earliest factor is extended backward over the lookback window. **`fit`** routes duplicate effective dates through **`_combine_duplicate_dates`**: last factor wins (not a product). The utility layer maps factors to implied rate levels via **`1/factor`**, assigns levels with backward **`searchsorted`**, and rejects non-positive factors with **`ValueError`**. Incremental behavior and defaults are unchanged.
> 
> New tests cover the GH #922 tort case, equivalence to incremental inputs across **`M`/`D`** and **`vertical_line`**, pre-window factors, duplicate dates, and the positive-factor guard.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ebf009d4a56dad6d8b6c23beb2dad06c9a589f2a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->