### PR TITLE
Change 1d to 1D/update unittest trigger

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -4,7 +4,7 @@ name: Unit Tests
 on:
   push:
     branches:
-    - '*'
+    - '**'
 
   pull_request:
 

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -4,7 +4,7 @@ name: Unit Tests
 on:
   push:
     branches:
-    - '**'
+      - '**'
 
   pull_request:
 

--- a/chainladder/core/base.py
+++ b/chainladder/core/base.py
@@ -427,7 +427,8 @@ class TriangleBase(
                     "Unable to infer datetime for field(s): " + str(fields) +
                     ". Please check the underlying data or any supplied format arguments."
                     )
-            target: Series = target_field.map(func=datetime_mapping)
+            # DataFrame.map already accepts func on 2.3
+            target: Series = target_field.to_frame().map(func=datetime_mapping).iloc[:,0]
 
         return target
 

--- a/chainladder/core/base.py
+++ b/chainladder/core/base.py
@@ -427,8 +427,7 @@ class TriangleBase(
                     "Unable to infer datetime for field(s): " + str(fields) +
                     ". Please check the underlying data or any supplied format arguments."
                     )
-            # DataFrame.map already accepts func on 2.3
-            target: Series = target_field.to_frame().map(func=datetime_mapping).iloc[:,0]
+            target: Series = target_field.map(datetime_mapping)
 
         return target
 

--- a/chainladder/core/base.py
+++ b/chainladder/core/base.py
@@ -440,7 +440,7 @@ class TriangleBase(
         For tabular format, this will convert the origin/valuation
         difference to a development lag.
         """
-        return ((valuation - origin) / (365.25 / 12)).dt.round("1d").dt.days
+        return ((valuation - origin) / (365.25 / 12)).dt.round("1D").dt.days
 
     @staticmethod
     def _get_grain(

--- a/chainladder/core/base.py
+++ b/chainladder/core/base.py
@@ -427,7 +427,7 @@ class TriangleBase(
                     "Unable to infer datetime for field(s): " + str(fields) +
                     ". Please check the underlying data or any supplied format arguments."
                     )
-            target: Series = target_field.map(arg=datetime_mapping)
+            target: Series = target_field.map(func=datetime_mapping)
 
         return target
 


### PR DESCRIPTION
## Summary of Changes  
updating 1d to 1D ahead of pandas deprecation
updating '*' to '**' to catch slash in branch name

## Related GitHub Issue(s)  
fixes #849 
fixes #1182 

## Additional Context for Reviewers  
no more deprecation warning for `d` [here](https://github.com/casact/chainladder-python/actions/runs/30785835466/job/91599117055#step:5:98)

<!-- Do not edit anything below this. -->

## Checklist
- [X] I passed tests locally for both code (`uv run pytest`) and documentation changes (`uv run --directory docs jb build . --builder=custom --custom-builder=doctest`)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small compatibility and CI trigger tweaks with no auth, data, or behavioral logic changes beyond avoiding pandas deprecations.
> 
> **Overview**
> Updates the unit-test workflow so **push** runs on all branch names, including those with slashes, by changing the branch filter from `'*'` to `'**'`.
> 
> In **`TriangleBase`**, development-lag calculation now uses pandas’ **`1D`** day rounding instead of deprecated **`1d`**, and datetime mapping calls **`Series.map`** without the removed **`arg=`** keyword.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 337982fb445f4bc885e0e1187b0c4377e2a0b343. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->