### PR TITLE
Streamlined the unit tests and addressed unit tests bug

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -4,7 +4,7 @@ name: Unit Tests
 on:
   push:
     branches:
-    - '*'
+    - '**'
 
   pull_request:
 

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -4,7 +4,7 @@ name: Unit Tests
 on:
   push:
     branches:
-    - '**'
+    - main
 
   pull_request:
 


### PR DESCRIPTION
## Summary of Changes  
Fixes 1182, previously, we used "*" only to catch the branch name, which can be escaped by "/", using "**" will fix that.
This fix goes one step further, as we are all familiar, there are WAAY too many tests that run on each PR. This PR will update that to run on every PR and push to main only, it will not rerun main multiple times.

## Related GitHub Issue(s)  
Closes #1182

## Additional Context for Reviewers  




<!-- Do not edit anything below this. -->

## Checklist
- [ ] I passed tests locally for both code (`uv run pytest`) and documentation changes (`uv run --directory docs jb build . --builder=custom --custom-builder=doctest`)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only GitHub Actions trigger configuration changed; no application or test logic was modified.
> 
> **Overview**
> **CI trigger change** in `pytest.yml`: `push` no longer uses the `'*'` branch filter (which could miss branches with `/` in the name). It now runs unit tests only on pushes to **`main`**, while **`pull_request`** still runs the full matrix on every PR.
> 
> This cuts redundant workflow runs on feature branches and avoids duplicate runs when `main` is updated, without changing what runs on PRs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cc2051f61b57dc87f3312ded645bab5664d7c259. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->