### PR TITLE
Fixes valuation grain bug

### DIFF
--- a/chainladder/core/tests/test_triangle.py
+++ b/chainladder/core/tests/test_triangle.py
@@ -1494,7 +1494,7 @@ def test_1d_monthly_valuation_date() -> None:
     assert pd.to_datetime(tri.valuation_date).date() == pd.Timestamp("2008-01-31").date()
     assert tri.development_grain == "M"
 
-def test_1d_monthly_valuation_date_expanded_dev_date -> None:
+def test_1d_monthly_valuation_date_expanded_dev_date() -> None:
     year_df = pd.DataFrame(
         {
             "origin": [1998, 1999, 2000, 2001, 2002],

--- a/chainladder/core/tests/test_triangle.py
+++ b/chainladder/core/tests/test_triangle.py
@@ -1448,6 +1448,31 @@ def test_single_valuation_date_preserves_exact_date():
     assert triangle.valuation_date == pd.Timestamp(val_date_exp)
     assert triangle.development_grain == 'M'
     assert int(triangle.valuation_date.strftime('%Y%m')) == 202510
+
+
+def test_1d_annual_valuation_date() -> None:
+    year_data = [
+        [1998, 2008, 900000, 890000],
+        [1999, 2008, 1200000, 1170000],
+        [2000, 2008, 1300000, 1265000],
+        [2001, 2008, 1800000, 1600000],
+        [2002, 2008, 1450000, 1200000],
+    ]
+    year_df = pd.DataFrame(
+        data=year_data, columns=["origin", "dev", "revenue", "expense"]
+    )
+    tri = cl.Triangle(
+        data=year_df,
+        origin="origin",
+        development="dev",
+        columns="expense",
+        development_format="%Y",
+        cumulative=True,
+    )
+    assert pd.to_datetime(tri.valuation_date).date() == pd.Timestamp("2008-12-31").date()
+    assert tri.development_grain == "Y"
+
+
 def test_OXDX_triangle():
     
     for x in [12,6,3,1]:

--- a/chainladder/core/tests/test_triangle.py
+++ b/chainladder/core/tests/test_triangle.py
@@ -1472,6 +1472,29 @@ def test_1d_annual_valuation_date() -> None:
     assert pd.to_datetime(tri.valuation_date).date() == pd.Timestamp("2008-12-31").date()
     assert tri.development_grain == "Y"
 
+def test_1d_monthly_valuation_date() -> None:
+    # Month is specified (%Y-%m), so keep January month-end — do not roll to year-end.
+    year_data = [
+        [1998, "2008-01", 900000, 890000],
+        [1999, "2008-01", 1200000, 1170000],
+        [2000, "2008-01", 1300000, 1265000],
+        [2001, "2008-01", 1800000, 1600000],
+        [2002, "2008-01", 1450000, 1200000],
+    ]
+    year_df = pd.DataFrame(
+        data=year_data, columns=["origin", "dev", "revenue", "expense"]
+    )
+    tri = cl.Triangle(
+        data=year_df,
+        origin="origin",
+        development="dev",
+        columns="expense",
+        development_format="%Y-%m",
+        cumulative=True,
+    )
+    assert pd.to_datetime(tri.valuation_date).date() == pd.Timestamp("2008-01-31").date()
+    assert tri.development_grain == "M"
+
 
 def test_OXDX_triangle():
     

--- a/chainladder/core/tests/test_triangle.py
+++ b/chainladder/core/tests/test_triangle.py
@@ -1473,7 +1473,6 @@ def test_1d_annual_valuation_date() -> None:
     assert tri.development_grain == "Y"
 
 def test_1d_monthly_valuation_date() -> None:
-    # Month is specified (%Y-%m), so keep January month-end — do not roll to year-end.
     year_data = [
         [1998, "2008-01", 900000, 890000],
         [1999, "2008-01", 1200000, 1170000],
@@ -1495,6 +1494,9 @@ def test_1d_monthly_valuation_date() -> None:
     assert pd.to_datetime(tri.valuation_date).date() == pd.Timestamp("2008-01-31").date()
     assert tri.development_grain == "M"
 
+def test_friedland_gl_self_insurer_grain() -> None:
+    data_valuation_date = cl.load_sample('friedland_gl_self_insurer').valuation_date
+    assert pd.to_datetime(data_valuation_date).date() == pd.Timestamp("2008-12-31").date()
 
 def test_OXDX_triangle():
     

--- a/chainladder/core/tests/test_triangle.py
+++ b/chainladder/core/tests/test_triangle.py
@@ -1494,6 +1494,25 @@ def test_1d_monthly_valuation_date() -> None:
     assert pd.to_datetime(tri.valuation_date).date() == pd.Timestamp("2008-01-31").date()
     assert tri.development_grain == "M"
 
+def test_1d_monthly_valuation_date_expanded_dev_date -> None:
+    year_df = pd.DataFrame(
+        {
+            "origin": [1998, 1999, 2000, 2001, 2002],
+            "dev": [2008.0, 2008.0, 2008.0, 2008.0, 2008.0],
+            "expense": [890000, 1170000, 1265000, 1600000, 1200000],
+        }
+    )
+    tri = cl.Triangle(
+        data=year_df,
+        origin="origin",
+        development="dev",
+        columns="expense",
+        development_format="%Y",
+        cumulative=True,
+    )
+    assert pd.to_datetime(tri.valuation_date).date() == pd.Timestamp("2008-12-31").date()
+    assert tri.development_grain == "Y"
+
 def test_friedland_gl_self_insurer_grain() -> None:
     data_valuation_date = cl.load_sample('friedland_gl_self_insurer').valuation_date
     assert pd.to_datetime(data_valuation_date).date() == pd.Timestamp("2008-12-31").date()

--- a/chainladder/core/triangle.py
+++ b/chainladder/core/triangle.py
@@ -482,10 +482,10 @@ class Triangle(TriangleBase):
         )
 
         if len(development_date.unique()) == 1:
-            # checks if development has any non-yearly values
-            dev_has_no_month = not bool(
-                development
-                and not data[development[0]].astype(str).str.fullmatch(r"\d{4}").all()
+            # checks if development is not empty, and if ithas any non-yearly values
+            dev_has_no_month = not development or all(
+                data[col].astype(str).str.fullmatch(r"\d{4}").all()
+                for col in development
             )
 
             if len(data) == 1 or dev_has_no_month:

--- a/chainladder/core/triangle.py
+++ b/chainladder/core/triangle.py
@@ -484,7 +484,11 @@ class Triangle(TriangleBase):
         if len(development_date.unique()) == 1:
             # checks if development is not empty, and if ithas any non-yearly values
             dev_has_no_month = not development or all(
-                data[col].astype("Int64").str.fullmatch(r"\d{4}").all()
+                pd.to_numeric(data[col], errors="coerce")
+                .astype("Int64")
+                .astype(str)
+                .str.fullmatch(r"\d{4}")
+                .all()
                 for col in development
             )
 

--- a/chainladder/core/triangle.py
+++ b/chainladder/core/triangle.py
@@ -484,7 +484,7 @@ class Triangle(TriangleBase):
         if len(development_date.unique()) == 1:
             # checks if development is not empty, and if ithas any non-yearly values
             dev_has_no_month = not development or all(
-                data[col].astype(str).str.fullmatch(r"\d{4}").all()
+                data[col].astype("Int64").str.fullmatch(r"\d{4}").all()
                 for col in development
             )
 

--- a/chainladder/core/triangle.py
+++ b/chainladder/core/triangle.py
@@ -487,10 +487,11 @@ class Triangle(TriangleBase):
                 development
                 and not data[development[0]].astype(str).str.fullmatch(r"\d{4}").all()
             )
-            if (
-                (len(data) == 1 or dev_has_no_month)
-                and self.origin_grain.split("-")[0] in ["Y", "A"]
-            ):
+            # if (
+            #     (len(data) == 1 or dev_has_no_month)
+            #     and self.origin_grain.split("-")[0] in ["Y", "A"]
+            # ):
+            if len(data) == 1 or dev_has_no_month:
                 # if development has no monthly values, match origin
                 self.development_grain = self.origin_grain
             else:
@@ -1475,10 +1476,14 @@ class Triangle(TriangleBase):
         ddims = len(ddims.drop_duplicates())
         if ddims == 1 and sign == -1:
             ddims = len(obj.odims)
-        if obj.values.density > 0 and obj.values.coords[-1].min() < 0:
-            obj.values.coords[-1] = obj.values.coords[-1] - min(
-                obj.values.coords[-1].min(), min_slide
-            )
+        if obj.values.density > 0:
+            if obj.values.coords[-1].min() < 0:
+                obj.values.coords[-1] = obj.values.coords[-1] - min(
+                    obj.values.coords[-1].min(), min_slide
+                )
+            # The lag axis is stepped in development grain while ddims above is
+            # counted in origin periods, so it can be too short to hold the
+            # offset coordinates when the two grains differ.
             ddims = np.max([np.max(obj.values.coords[-1]) + 1, ddims])
         obj.values.shape = tuple(list(obj.shape[:-1]) + [ddims])
         if options.AUTO_SPARSE == False or backend == "cupy":

--- a/chainladder/core/triangle.py
+++ b/chainladder/core/triangle.py
@@ -487,10 +487,7 @@ class Triangle(TriangleBase):
                 development
                 and not data[development[0]].astype(str).str.fullmatch(r"\d{4}").all()
             )
-            # if (
-            #     (len(data) == 1 or dev_has_no_month)
-            #     and self.origin_grain.split("-")[0] in ["Y", "A"]
-            # ):
+
             if len(data) == 1 or dev_has_no_month:
                 # if development has no monthly values, match origin
                 self.development_grain = self.origin_grain

--- a/chainladder/core/triangle.py
+++ b/chainladder/core/triangle.py
@@ -482,7 +482,16 @@ class Triangle(TriangleBase):
         )
 
         if len(development_date.unique()) == 1:
-            if len(data) == 1 and self.origin_grain.split("-")[0] in ["Y", "A"]:
+            # checks if development has any non-yearly values
+            dev_has_no_month = not bool(
+                development
+                and not data[development[0]].astype(str).str.fullmatch(r"\d{4}").all()
+            )
+            if (
+                (len(data) == 1 or dev_has_no_month)
+                and self.origin_grain.split("-")[0] in ["Y", "A"]
+            ):
+                # if development has no monthly values, match origin
                 self.development_grain = self.origin_grain
             else:
                 dev_date = pd.to_datetime(development_date.iloc[0])

--- a/chainladder/core/triangle.py
+++ b/chainladder/core/triangle.py
@@ -1478,9 +1478,6 @@ class Triangle(TriangleBase):
                 obj.values.coords[-1] = obj.values.coords[-1] - min(
                     obj.values.coords[-1].min(), min_slide
                 )
-            # The lag axis is stepped in development grain while ddims above is
-            # counted in origin periods, so it can be too short to hold the
-            # offset coordinates when the two grains differ.
             ddims = np.max([np.max(obj.values.coords[-1]) + 1, ddims])
         obj.values.shape = tuple(list(obj.shape[:-1]) + [ddims])
         if options.AUTO_SPARSE == False or backend == "cupy":

--- a/chainladder/utils/data/_manifest.py
+++ b/chainladder/utils/data/_manifest.py
@@ -160,7 +160,6 @@ SAMPLES: dict = {
             "Paid Claims",
         ],
         "cumulative": True,
-        "development_format": "%Y-12-31",
     },
     "friedland_med_mal": {
         "origin": "Accident Year",


### PR DESCRIPTION
## Summary of Changes  
If valuation_date is of length 1 (there's only 1 diagonal), and it contains no month info, it will be defaulted to match origin grain instead

## Related GitHub Issue(s)  
Fixes #1192

## Additional Context for Reviewers  
Should be pretty easy to review, added 3 new tests.



<!-- Do not edit anything below this. -->

## Checklist
- [x] I passed tests locally for both code (`uv run pytest`) and documentation changes (`uv run --directory docs jb build . --builder=custom --custom-builder=doctest`)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core triangle construction and val/dev conversion logic used across the library; behavior shifts for single-diagonal inputs but is covered by new regression tests.
> 
> **Overview**
> Fixes **valuation / development grain** when every row shares one development date (fixes #1192). Triangles with a single diagonal no longer default to monthly grain when development values are year-only (e.g. `2008` or `%Y`).
> 
> **`Triangle.__init__`** now treats development as year-only when all development column values match `\d{4}`, or when there is only one data row—then **`development_grain` matches `origin_grain`**. If month-level information exists, it still compares the parsed date to the origin period end before choosing monthly vs origin grain.
> 
> **`val_to_dev` / `_val_dev`** always recomputes development-column width from coordinate extents when the array has density, not only when negative development indices need sliding—so single-diagonal triangles keep the correct lag dimension.
> 
> The **`friedland_gl_self_insurer`** sample manifest drops **`development_format: "%Y-12-31`** so loading uses the same inference rules. New tests cover annual vs monthly single-diagonal cases and the friedland sample’s `2008-12-31` valuation date.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bac78c58d32dc33ad8c926d9e670f26204289d07. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->