### PR TITLE
[DOCS] Add See Also links to core reserving methods

### DIFF
--- a/chainladder/adjustments/bootstrap.py
+++ b/chainladder/adjustments/bootstrap.py
@@ -47,6 +47,10 @@ class BootstrapODPSample(DevelopmentBase):
     scale_:
         The scale parameter to be used in generating process risk
 
+    See Also
+    --------
+    MackChainladder : Estimates prediction error for chainladder reserves.
+
     Examples
     --------
 

--- a/chainladder/methods/benktander.py
+++ b/chainladder/methods/benktander.py
@@ -37,6 +37,13 @@ class Benktander(MethodBase):
     ibnr_: Triangle
         The IBNR per the method
 
+    See Also
+    --------
+    Chainladder : Projects ultimate losses entirely from development patterns.
+    ExpectedLoss : Uses only an apriori expected ultimate.
+    BornhuetterFerguson : Blends development with an apriori ultimate.
+    CapeCod : Estimates apriori loss ratios from exposure.
+
     Examples
     --------
     Benktander is the iterated Bornhuetter-Ferguson model. Like BF, it

--- a/chainladder/methods/bornferg.py
+++ b/chainladder/methods/bornferg.py
@@ -40,8 +40,9 @@ class BornhuetterFerguson(Benktander):
     See Also
     --------
     Chainladder : Projects ultimate losses entirely from development patterns.
-    MackChainladder : Adds prediction error estimates to chainladder projections.
+    ExpectedLoss : Uses only an apriori expected ultimate.
     Benktander : Iterative generalization of the Bornhuetter-Ferguson method.
+    CapeCod : Estimates apriori loss ratios from exposure.
 
     Examples
     --------

--- a/chainladder/methods/bornferg.py
+++ b/chainladder/methods/bornferg.py
@@ -37,6 +37,12 @@ class BornhuetterFerguson(Benktander):
     ibnr_: Triangle
         The IBNR per the method
 
+    See Also
+    --------
+    Chainladder : Projects ultimate losses entirely from development patterns.
+    MackChainladder : Adds prediction error estimates to chainladder projections.
+    Benktander : Iterative generalization of the Bornhuetter-Ferguson method.
+
     Examples
     --------
     Bornhuetter-Ferguson requires an apriori expected ultimate per origin,

--- a/chainladder/methods/capecod.py
+++ b/chainladder/methods/capecod.py
@@ -55,6 +55,13 @@ class CapeCod(Benktander):
     detrended_apriori_:
         The detrended apriori vector developed by the Cape Cod Method
 
+    See Also
+    --------
+    Chainladder : Projects ultimate losses entirely from development patterns.
+    ExpectedLoss : Uses only an apriori expected ultimate.
+    BornhuetterFerguson : Blends development with an apriori ultimate.
+    Benktander : Iterative Bornhuetter-Ferguson method.
+
     Examples
     --------
     Unlike Bornhuetter-Ferguson and Benktander, CapeCod derives the apriori

--- a/chainladder/methods/chainladder.py
+++ b/chainladder/methods/chainladder.py
@@ -29,8 +29,10 @@ class Chainladder(MethodBase):
 
     See Also
     --------
-    MackChainladder : Stochastic extension with parameter and process risk.
-    BornhuetterFerguson : Blends development with an apriori ultimate estimate.
+    ExpectedLoss : Uses only an apriori expected ultimate.
+    BornhuetterFerguson : Blends development with an apriori ultimate.
+    Benktander : Iterative Bornhuetter-Ferguson method.
+    CapeCod : Estimates apriori loss ratios from exposure.
 
     Examples
     --------

--- a/chainladder/methods/chainladder.py
+++ b/chainladder/methods/chainladder.py
@@ -27,6 +27,11 @@ class Chainladder(MethodBase):
         The ultimates back-filled to each development period in **X** retaining
         the known data
 
+    See Also
+    --------
+    MackChainladder : Stochastic extension with parameter and process risk.
+    BornhuetterFerguson : Blends development with an apriori ultimate estimate.
+
     Examples
     --------
     Fit the chainladder method to a loss triangle and inspect the projected

--- a/chainladder/methods/expectedloss.py
+++ b/chainladder/methods/expectedloss.py
@@ -34,6 +34,13 @@ class ExpectedLoss(Benktander):
     ibnr_: Triangle
         The IBNR per the method
 
+    See Also
+    --------
+    Chainladder : Projects ultimate losses entirely from development patterns.
+    BornhuetterFerguson : Blends development with an apriori ultimate.
+    Benktander : Iterative Bornhuetter-Ferguson method.
+    CapeCod : Estimates apriori loss ratios from exposure.
+
     Examples
     --------
 

--- a/chainladder/methods/mack.py
+++ b/chainladder/methods/mack.py
@@ -42,8 +42,7 @@ class MackChainladder(Chainladder):
 
     See Also
     --------
-    Chainladder : Deterministic counterpart for ultimate and IBNR estimates.
-    BornhuetterFerguson : Apriori-weighted alternative to pure development.
+    BootstrapODPSample : Generates ODP bootstrap samples for reserve uncertainty.
 
     Examples
     --------

--- a/chainladder/methods/mack.py
+++ b/chainladder/methods/mack.py
@@ -40,6 +40,11 @@ class MackChainladder(Chainladder):
     total_mack_std_err_:
         The total prediction error across all origin periods
 
+    See Also
+    --------
+    Chainladder : Deterministic counterpart for ultimate and IBNR estimates.
+    BornhuetterFerguson : Apriori-weighted alternative to pure development.
+
     Examples
     --------
     Use ``MackChainladder`` when the IBNR point estimate alone is not


### PR DESCRIPTION
## Summary of Changes

- Add numpydoc `See Also` sections to the deterministic reserving estimators: `Chainladder`, `ExpectedLoss`, `BornhuetterFerguson`, `Benktander`, and `CapeCod`.
- Cross-link each deterministic estimator only to its deterministic peers.
- Cross-link the stochastic `MackChainladder` and `BootstrapODPSample` documentation.
- Documentation only; no reserving logic or public API behavior changes.

## Related GitHub Issue(s)

Part of #1137 — focused on the core reserving estimators.

## Additional Context for Reviewers

Validation:

- Full test suite — 1,037 passed, 2 skipped.
- Focused methods and adjustments suite after this update — 84 passed.
- Jupyter Book documentation build — 264 doctests passed, 0 failed.
- Parsed all seven docstrings with `numpydoc.docscrape.ClassDoc` and verified every intended `See Also` target.
- `git diff --check`

Disclosure: I used AI assistance while implementing and reviewing this documentation change. I reviewed the final seven-file diff and validation results before updating the PR.

<!-- Do not edit anything below this. -->

## Checklist

- [x] I passed tests locally for both code and documentation changes.