### PR TITLE
fix(parallelogram): support quarterly and semiannual origin grains

### DIFF
--- a/chainladder/adjustments/tests/test_parallelogram.py
+++ b/chainladder/adjustments/tests/test_parallelogram.py
@@ -507,3 +507,55 @@ def test_cumulative_duplicate_date_last_wins():
         np.round(olf.to_frame().values.flatten(), 6)
         == [0.67, 0.67, 0.67, 0.67, 0.67, 0.75, 1.0, 1.0, 1.0, 1.0, 1.0]
     )
+
+
+def _olf_for_freq(freq, rates):
+    """Fit ParallelogramOLF against a premium triangle of the given origin grain."""
+    origin = pd.date_range("2016-01-01", "2018-12-31", freq=freq)
+    triangle = cl.Triangle(
+        pd.DataFrame({"origin": origin, "values": 1.0}),
+        origin="origin",
+        columns="values",
+    )
+    olf = cl.ParallelogramOLF(
+        rate_history=rates,
+        change_col="RateChange",
+        date_col="EffDate",
+        vertical_line=False,
+    ).fit(triangle)
+    return triangle.origin_grain, np.asarray(olf.olf_.values).flatten()
+
+
+RATE_HISTORY = pd.DataFrame(
+    {
+        "EffDate": [pd.Timestamp("2016-07-01"), pd.Timestamp("2017-04-01")],
+        "RateChange": [0.08, 0.05],
+    }
+)
+
+
+@pytest.mark.parametrize(
+    "freq, grain, origins", [("YS", "Y", 3), ("2QS", "S", 6), ("QS", "Q", 12), ("MS", "M", 36)]
+)
+def test_olf_supports_every_origin_grain(freq, grain, origins):
+    # Quarterly and semiannual premium triangles used to raise ValueError, so
+    # only two of the four grains Triangle.origin_grain can return were usable.
+    # The row count is asserted because parallelogram_olf is broadcast against
+    # the triangle positionally: a semiannual result of length 12 would align
+    # against the wrong origins rather than fail.
+    observed_grain, olf = _olf_for_freq(freq, RATE_HISTORY)
+    assert observed_grain == grain
+    assert len(olf) == origins
+
+
+@pytest.mark.parametrize("grain, freq, months", [("Y", "YS", 12), ("S", "2QS", 6), ("Q", "QS", 3)])
+def test_olf_aggregates_consistently_with_monthly(grain, freq, months):
+    # An on-level factor is a ratio of rate levels, so a coarser grain is the
+    # reciprocal of the mean reciprocal of the months it spans. The "Y" case
+    # holds on unfixed code too and is kept as a control on the identity.
+    _, monthly = _olf_for_freq("MS", RATE_HISTORY)
+    _, coarse = _olf_for_freq(freq, RATE_HISTORY)
+    expected = np.array(
+        [1 / np.mean(1 / monthly[i : i + months]) for i in range(0, len(monthly), months)]
+    )
+    np.testing.assert_allclose(coarse, expected, rtol=1e-9)

--- a/chainladder/utils/utility_functions.py
+++ b/chainladder/utils/utility_functions.py
@@ -428,11 +428,18 @@ def _origin_periods(index, grain):
     """Bucket a DatetimeIndex into origin periods of the given Triangle grain.
 
     ``DatetimeIndex.to_period`` covers "Y", "Q" and "M" directly. It has no
-    semiannual frequency, and "2Q" does not stand in for one: pandas ignores the
-    multiple when converting to periods, so ``to_period("2Q")`` returns the same
-    four buckets a year that ``to_period("Q")`` does. "S" is therefore built by
-    collapsing each half year onto the quarter it starts in, which also matches
-    how Triangle labels a semiannual origin (``"%YQ%q"``).
+    semiannual frequency, and "2Q" does not stand in for one. The multiple is
+    honoured, so a "2Q" period is six months long, but each one is anchored to
+    the quarter of the observation rather than to a fixed half-year boundary,
+    so the windows overlap::
+
+        2016-01-01 -> 2016Q1 [2016-01-01 .. 2016-06-30]
+        2016-04-01 -> 2016Q2 [2016-04-01 .. 2016-09-30]
+
+    Grouping on that yields eight buckets over two years instead of four, which
+    would then be broadcast against a six-origin triangle. "S" is therefore
+    built by collapsing each half year onto the quarter it starts in, which also
+    matches how Triangle labels a semiannual origin (``"%YQ%q"``).
     """
     if grain == "S":
         quarters = index.to_period("Q")

--- a/chainladder/utils/utility_functions.py
+++ b/chainladder/utils/utility_functions.py
@@ -424,6 +424,27 @@ def read_json(json_str, array_backend=None):
         return cl.__dict__[json_dict["__class__"]]().set_params(**json_dict["params"])
 
 
+def _origin_periods(index, grain):
+    """Bucket a DatetimeIndex into origin periods of the given Triangle grain.
+
+    ``DatetimeIndex.to_period`` covers "Y", "Q" and "M" directly. It has no
+    semiannual frequency, and "2Q" does not stand in for one: pandas ignores the
+    multiple when converting to periods, so ``to_period("2Q")`` returns the same
+    four buckets a year that ``to_period("Q")`` does. "S" is therefore built by
+    collapsing each half year onto the quarter it starts in, which also matches
+    how Triangle labels a semiannual origin (``"%YQ%q"``).
+    """
+    if grain == "S":
+        quarters = index.to_period("Q")
+        return pd.PeriodIndex(
+            [
+                pd.Period(year=q.year, quarter=1 if q.quarter <= 2 else 3, freq="Q")
+                for q in quarters
+            ]
+        )
+    return index.to_period(grain)
+
+
 def parallelogram_olf(
     values,
     dates,
@@ -522,8 +543,13 @@ def parallelogram_olf(
 
         cum_avg = cum_avg.iloc[dropdates_base + leap_day :]
 
-        fcrl = cum_avg.groupby(cum_avg.index.to_period(grain)).mean().reset_index()
+        periods = _origin_periods(cum_avg.index, grain)
+        fcrl = cum_avg.groupby(periods).mean().reset_index()
         fcrl.columns = ["Origin", "OLF"]
+        # Carry the leap flag off the periods while they are still periods. It
+        # used to be recovered by strptime-parsing the stringified label, which
+        # only ever worked for the "Y" and "M" label shapes.
+        fcrl["is_leap"] = pd.PeriodIndex(fcrl["Origin"]).is_leap_year
         fcrl["Origin"] = fcrl["Origin"].astype(str)
         fcrl["OLF"] = crl / fcrl["OLF"]
 
@@ -533,16 +559,23 @@ def parallelogram_olf(
     fcrl_leaps = fcrl_non_leaps if approximation_grain == "M" else _fcrl_for_leap(True)
 
     combined = fcrl_non_leaps.join(fcrl_leaps, lsuffix="_non_leaps", rsuffix="_leaps")
-    combined["is_leap"] = pd.to_datetime(
-        combined["Origin_non_leaps"], format="%Y" + ("-%m" if grain == "M" else "")
-    ).dt.is_leap_year
 
     combined["final_OLF"] = np.where(
-        combined["is_leap"], combined["OLF_leaps"], combined["OLF_non_leaps"]
+        combined["is_leap_non_leaps"],
+        combined["OLF_leaps"],
+        combined["OLF_non_leaps"],
     )
 
     combined.drop(
-        ["OLF_non_leaps", "Origin_leaps", "OLF_leaps", "is_leap"], axis=1, inplace=True
+        [
+            "OLF_non_leaps",
+            "is_leap_non_leaps",
+            "Origin_leaps",
+            "OLF_leaps",
+            "is_leap_leaps",
+        ],
+        axis=1,
+        inplace=True,
     )
     combined.columns = ["Origin", "OLF"]
 

--- a/chainladder/utils/utility_functions.py
+++ b/chainladder/utils/utility_functions.py
@@ -17,7 +17,7 @@ from io import StringIO
 from patsy import dmatrix  # noqa
 from sklearn.base import BaseEstimator, TransformerMixin
 
-from typing import Iterable, Union, Optional, TYPE_CHECKING
+from typing import Union, Optional, TYPE_CHECKING
 
 if TYPE_CHECKING:
     from chainladder import Triangle, MethodBase, Pipeline
@@ -719,7 +719,7 @@ def concat(
     if ignore_index and axis == 0:
         out.key_labels = ["Index"]
     out.valuation_date = pd.Series([obj.valuation_date for obj in objs]).max()
-    if out.ddims.dtype == __dt64_dtype__ and type(out.ddims) == np.ndarray:
+    if out.ddims.dtype == __dt64_dtype__ and type(out.ddims) is np.ndarray:
         out.ddims = pd.DatetimeIndex(out.ddims)
     out._set_slicers()
     if sort:


### PR DESCRIPTION
## Summary of Changes

`ParallelogramOLF` raises `ValueError` on two of the four grains `Triangle.origin_grain` can return, so on-leveling a quarterly or semiannual premium triangle is not possible today:

```python
cl.ParallelogramOLF(rate_history=rates, change_col="RateChange",
                    date_col="EffDate", vertical_line=False).fit(premium_triangle)
```

| origin grain | result on `main` |
| --- | --- |
| `Y` | ok |
| `S` | `ValueError: Invalid frequency: S` |
| `Q` | `ValueError: unconverted data remains when parsing with format "%Y": "Q1"` |
| `M` | ok |

There are two independent causes, both in `parallelogram_olf`.

**The leap-year flag was recovered from the label after it had been stringified.** `utility_functions.py:536` parsed the origin string with a format built as `"%Y" + ("-%m" if grain == "M" else "")`, which only ever describes the `Y` and `M` label shapes, so `"2016Q1"` fails to parse. The flag is now taken off the `PeriodIndex` while it is still a `PeriodIndex`, which drops the dependency on label shape entirely.

**`to_period("S")` does not exist, and `"2Q"` is not a substitute.** pandas reads `"S"` as seconds. `"2Q"` looks like the obvious stand-in and is not one, though not for the reason I first gave here: the multiple *is* honoured, so a 2Q period is six months long. Each one is anchored to the quarter of the observation rather than to a fixed half-year boundary, so consecutive windows overlap (correction courtesy of @henrydingliu below):

```python
>>> idx = pd.date_range("2016-01-01", "2017-12-31", freq="MS")
>>> list(zip(idx[:4].date, idx[:4].to_period("2Q")))
[(2016-01-01, 2016Q1), (2016-02-01, 2016Q1), (2016-03-01, 2016Q1), (2016-04-01, 2016Q2)]
>>> idx.to_period("2Q")[0].start_time, idx.to_period("2Q")[0].end_time
(2016-01-01, 2016-06-30)
>>> idx.to_period("2Q")[3].start_time, idx.to_period("2Q")[3].end_time
(2016-04-01, 2016-09-30)
>>> len(set(idx.to_period("Q"))), len(set(idx.to_period("2Q")))
(8, 8)
```

Two years therefore give eight overlapping windows rather than four half years.

That matters more than it looks. `parallelogram_olf` is broadcast against the triangle positionally (`parallelogram.py:296` takes `.values[None, None]`), so a semiannual result of length 12 would misalign against a 6-origin triangle **silently**, rather than raising. The new `_origin_periods` helper therefore builds half years explicitly, labelled by the quarter they start in, which matches Triangle's own `"%YQ%q"` semiannual format (`triangle.py:855`).

## Related GitHub Issue(s)

Continues #524, which fixed the monthly grain. The leap-year handling was generalised as far as `M` there and stopped, leaving `Q` and `S` uncovered.

Related to #1050 (Centralize supported grain values). This PR is compatible with that refactor rather than a substitute for it: if the `S` / `2Q` mapping is centralised later, `_origin_periods` is the single place this function would consume it from.

## Additional Context for Reviewers

**Values, not just absence of a crash.** Results are checked against the aggregation identity used to validate #524, `OLF(period) == 1 / mean(1 / OLF(month))`. It holds to 2.2e-16 for both `S` and `Q`. The `Y` case passes on unfixed code as well and is kept in the suite as a control, so the identity is demonstrated rather than assumed.

**Row counts are asserted, not just values.** Y 3, S 6, Q 12, M 36 for a three-year triangle. The `S == 6` assertion is the one that catches a wrong semiannual bucketing, for the positional-broadcast reason above.

**Nothing changes for `Y` and `M`.** 72 scenarios covering both grains x `approximation_grain` M and D x `vertical_line` both ways x `policy_length` 6/12/24 x windows spanning the 2016 and 2020 leap years, including a 2020-02-29 effective date so the daily leap branch is exercised, hash identically before and after.

**The tests discriminate.** On unmodified code the new tests are 4 failed / 3 passed, the three passes being the `Y` and `M` controls; with the fix, 7 passed. Full suite 1049 passed, 2 skipped.

**About the second commit.** The ruff workflow lints whole changed files, and `utility_functions.py` already carried `F401` (unused `typing.Iterable`) and `E721` on `main` before this branch, so any PR touching this file reports them. I cleared them in a separate commit so it is easy to drop if you would rather keep that out of scope. `is` was used rather than `isinstance` to keep the comparison's exact meaning.

## Checklist
- [x] I passed tests locally for both code (`uv run pytest`) and documentation changes
