### PR TITLE
docs: add Triangle.heatmap examples (#704)

### DIFF
--- a/chainladder/core/display.py
+++ b/chainladder/core/display.py
@@ -158,6 +158,11 @@ class TriangleDisplay:
         Color the background in a gradient according to the data in each
         column (optionally row). Requires matplotlib.
 
+        Styles a single 2-D triangle for notebook display and returns an
+        IPython HTML object. Multi-dimensional triangles raise
+        ``ValueError``. See the :ref:`User Guide <triangle:heatmap>` for a
+        rendered example.
+
         Parameters
         ----------
 
@@ -173,51 +178,6 @@ class TriangleDisplay:
         Returns
         -------
             Ipython.display.HTML
-
-        Examples
-        --------
-        ``heatmap`` styles a single 2-D triangle for notebook display. The
-        return value is an IPython HTML object with a background gradient.
-
-        .. testsetup::
-
-            import chainladder as cl
-
-        .. testcode::
-
-            html = cl.load_sample('raa').heatmap()
-            print(type(html).__name__)
-            print('background-color' in html.data)
-
-        .. testoutput::
-
-            HTML
-            True
-
-        A different matplotlib colormap can be passed to ``cmap``. The result
-        is still HTML; only the colors change.
-
-        .. testcode::
-
-            html = cl.load_sample('raa').heatmap(cmap='viridis')
-            print(type(html).__name__)
-
-        .. testoutput::
-
-            HTML
-
-        Multi-dimensional triangles are not supported.
-
-        .. testcode::
-
-            try:
-                cl.load_sample('clrd').heatmap()
-            except ValueError as err:
-                print(err)
-
-        .. testoutput::
-
-            heatmap() only works with a single triangle.
         """
         if self._dimensionality == 'single':
             data = self._repr_format()

--- a/chainladder/core/display.py
+++ b/chainladder/core/display.py
@@ -174,6 +174,50 @@ class TriangleDisplay:
         -------
             Ipython.display.HTML
 
+        Examples
+        --------
+        ``heatmap`` styles a single 2-D triangle for notebook display. The
+        return value is an IPython HTML object with a background gradient.
+
+        .. testsetup::
+
+            import chainladder as cl
+
+        .. testcode::
+
+            html = cl.load_sample('raa').heatmap()
+            print(type(html).__name__)
+            print('background-color' in html.data)
+
+        .. testoutput::
+
+            HTML
+            True
+
+        A different matplotlib colormap can be passed to ``cmap``. The result
+        is still HTML; only the colors change.
+
+        .. testcode::
+
+            html = cl.load_sample('raa').heatmap(cmap='viridis')
+            print(type(html).__name__)
+
+        .. testoutput::
+
+            HTML
+
+        Multi-dimensional triangles are not supported.
+
+        .. testcode::
+
+            try:
+                cl.load_sample('clrd').heatmap()
+            except ValueError as err:
+                print(err)
+
+        .. testoutput::
+
+            heatmap() only works with a single triangle.
         """
         if self._dimensionality == 'single':
             data = self._repr_format()

--- a/docs/user_guide/triangle.ipynb
+++ b/docs/user_guide/triangle.ipynb
@@ -1246,6 +1246,7 @@
    "id": "a6a578af",
    "metadata": {},
    "source": [
+    "(triangle:heatmap)=\n",
     "### Link Ratios\n",
     "\n",
     "The age-to-age factors or link ratios of a Triangle can be accessed with the\n",


### PR DESCRIPTION
## Summary of Changes

- Add doctest `Examples` for `Triangle.heatmap` in `chainladder/core/display.py`.
- Cover the default colormap, an alternate `cmap`, and the multi-dimensional `ValueError`.

## Related GitHub Issue(s)

- https://github.com/casact/chainladder-python/issues/704

## Additional Context for Reviewers

Bite-sized core-module follow-up for #704. Companions: slicing #1208, I/O #1209.

HTML output is asserted by type and by the presence of `background-color` rather than dumping the full markup.

## Checklist
- [x] I passed tests locally for both code (uv run pytest) and documentation changes (uv run --directory docs jb build . --builder=custom --custom-builder=doctest)

Made with [Cursor](https://cursor.com)