### PR TITLE
Fix ParallelogramOLF ValueError with approximation_grain="D" after a leap year

### DIFF
--- a/chainladder/adjustments/tests/test_parallelogram.py
+++ b/chainladder/adjustments/tests/test_parallelogram.py
@@ -509,6 +509,33 @@ def test_cumulative_duplicate_date_last_wins():
     )
 
 
+def test_daily_grain_after_leap_year():
+    """Daily approximation_grain must not misalign origins after a leap year.
+
+    A rate change effective in the leap year 2016, combined with a triangle
+    whose first origin is 2017-01-01, used to leak a spurious extra "2016"
+    origin bucket into the daily-grain calculation, causing a shape mismatch
+    when the OLF was broadcast against the triangle. See GH #1219.
+    """
+    rates = pd.DataFrame({"EffDate": [pd.Timestamp("2016-07-01")], "RateChange": [0.05]})
+    origin = pd.date_range("2017-01-01", "2019-12-31", freq="YS")
+    triangle = cl.Triangle(
+        pd.DataFrame({"origin": origin, "values": 1.0}),
+        origin="origin",
+        columns="values",
+    )
+
+    olf = cl.ParallelogramOLF(
+        rate_history=rates,
+        change_col="RateChange",
+        date_col="EffDate",
+        approximation_grain="D",
+    ).fit(triangle)
+
+    assert len(olf.olf_.origin) == 3
+    assert olf.olf_.to_frame().notna().all().all()
+
+
 def _olf_for_freq(freq, rates):
     """Fit ParallelogramOLF against a premium triangle of the given origin grain."""
     origin = pd.date_range("2016-01-01", "2018-12-31", freq=freq)

--- a/chainladder/utils/utility_functions.py
+++ b/chainladder/utils/utility_functions.py
@@ -478,9 +478,11 @@ def parallelogram_olf(
     dates = pd.to_datetime(dates)
 
     if start_date:
-        start_date = pd.to_datetime(start_date) - pd.tseries.offsets.DateOffset(days=1)
+        true_start_date = pd.to_datetime(start_date)
+        start_date = true_start_date - pd.tseries.offsets.DateOffset(days=1)
     else:
-        start_date = pd.to_datetime("{}-01-01".format(dates.min().year))
+        true_start_date = pd.to_datetime("{}-01-01".format(dates.min().year))
+        start_date = true_start_date
 
     if not end_date:
         end_date = pd.to_datetime("{}-12-31".format(dates.max().year))
@@ -551,6 +553,16 @@ def parallelogram_olf(
         cum_avg = cum_avg.iloc[dropdates_base + leap_day :]
 
         periods = _origin_periods(cum_avg.index, grain)
+        # The day-count drop above is an approximation and, depending on
+        # where leap days fall relative to start_date, can leave in a
+        # handful of days that belong to the origin period just before the
+        # triangle's actual first origin. Left uncorrected, that spurious
+        # period ends up as an extra row that misaligns everything against
+        # the triangle when broadcast (see GH #1219). Clip it here.
+        min_period = _origin_periods(pd.DatetimeIndex([true_start_date]), grain)[0]
+        keep = periods >= min_period
+        cum_avg = cum_avg[keep]
+        periods = periods[keep]
         fcrl = cum_avg.groupby(periods).mean().reset_index()
         fcrl.columns = ["Origin", "OLF"]
         # Carry the leap flag off the periods while they are still periods. It


### PR DESCRIPTION
Fixes #1219.

`ParallelogramOLF(..., approximation_grain="D")` throws a broadcast `ValueError` when a rate change lands in a leap year right before the triangle's first origin:

```python
rates = pd.DataFrame({"EffDate": [pd.Timestamp("2016-07-01")], "RateChange": [0.05]})
origin = pd.date_range("2017-01-01", "2019-12-31", freq="YS")
triangle = cl.Triangle(pd.DataFrame({"origin": origin, "values": 1.0}), origin="origin", columns="values")
cl.ParallelogramOLF(rate_history=rates, change_col="RateChange", date_col="EffDate", approximation_grain="D").fit(triangle)
# ValueError: operands could not be broadcast together with shapes (1,1,3,1) (1,1,4,1)
```

The daily day-count window (`dropdates_base + leap_day`) is an approximation meant to move the window back by exactly `lookback_years`. Depending on where the leap day falls, it can leave in a few trailing days from the calendar year before the triangle's real first origin, which get grouped into a spurious extra origin row.

Fix: capture the triangle's true first origin before the existing `-1 day` offset is applied, and clip anything computed before it.

Ran locally:
```
$ pytest chainladder/adjustments/tests/test_parallelogram.py -q
20 passed, 19 warnings in 6.63s
```
