### PR TITLE
Fix ParallelogramOLF daily-grain ValueError on triangles starting after a leap year

### DIFF
--- a/chainladder/adjustments/tests/test_parallelogram.py
+++ b/chainladder/adjustments/tests/test_parallelogram.py
@@ -559,3 +559,30 @@ def test_olf_aggregates_consistently_with_monthly(grain, freq, months):
         [1 / np.mean(1 / monthly[i : i + months]) for i in range(0, len(monthly), months)]
     )
     np.testing.assert_allclose(coarse, expected, rtol=1e-9)
+
+
+def test_daily_grain_after_leap_year():
+    # A daily approximation on a triangle whose origins start right after a leap
+    # year used to trim the lookback window by row count, which dropped one more
+    # row in the leap pass than the non-leap pass. When that row was the only one
+    # of its origin period the two passes produced a different number of origins
+    # and .fit() failed with a broadcast error.
+    rates = pd.DataFrame({
+        "EffDate": [pd.Timestamp("2016-07-01")],
+        "RateChange": [0.05],
+    })
+    origin = pd.date_range("2017-01-01", "2019-12-31", freq="YS")
+    triangle = cl.Triangle(
+        pd.DataFrame({"origin": origin, "values": 1.0}),
+        origin="origin",
+        columns="values",
+        cumulative=True,
+    )
+    olf = cl.ParallelogramOLF(
+        rate_history=rates,
+        change_col="RateChange",
+        date_col="EffDate",
+        approximation_grain="D",
+    ).fit(triangle)
+    assert len(olf.olf_.origin) == len(triangle.origin)
+    assert not olf.olf_.to_frame(origin_as_datetime=False).isna().any().any()

--- a/chainladder/adjustments/tests/test_parallelogram.py
+++ b/chainladder/adjustments/tests/test_parallelogram.py
@@ -47,7 +47,8 @@ def test_non_vertical_line():
     )
 
     result = (
-        cl.parallelogram_olf([0.20], ["7/1/2017"], approximation_grain="D")
+        cl
+        .parallelogram_olf([0.20], ["7/1/2017"], approximation_grain="D")
         .loc["2017"]
         .iloc[0]
         - 1
@@ -56,16 +57,15 @@ def test_non_vertical_line():
     assert true_olf == result
 
     # Monthly approximation
-    rate_history = pd.DataFrame(
-        {
-            "EffDate": ["2010-07-01", "2011-01-01", "2012-07-01", "2013-04-01"],
-            "RateChange": [0.035, 0.05, 0.10, -0.01],
-        }
-    )
+    rate_history = pd.DataFrame({
+        "EffDate": ["2010-07-01", "2011-01-01", "2012-07-01", "2013-04-01"],
+        "RateChange": [0.035, 0.05, 0.10, -0.01],
+    })
 
-    data = pd.DataFrame(
-        {"Year": list(range(2006, 2016)), "EarnedPremium": [10_000] * 10}
-    )
+    data = pd.DataFrame({
+        "Year": list(range(2006, 2016)),
+        "EarnedPremium": [10_000] * 10,
+    })
 
     prem_tri = cl.Triangle(
         data, origin="Year", columns="EarnedPremium", cumulative=True
@@ -94,16 +94,15 @@ def test_non_vertical_line():
     ).all()
 
     # Daily approximation
-    rate_history = pd.DataFrame(
-        {
-            "EffDate": ["2010-07-01", "2011-01-01", "2012-07-01", "2013-04-01"],
-            "RateChange": [0.035, 0.05, 0.10, -0.01],
-        }
-    )
+    rate_history = pd.DataFrame({
+        "EffDate": ["2010-07-01", "2011-01-01", "2012-07-01", "2013-04-01"],
+        "RateChange": [0.035, 0.05, 0.10, -0.01],
+    })
 
-    data = pd.DataFrame(
-        {"Year": list(range(2006, 2016)), "EarnedPremium": [10_000] * 10}
-    )
+    data = pd.DataFrame({
+        "Year": list(range(2006, 2016)),
+        "EarnedPremium": [10_000] * 10,
+    })
 
     prem_tri = cl.Triangle(
         data, origin="Year", columns="EarnedPremium", cumulative=True
@@ -141,15 +140,14 @@ def test_vertical_line():
 
 
 def test_policy_length():
-    rate_history = pd.DataFrame(
-        {
-            "EffDate": ["2010-07-01", "2011-01-01", "2012-04-01"],
-            "RateChange": [0.05, 0.1, -0.01],
-        }
-    )
-    data = pd.DataFrame(
-        {"Year": [2010, 2011, 2012, 2013, 2014], "EarnedPremium": [10_000] * 5}
-    )
+    rate_history = pd.DataFrame({
+        "EffDate": ["2010-07-01", "2011-01-01", "2012-04-01"],
+        "RateChange": [0.05, 0.1, -0.01],
+    })
+    data = pd.DataFrame({
+        "Year": [2010, 2011, 2012, 2013, 2014],
+        "EarnedPremium": [10_000] * 5,
+    })
     prem_tri = cl.Triangle(
         data, origin="Year", columns="EarnedPremium", cumulative=True
     )
@@ -170,15 +168,14 @@ def test_policy_length():
         == [1.129333, 1.013023, 0.994975, 1, 1]
     ).all()
 
-    rate_history = pd.DataFrame(
-        {
-            "EffDate": ["2010-07-01", "2011-10-01", "2012-04-01"],
-            "RateChange": [0.35, 0.149, -0.095],
-        }
-    )
-    data = pd.DataFrame(
-        {"Year": [2010, 2011, 2012, 2013, 2014], "EarnedPremium": [10_000] * 5}
-    )
+    rate_history = pd.DataFrame({
+        "EffDate": ["2010-07-01", "2011-10-01", "2012-04-01"],
+        "RateChange": [0.35, 0.149, -0.095],
+    })
+    data = pd.DataFrame({
+        "Year": [2010, 2011, 2012, 2013, 2014],
+        "EarnedPremium": [10_000] * 5,
+    })
     prem_tri = cl.Triangle(
         data, origin="Year", columns="EarnedPremium", cumulative=True
     )
@@ -207,15 +204,14 @@ def test_policy_length():
         == [1.290842, 1.030251, 0.958285, 1, 1]
     ).all()
 
-    rate_history = pd.DataFrame(
-        {
-            "EffDate": ["2010-07-01"],
-            "RateChange": [0.20],
-        }
-    )
-    data = pd.DataFrame(
-        {"Year": [2010, 2011, 2012, 2013, 2014], "EarnedPremium": [10_000] * 5}
-    )
+    rate_history = pd.DataFrame({
+        "EffDate": ["2010-07-01"],
+        "RateChange": [0.20],
+    })
+    data = pd.DataFrame({
+        "Year": [2010, 2011, 2012, 2013, 2014],
+        "EarnedPremium": [10_000] * 5,
+    })
     prem_tri = cl.Triangle(
         data,
         origin="Year",
@@ -224,7 +220,8 @@ def test_policy_length():
     )
 
     lhs = np.round(
-        cl.ParallelogramOLF(
+        cl
+        .ParallelogramOLF(
             rate_history,
             change_col="RateChange",
             date_col="EffDate",
@@ -255,25 +252,29 @@ def test_policy_length():
     )
 
     assert (
-        cl.parallelogram_olf(df_prem["Rate Changes"], df_prem["Date"])
+        cl
+        .parallelogram_olf(df_prem["Rate Changes"], df_prem["Date"])
         .reset_index()["OLF"]
         .notna()
         .all()
     )
     assert (
-        cl.parallelogram_olf(df_prem["Rate Changes"], df_prem["Date"], policy_length=12)
+        cl
+        .parallelogram_olf(df_prem["Rate Changes"], df_prem["Date"], policy_length=12)
         .reset_index()["OLF"]
         .notna()
         .all()
     )
     assert (
-        cl.parallelogram_olf(df_prem["Rate Changes"], df_prem["Date"], policy_length=6)
+        cl
+        .parallelogram_olf(df_prem["Rate Changes"], df_prem["Date"], policy_length=6)
         .reset_index()["OLF"]
         .notna()
         .all()
     )
     assert (
-        cl.parallelogram_olf(
+        cl
+        .parallelogram_olf(
             df_prem["Rate Changes"],
             df_prem["Date"],
             policy_length=6,
@@ -286,15 +287,14 @@ def test_policy_length():
 
 
 def test_rate_impact_middle_of_year():
-    rate_history = pd.DataFrame(
-        {
-            "EffDate": ["2010-01-01"],
-            "RateChange": [0.20],
-        }
-    )
-    data = pd.DataFrame(
-        {"Year": [2010, 2011, 2012, 2013, 2014], "EarnedPremium": [10_000] * 5}
-    )
+    rate_history = pd.DataFrame({
+        "EffDate": ["2010-01-01"],
+        "RateChange": [0.20],
+    })
+    data = pd.DataFrame({
+        "Year": [2010, 2011, 2012, 2013, 2014],
+        "EarnedPremium": [10_000] * 5,
+    })
     prem_tri = cl.Triangle(
         data,
         origin="Year",
@@ -303,7 +303,8 @@ def test_rate_impact_middle_of_year():
     )
 
     monthly = np.round(
-        cl.ParallelogramOLF(
+        cl
+        .ParallelogramOLF(
             rate_history,
             change_col="RateChange",
             date_col="EffDate",
@@ -317,7 +318,8 @@ def test_rate_impact_middle_of_year():
     )
     # print(monthly)
     daily = np.round(
-        cl.ParallelogramOLF(
+        cl
+        .ParallelogramOLF(
             rate_history,
             change_col="RateChange",
             date_col="EffDate",
@@ -335,15 +337,14 @@ def test_rate_impact_middle_of_year():
 
 
 def test_rate_impact_beginning_of_year():
-    rate_history = pd.DataFrame(
-        {
-            "EffDate": ["2010-07-01"],
-            "RateChange": [0.20],
-        }
-    )
-    data = pd.DataFrame(
-        {"Year": [2010, 2011, 2012, 2013, 2014], "EarnedPremium": [10_000] * 5}
-    )
+    rate_history = pd.DataFrame({
+        "EffDate": ["2010-07-01"],
+        "RateChange": [0.20],
+    })
+    data = pd.DataFrame({
+        "Year": [2010, 2011, 2012, 2013, 2014],
+        "EarnedPremium": [10_000] * 5,
+    })
     prem_tri = cl.Triangle(
         data,
         origin="Year",
@@ -352,7 +353,8 @@ def test_rate_impact_beginning_of_year():
     )
 
     monthly = np.round(
-        cl.ParallelogramOLF(
+        cl
+        .ParallelogramOLF(
             rate_history,
             change_col="RateChange",
             date_col="EffDate",
@@ -366,7 +368,8 @@ def test_rate_impact_beginning_of_year():
     )
     # print(monthly)
     daily = np.round(
-        cl.ParallelogramOLF(
+        cl
+        .ParallelogramOLF(
             rate_history,
             change_col="RateChange",
             date_col="EffDate",
@@ -386,14 +389,13 @@ def test_rate_impact_beginning_of_year():
 
 def test_cumulative_tort_reform():
     """Cumulative on-level factors can be supplied directly. See GH #922."""
-    tort = pd.DataFrame(
-        {
-            "EffDate": ["1998-01-01", "2003-01-01", "2004-01-01"],
-            "Factor": [0.67, 0.75, 1.00],
-        }
-    )
+    tort = pd.DataFrame({
+        "EffDate": ["1998-01-01", "2003-01-01", "2004-01-01"],
+        "Factor": [0.67, 0.75, 1.00],
+    })
     olf = (
-        cl.ParallelogramOLF(
+        cl
+        .ParallelogramOLF(
             rate_history=tort,
             change_col="Factor",
             date_col="EffDate",
@@ -413,9 +415,10 @@ def test_cumulative_tort_reform():
 
 def test_cumulative_matches_incremental():
     """Cumulative factors and their incremental equivalent agree."""
-    data = pd.DataFrame(
-        {"Year": list(range(2006, 2016)), "EarnedPremium": [10_000] * 10}
-    )
+    data = pd.DataFrame({
+        "Year": list(range(2006, 2016)),
+        "EarnedPremium": [10_000] * 10,
+    })
     prem_tri = cl.Triangle(
         data, origin="Year", columns="EarnedPremium", cumulative=True
     )
@@ -442,9 +445,10 @@ def test_cumulative_matches_incremental():
                 cumulative=True,
                 **kw,
             ).fit_transform(prem_tri)
-            assert np.allclose(
-                incremental.olf_.values, cumulative.olf_.values
-            ), (grain, vertical_line)
+            assert np.allclose(incremental.olf_.values, cumulative.olf_.values), (
+                grain,
+                vertical_line,
+            )
 
 
 def test_cumulative_rejects_non_positive():
@@ -463,11 +467,13 @@ def test_cumulative_factor_predates_window():
     prem_tri = cl.Triangle(
         data, origin="Year", columns="EarnedPremium", cumulative=True
     )
-    factors = pd.DataFrame(
-        {"EffDate": ["2000-01-01", "2005-01-01"], "Factor": [0.5, 1.0]}
-    )
+    factors = pd.DataFrame({
+        "EffDate": ["2000-01-01", "2005-01-01"],
+        "Factor": [0.5, 1.0],
+    })
     olf = (
-        cl.ParallelogramOLF(
+        cl
+        .ParallelogramOLF(
             rate_history=factors,
             change_col="Factor",
             date_col="EffDate",
@@ -485,14 +491,13 @@ def test_cumulative_factor_predates_window():
 
 def test_cumulative_duplicate_date_last_wins():
     """Duplicate effective dates keep the last cumulative factor, not a product."""
-    dup = pd.DataFrame(
-        {
-            "EffDate": ["1998-01-01", "2003-01-01", "2003-01-01", "2004-01-01"],
-            "Factor": [0.67, 0.67, 0.75, 1.00],
-        }
-    )
+    dup = pd.DataFrame({
+        "EffDate": ["1998-01-01", "2003-01-01", "2003-01-01", "2004-01-01"],
+        "Factor": [0.67, 0.67, 0.75, 1.00],
+    })
     olf = (
-        cl.ParallelogramOLF(
+        cl
+        .ParallelogramOLF(
             rate_history=dup,
             change_col="Factor",
             date_col="EffDate",
@@ -526,16 +531,15 @@ def _olf_for_freq(freq, rates):
     return triangle.origin_grain, np.asarray(olf.olf_.values).flatten()
 
 
-RATE_HISTORY = pd.DataFrame(
-    {
-        "EffDate": [pd.Timestamp("2016-07-01"), pd.Timestamp("2017-04-01")],
-        "RateChange": [0.08, 0.05],
-    }
-)
+RATE_HISTORY = pd.DataFrame({
+    "EffDate": [pd.Timestamp("2016-07-01"), pd.Timestamp("2017-04-01")],
+    "RateChange": [0.08, 0.05],
+})
 
 
 @pytest.mark.parametrize(
-    "freq, grain, origins", [("YS", "Y", 3), ("2QS", "S", 6), ("QS", "Q", 12), ("MS", "M", 36)]
+    "freq, grain, origins",
+    [("YS", "Y", 3), ("2QS", "S", 6), ("QS", "Q", 12), ("MS", "M", 36)],
 )
 def test_olf_supports_every_origin_grain(freq, grain, origins):
     # Quarterly and semiannual premium triangles used to raise ValueError, so
@@ -548,16 +552,18 @@ def test_olf_supports_every_origin_grain(freq, grain, origins):
     assert len(olf) == origins
 
 
-@pytest.mark.parametrize("grain, freq, months", [("Y", "YS", 12), ("S", "2QS", 6), ("Q", "QS", 3)])
+@pytest.mark.parametrize(
+    "grain, freq, months", [("Y", "YS", 12), ("S", "2QS", 6), ("Q", "QS", 3)]
+)
 def test_olf_aggregates_consistently_with_monthly(grain, freq, months):
     # An on-level factor is a ratio of rate levels, so a coarser grain is the
     # reciprocal of the mean reciprocal of the months it spans. The "Y" case
     # holds on unfixed code too and is kept as a control on the identity.
     _, monthly = _olf_for_freq("MS", RATE_HISTORY)
     _, coarse = _olf_for_freq(freq, RATE_HISTORY)
-    expected = np.array(
-        [1 / np.mean(1 / monthly[i : i + months]) for i in range(0, len(monthly), months)]
-    )
+    expected = np.array([
+        1 / np.mean(1 / monthly[i : i + months]) for i in range(0, len(monthly), months)
+    ])
     np.testing.assert_allclose(coarse, expected, rtol=1e-9)
 
 

--- a/chainladder/utils/utility_functions.py
+++ b/chainladder/utils/utility_functions.py
@@ -95,9 +95,7 @@ def load_sample(key: str, *args, **kwargs) -> Triangle:
             what data are available.
             
             You supplied: {}
-            """.format(
-                key
-            )
+            """.format(key)
         )
 
     dataset_path: str = os.path.join(utils_path, "data", key.lower() + ".csv")
@@ -170,8 +168,9 @@ def list_samples(include_grain: bool = True) -> DataFrame:
     .. code-block:: python
 
         import chainladder as cl
-        cl.list_samples()                    # full table, grain included
-        cl.list_samples(include_grain=False) # fast, metadata only
+
+        cl.list_samples()  # full table, grain included
+        cl.list_samples(include_grain=False)  # fast, metadata only
     """
     records: list = []
     for name in sorted(SAMPLES):
@@ -443,12 +442,10 @@ def _origin_periods(index, grain):
     """
     if grain == "S":
         quarters = index.to_period("Q")
-        return pd.PeriodIndex(
-            [
-                pd.Period(year=q.year, quarter=1 if q.quarter <= 2 else 3, freq="Q")
-                for q in quarters
-            ]
-        )
+        return pd.PeriodIndex([
+            pd.Period(year=q.year, quarter=1 if q.quarter <= 2 else 3, freq="Q")
+            for q in quarters
+        ])
     return index.to_period(grain)
 
 
@@ -563,7 +560,9 @@ def parallelogram_olf(
     # Join on the origin period rather than row position.
     combined = fcrl_non_leaps.join(fcrl_leaps, lsuffix="_non_leaps", rsuffix="_leaps")
     is_leap = combined["is_leap_non_leaps"].fillna(combined["is_leap_leaps"])
-    combined["OLF"] = np.where(is_leap, combined["OLF_leaps"], combined["OLF_non_leaps"])
+    combined["OLF"] = np.where(
+        is_leap, combined["OLF_leaps"], combined["OLF_non_leaps"]
+    )
 
     return combined[["OLF"]]
 
@@ -960,9 +959,10 @@ class PatsyFormula(BaseEstimator, TransformerMixin):
 
 
 def model_diagnostics(
-        model: Triangle | MethodBase | Pipeline, 
-        name: str | None = None, 
-        groupby: str | list(str) | None = None) -> Triangle:
+    model: Triangle | MethodBase | Pipeline,
+    name: str | None = None,
+    groupby: str | list(str) | None = None,
+) -> Triangle:
     """A helper function that summarizes various vectors of an
     IBNR model as columns of a Triangle
 
@@ -978,7 +978,7 @@ def model_diagnostics(
 
     Returns
     -------
-    Triangle with relevant figures as columns, including 
+    Triangle with relevant figures as columns, including
     - ``Latest``: Cumulative value at the latest valuation date, equivalent to ``latest_diagonal``
     - ``Month/Quarter/Year Incremental``: Actual emergence between the latest valuation and the one prior valuation date
     - ``LDF``: Age-to-age loss development factor to the next development/valuation period (from ``ldf_``); ignored if ``groupby`` is supplied
@@ -988,8 +988,8 @@ def model_diagnostics(
     - ``Run Off 1/2/3...``: Expected incremental emergence in successive future valuation periods (from ``full_expectation_``)
     - ``Apriori``: Expected ultimate for Benktander family of methods (from ``expectation_``)
 
-    Columns from the original Triangle are cross-joined into the index. 
-    ``Measure`` will contain all the columns from the original Triangle. 
+    Columns from the original Triangle are cross-joined into the index.
+    ``Measure`` will contain all the columns from the original Triangle.
     """
     from chainladder import Pipeline, Triangle
 
@@ -1035,7 +1035,8 @@ def model_diagnostics(
                 obj.X_
                 - obj.X_[
                     val
-                    < pd.Period(out.valuation_date, freq="Q")
+                    < pd
+                    .Period(out.valuation_date, freq="Q")
                     .to_timestamp(how="s")
                     .strftime("%Y-%m")
                 ]
@@ -1049,8 +1050,12 @@ def model_diagnostics(
         else:
             out["Year Incremental"] = 0
         if groupby is None:
-            out["LDF"] = obj.ldf_.align_pattern(obj.X_.incr_to_cum(), sample_weight=obj.ultimate_[col])[col]
-            out["CDF"] = obj.cdf_.align_pattern(obj.X_.incr_to_cum(), sample_weight=obj.ultimate_[col])[col]
+            out["LDF"] = obj.ldf_.align_pattern(
+                obj.X_.incr_to_cum(), sample_weight=obj.ultimate_[col]
+            )[col]
+            out["CDF"] = obj.cdf_.align_pattern(
+                obj.X_.incr_to_cum(), sample_weight=obj.ultimate_[col]
+            )[col]
         out["Ultimate"] = obj.ultimate_[col]
         out["IBNR"] = out["Ultimate"] - out["Latest"]
         for i in range(run_off.shape[-1]):
@@ -1089,20 +1094,16 @@ def PTF_formula(
         graingamma = [(i + 1) * dgrain for i in gamma]
         for ind in range(1, len(graingamma)):
             formula_parts += [
-                "+".join(
-                    [
-                        f"I((np.minimum({graingamma[ind]},development) - np.minimum({graingamma[ind - 1]},development)) / {dgrain})"
-                    ]
-                )
+                "+".join([
+                    f"I((np.minimum({graingamma[ind]},development) - np.minimum({graingamma[ind - 1]},development)) / {dgrain})"
+                ])
             ]
     if iota:
         for ind in range(1, len(iota)):
             formula_parts += [
-                "+".join(
-                    [
-                        f"I(np.minimum({iota[ind]},valuation) - np.minimum({iota[ind - 1]},valuation))"
-                    ]
-                )
+                "+".join([
+                    f"I(np.minimum({iota[ind]},valuation) - np.minimum({iota[ind - 1]},valuation))"
+                ])
             ]
     if formula_parts:
         return "+".join(formula_parts)

--- a/chainladder/utils/utility_functions.py
+++ b/chainladder/utils/utility_functions.py
@@ -478,9 +478,11 @@ def parallelogram_olf(
     dates = pd.to_datetime(dates)
 
     if start_date:
-        start_date = pd.to_datetime(start_date) - pd.tseries.offsets.DateOffset(days=1)
+        window_start = pd.to_datetime(start_date)
+        start_date = window_start - pd.tseries.offsets.DateOffset(days=1)
     else:
-        start_date = pd.to_datetime("{}-01-01".format(dates.min().year))
+        window_start = pd.to_datetime("{}-01-01".format(dates.min().year))
+        start_date = window_start
 
     if not end_date:
         end_date = pd.to_datetime("{}-12-31".format(dates.max().year))
@@ -522,33 +524,26 @@ def parallelogram_olf(
         "M": policy_length,
         "D": int(365 * policy_length / 12),
     }[approximation_grain]
-    dropdates_base = {
-        "M": 12 * lookback_years,
-        "D": 366 * lookback_years,
-    }[approximation_grain]
 
     def _fcrl_for_leap(is_leap_year: bool):
         # In monthly mode every month is treated as an equal length period, so a
-        # leap day has no effect on the rolling window or the lookback drop.
+        # leap day has no effect on the rolling window.
         if approximation_grain == "M":
             is_leap_year = False
 
-        if is_leap_year:
-            leap_day = 1
-        else:
-            leap_day = 0
+        leap_day = 1 if is_leap_year else 0
 
         if vertical_line:  # rectangle method, rate change impact is immediate
             cum_avg = cum_rate_changes
 
         else:  # parallelogram method, rate change impact is overtime
-            #
             average_period = max(rolling_num_base + leap_day, 1)
 
             cum_avg = cum_rate_changes.rolling(average_period).mean()
             cum_avg = (cum_avg + cum_avg.shift(1).values) / 2
 
-        cum_avg = cum_avg.iloc[dropdates_base + leap_day :]
+        # Trim the lookback window by date so both passes span the same origins.
+        cum_avg = cum_avg[cum_avg.index >= window_start]
 
         periods = _origin_periods(cum_avg.index, grain)
         fcrl = cum_avg.groupby(periods).mean().reset_index()
@@ -560,33 +555,17 @@ def parallelogram_olf(
         fcrl["Origin"] = fcrl["Origin"].astype(str)
         fcrl["OLF"] = crl / fcrl["OLF"]
 
-        return fcrl
+        return fcrl.set_index("Origin")
 
     fcrl_non_leaps = _fcrl_for_leap(False)
     fcrl_leaps = fcrl_non_leaps if approximation_grain == "M" else _fcrl_for_leap(True)
 
+    # Join on the origin period rather than row position.
     combined = fcrl_non_leaps.join(fcrl_leaps, lsuffix="_non_leaps", rsuffix="_leaps")
+    is_leap = combined["is_leap_non_leaps"].fillna(combined["is_leap_leaps"])
+    combined["OLF"] = np.where(is_leap, combined["OLF_leaps"], combined["OLF_non_leaps"])
 
-    combined["final_OLF"] = np.where(
-        combined["is_leap_non_leaps"],
-        combined["OLF_leaps"],
-        combined["OLF_non_leaps"],
-    )
-
-    combined.drop(
-        [
-            "OLF_non_leaps",
-            "is_leap_non_leaps",
-            "Origin_leaps",
-            "OLF_leaps",
-            "is_leap_leaps",
-        ],
-        axis=1,
-        inplace=True,
-    )
-    combined.columns = ["Origin", "OLF"]
-
-    return combined.set_index("Origin")
+    return combined[["OLF"]]
 
 
 def set_common_backend(objs):


### PR DESCRIPTION
Closes #1219.

With `approximation_grain="D"`, `parallelogram_olf` trimmed the lookback window from the front of the daily grid by a fixed row count (`366 * lookback_years`). The leap pass trims one extra row than the non-leap pass, and when that row is the only day of the first origin period the two passes group into a different number of origins - 3 vs 4 on the repro. The result is then broadcast against the triangle positionally, so the mismatch surfaces as `ValueError: operands could not be broadcast together with shapes (1,1,3,1) (1,1,4,1)` inside `.fit()`.

It also meant the trim landed a day or so away from the real window start, so a partial origin period (a single 2016-12-31 day here) could leak in even when the counts happened to match.

The fix trims by date instead: both passes keep everything from the actual window start (`origin[0]` for the ParallelogramOLF path, Jan 1 of the earliest rate year otherwise), so they always span the same origins. The two passes are then joined on the origin period rather than on row position, and the leap flag is filled from whichever side is present, so a future divergence in either pass can't silently mis-pair origins again. Monthly and non-leap daily results are unchanged apart from at most a one-day shift at the leading origin from trimming at the true boundary.

```
$ python -m pytest chainladder/adjustments/tests/test_parallelogram.py -q
20 passed

$ python -m pytest chainladder/adjustments/ chainladder/utils/tests/ -q
140 passed, 1 skipped
```

The daily-after-leap case from the issue is added as a regression test.
