### PR TITLE
[BUG] Respect dropped link ratios when applying n_periods

### DIFF
--- a/chainladder/development/base.py
+++ b/chainladder/development/base.py
@@ -82,11 +82,31 @@ class DevelopmentBase(
             .to_frame()
         )
 
-    def _assign_n_periods_weight(self, X, n_periods):
-        """Used to apply the n_periods weight"""
+    def _assign_n_periods_weight(self, X, n_periods, candidate_weight=None):
+        """Used to apply the n_periods weight.
 
-        def _assign_n_periods_weight_int(X, n_periods):
+        When ``candidate_weight`` is supplied, it represents factors that have
+        already been excluded (for example through ``drop`` or
+        ``drop_valuation``).  ``n_periods`` is then applied to the most recent
+        remaining factors rather than to a fixed calendar window.
+        """
+
+        def _assign_n_periods_weight_int(X, n_periods, candidate_weight):
             xp = X.get_array_module()
+            if candidate_weight is not None:
+                candidate = (
+                    candidate_weight[None, None]
+                    if candidate_weight.ndim == 2
+                    else candidate_weight
+                )
+                valid = candidate > 0
+                if n_periods < 1 or n_periods >= X.shape[-2] - 1:
+                    return candidate
+                rank_from_latest = xp.cumsum(valid[..., ::-1, :], axis=2)[
+                    ..., ::-1, :
+                ]
+                return (valid & (rank_from_latest <= n_periods)).astype(float)
+
             val_offset = {
                 "Y": {"Y": 1},
                 "S": {"Y": 2, "S": 1},
@@ -106,7 +126,7 @@ class DevelopmentBase(
         xp = X.get_array_module()
 
         dict_map = {
-            item: _assign_n_periods_weight_int(X, item)
+            item: _assign_n_periods_weight_int(X, item, candidate_weight)
             for item in set(n_periods.flatten())
         }
 

--- a/chainladder/development/development.py
+++ b/chainladder/development/development.py
@@ -414,9 +414,17 @@ class Development(DevelopmentBase):
         else:
             self.w_v2_ = tw.fit(obj.age_to_age).w_
 
+        drop_adjustment = self._drop_adjustment(obj, link_ratio)
+        candidate_weight = None
+        if (self.drop is not None) | (self.drop_valuation is not None):
+            candidate_weight = np.isfinite(link_ratio).astype(float)
+        if self.drop is not None:
+            candidate_weight = candidate_weight * self._drop(obj)
+        if self.drop_valuation is not None:
+            candidate_weight = candidate_weight * self._drop_valuation(obj)
         self.w_ = self._assign_n_periods_weight(
-            obj, n_periods_
-        ) * self._drop_adjustment(obj, link_ratio)
+            obj, n_periods_, candidate_weight
+        ) * drop_adjustment
 
         params = WeightedRegression(axis=2, thru_orig=True, xp=xp).fit(
             x, y, self.w_, average_

--- a/chainladder/development/tests/test_development.py
+++ b/chainladder/development/tests/test_development.py
@@ -125,6 +125,21 @@ def test_n_periods():
         == _FutureDevelopment(dev).fit(d).ldf_
     )
 
+
+def test_n_periods_uses_most_recent_non_dropped_link_ratio(raa):
+    dev = cl.Development(n_periods=1, drop=("1989", 12)).fit(raa)
+
+    assert dev.ldf_.values[0, 0, 0, 0] == pytest.approx(6947 / 1351)
+
+
+def test_n_periods_ignores_non_finite_link_ratios_after_drop(raa):
+    raa = raa.set_backend("numpy")
+    raa.values[0, 0, 7, 0] = 0
+    dev = cl.Development(n_periods=1, drop=("1989", 12)).fit(raa)
+
+    assert dev.ldf_.values[0, 0, 0, 0] == pytest.approx(4020 / 557)
+
+
 def test_drophighlow(raa):
     dev = cl.Development(drop_high=0)
     lhs = np.round(dev.fit(raa).cdf_.values, 4).flatten()
@@ -836,4 +851,3 @@ def test_pct_reported_requires_ldf(raa):
         raa.pct_reported_
     with pytest.raises(AttributeError):
         raa.pct_unreported_
-


### PR DESCRIPTION
Fixes #604

## Summary

n_periods now selects the most recent valid link ratios after applying drop and drop_valuation.

Previously, dropping the latest ratio could leave the selected period empty and result in a NaN LDF.

## Changes

- Apply explicit exclusions before selecting periods.
- Skip non-finite link ratios when choosing the fallback period.
- Add regression coverage for both cases.