### PR TITLE
ENH Add one-period triangle backtesting

### DIFF
--- a/chainladder/__init__.py
+++ b/chainladder/__init__.py
@@ -506,6 +506,7 @@ from chainladder.methods import (  # noqa (API import)
 )
 from chainladder.workflow import (  # noqa (API import)
     GridSearch,
+    Backtest,
     Pipeline,
     VotingChainladder,
     TriangleSelector,

--- a/chainladder/tests/test_public_api.py
+++ b/chainladder/tests/test_public_api.py
@@ -73,6 +73,7 @@ EXPECTED_PUBLIC_API = {
     "ExpectedLoss",
     # workflow
     "GridSearch",
+    "Backtest",
     "Pipeline",
     "VotingChainladder",
     "TriangleSelector",

--- a/chainladder/workflow/__init__.py
+++ b/chainladder/workflow/__init__.py
@@ -1,9 +1,11 @@
 from chainladder.workflow.gridsearch import GridSearch, Pipeline  # noqa (API import)
+from chainladder.workflow.backtesting import Backtest  # noqa (API import)
 from chainladder.workflow.voting import VotingChainladder  # noqa (API import)
 from chainladder.workflow.voting import TriangleSelector  # noqa (API import)
 
 __all__ = [
     "GridSearch",
+    "Backtest",
     "Pipeline",
     "VotingChainladder",
     "TriangleSelector"

--- a/chainladder/workflow/backtesting.py
+++ b/chainladder/workflow/backtesting.py
@@ -12,13 +12,13 @@ from chainladder.methods import Chainladder
 
 
 class Backtest(BaseEstimator, EstimatorIO):
-    """One-period-ahead diagonal backtesting for reserving methods.
+    """Multi-period diagonal backtesting for reserving methods.
 
     Each backtest fits a fresh copy of ``estimator`` using data available at a
     historical valuation date. The projected cumulative values for origins
-    present at that date are compared with the next observed valuation
-    diagonal. This makes the class useful for short-tailed business where the
-    next reporting period is a practical validation horizon.
+    present at that date are compared with the observed valuation diagonal at
+    the selected horizon. This makes the class useful for short-tailed business
+    where one or a few reporting periods are practical validation horizons.
 
     Parameters
     ----------
@@ -33,6 +33,9 @@ class Backtest(BaseEstimator, EstimatorIO):
     n_periods : int, default=3
         Number of most recent eligible valuation periods to backtest when
         ``valuation_periods`` is not supplied.
+    horizon : int, default=1
+        Number of reporting periods between the training valuation and the
+        observed valuation used for comparison.
 
     Attributes
     ----------
@@ -68,10 +71,12 @@ class Backtest(BaseEstimator, EstimatorIO):
         estimator=None,
         valuation_periods: str | list[str] | None = None,
         n_periods: int = 3,
+        horizon: int = 1,
     ):
         self.estimator = estimator
         self.valuation_periods = valuation_periods
         self.n_periods = n_periods
+        self.horizon = horizon
 
     @staticmethod
     def _to_long(triangle, value_name: str) -> pd.DataFrame:
@@ -89,9 +94,14 @@ class Backtest(BaseEstimator, EstimatorIO):
     def _get_valuation_periods(self, X) -> pd.DatetimeIndex:
         available = X.valuation[X.valuation <= X.valuation_date]
         available = pd.DatetimeIndex(available.drop_duplicates().sort_values())
-        eligible = available[:-1]
+        if not isinstance(self.horizon, int) or self.horizon < 1:
+            raise ValueError("horizon must be a positive integer.")
+        eligible = available[:-self.horizon]
         if len(eligible) == 0:
-            raise ValueError("At least two observed valuation periods are required.")
+            raise ValueError(
+                "The triangle does not have enough observed valuation periods "
+                "for the selected horizon."
+            )
 
         if self.valuation_periods is None:
             if not isinstance(self.n_periods, int) or self.n_periods < 1:
@@ -108,7 +118,7 @@ class Backtest(BaseEstimator, EstimatorIO):
             values = ", ".join(missing.astype(str))
             raise ValueError(
                 "valuation_periods must be observed periods with a following "
-                f"valuation period. Invalid periods: {values}."
+                f"valuation period at the selected horizon. Invalid periods: {values}."
             )
         return pd.DatetimeIndex(
             [eligible[eligible_periods.get_loc(period)] for period in requested]
@@ -138,7 +148,7 @@ class Backtest(BaseEstimator, EstimatorIO):
         results = []
         self.models_ = {}
         for valuation in periods:
-            target_valuation = available[available.get_loc(valuation) + 1]
+            target_valuation = available[available.get_loc(valuation) + self.horizon]
             train = obj[obj.valuation <= valuation]
             fitted = clone(estimator)
             if sample_weight is None:
@@ -161,6 +171,7 @@ class Backtest(BaseEstimator, EstimatorIO):
                 )
             result["valuation"] = valuation
             result["target_valuation"] = target_valuation
+            result["horizon"] = self.horizon
             result["error"] = result["actual"] - result["predicted"]
             result["absolute_error"] = result["error"].abs()
             result["absolute_percentage_error"] = np.where(
@@ -174,7 +185,7 @@ class Backtest(BaseEstimator, EstimatorIO):
         self.results_ = pd.concat(results, ignore_index=True)
         self.summary_ = (
             self.results_
-            .groupby(["valuation", "target_valuation"], as_index=False)
+            .groupby(["valuation", "target_valuation", "horizon"], as_index=False)
             .agg(
                 observations=("actual", "size"),
                 actual=("actual", "sum"),

--- a/chainladder/workflow/backtesting.py
+++ b/chainladder/workflow/backtesting.py
@@ -1,0 +1,192 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+from sklearn.base import BaseEstimator, clone
+
+from chainladder.core.io import EstimatorIO
+from chainladder.methods import Chainladder
+
+
+class Backtest(BaseEstimator, EstimatorIO):
+    """One-period-ahead diagonal backtesting for reserving methods.
+
+    Each backtest fits a fresh copy of ``estimator`` using data available at a
+    historical valuation date. The projected cumulative values for origins
+    present at that date are compared with the next observed valuation
+    diagonal. This makes the class useful for short-tailed business where the
+    next reporting period is a practical validation horizon.
+
+    Parameters
+    ----------
+    estimator : estimator, optional
+        Reserving estimator with a ``full_triangle_`` attribute after fitting.
+        Defaults to :class:`~chainladder.Chainladder`.
+    valuation_periods : str or list of str, optional
+        Historical valuation periods to backtest.  For example, annual data
+        accepts ``["2021", "2022"]`` and quarterly data accepts
+        ``["2022Q3", "2022Q4"]``.  Each period must have a following observed
+        valuation period.
+    n_periods : int, default=3
+        Number of most recent eligible valuation periods to backtest when
+        ``valuation_periods`` is not supplied.
+
+    Attributes
+    ----------
+    results_ : DataFrame
+        Cell-level forecast results with actual, predicted, and error fields.
+    summary_ : DataFrame
+        Aggregated backtest results by valuation period.
+    valuation_periods_ : DatetimeIndex
+        Historical valuation dates used for the backtest.
+
+    Examples
+    --------
+    Backtest the two most recent annual valuation periods.
+
+    .. testsetup::
+
+        import chainladder as cl
+
+    .. testcode::
+
+        result = cl.Backtest(n_periods=2).fit(cl.load_sample("raa"))
+        print(result.summary_.loc[:, ["observations", "error"]].round(2))
+
+    .. testoutput::
+
+       observations    error
+    0             8  3639.56
+    1             9 -7129.31
+    """
+
+    def __init__(
+        self,
+        estimator=None,
+        valuation_periods: str | list[str] | None = None,
+        n_periods: int = 3,
+    ):
+        self.estimator = estimator
+        self.valuation_periods = valuation_periods
+        self.n_periods = n_periods
+
+    @staticmethod
+    def _to_long(triangle, value_name: str) -> pd.DataFrame:
+        """Convert a Triangle to a consistent long-form DataFrame."""
+        frame = triangle.to_frame(keepdims=True).reset_index()
+        id_vars = triangle.key_labels + ["origin", "development"]
+        value_columns = [column for column in triangle.columns if column in frame]
+        return frame.melt(
+            id_vars=id_vars,
+            value_vars=value_columns,
+            var_name="column",
+            value_name=value_name,
+        )
+
+    def _get_valuation_periods(self, X) -> pd.DatetimeIndex:
+        available = X.valuation[X.valuation <= X.valuation_date]
+        available = pd.DatetimeIndex(available.drop_duplicates().sort_values())
+        eligible = available[:-1]
+        if len(eligible) == 0:
+            raise ValueError("At least two observed valuation periods are required.")
+
+        if self.valuation_periods is None:
+            if not isinstance(self.n_periods, int) or self.n_periods < 1:
+                raise ValueError("n_periods must be a positive integer.")
+            return eligible[-self.n_periods :]
+
+        requested = [self.valuation_periods]
+        if not isinstance(self.valuation_periods, str):
+            requested = self.valuation_periods
+        requested = pd.PeriodIndex(requested, freq=X.development_grain)
+        eligible_periods = pd.PeriodIndex(eligible, freq=X.development_grain)
+        missing = requested[~requested.isin(eligible_periods)]
+        if len(missing):
+            values = ", ".join(missing.astype(str))
+            raise ValueError(
+                "valuation_periods must be observed periods with a following "
+                f"valuation period. Invalid periods: {values}."
+            )
+        return pd.DatetimeIndex(
+            [eligible[eligible_periods.get_loc(period)] for period in requested]
+        )
+
+    @staticmethod
+    def _full_triangle(fitted):
+        """Return a fitted estimator's full triangle, including pipeline support."""
+        if hasattr(fitted, "full_triangle_"):
+            return fitted.full_triangle_
+        if hasattr(fitted, "named_steps"):
+            for step in reversed(fitted.named_steps.values()):
+                if hasattr(step, "full_triangle_"):
+                    return step.full_triangle_
+        raise ValueError(
+            "estimator must expose full_triangle_ after fitting to run a backtest."
+        )
+
+    def fit(self, X, y=None, sample_weight=None):
+        """Fit backtests at the selected historical valuation periods."""
+        obj = X.incr_to_cum()
+        available = obj.valuation[obj.valuation <= obj.valuation_date]
+        available = pd.DatetimeIndex(available.drop_duplicates().sort_values())
+        periods = self._get_valuation_periods(obj)
+        estimator = Chainladder() if self.estimator is None else self.estimator
+
+        results = []
+        self.models_ = {}
+        for valuation in periods:
+            target_valuation = available[available.get_loc(valuation) + 1]
+            train = obj[obj.valuation <= valuation]
+            fitted = clone(estimator)
+            if sample_weight is None:
+                fitted.fit(train)
+            else:
+                weight = sample_weight[sample_weight.valuation <= valuation]
+                fitted.fit(train, sample_weight=weight)
+            self.models_[valuation] = fitted
+
+            predicted = self._to_long(self._full_triangle(fitted), "predicted")
+            actual = self._to_long(
+                obj[obj.valuation == target_valuation], "actual"
+            )
+            keys = obj.key_labels + ["origin", "development", "column"]
+            result = actual.merge(predicted, on=keys, how="inner")
+            result = result[np.isfinite(result["actual"]) & np.isfinite(result["predicted"])]
+            if result.empty:
+                raise ValueError(
+                    "No projected cells aligned with the next observed valuation diagonal."
+                )
+            result["valuation"] = valuation
+            result["target_valuation"] = target_valuation
+            result["error"] = result["actual"] - result["predicted"]
+            result["absolute_error"] = result["error"].abs()
+            result["absolute_percentage_error"] = np.where(
+                result["actual"] == 0,
+                np.nan,
+                result["absolute_error"] / result["actual"].abs(),
+            )
+            results.append(result)
+
+        self.valuation_periods_ = periods
+        self.results_ = pd.concat(results, ignore_index=True)
+        self.summary_ = (
+            self.results_
+            .groupby(["valuation", "target_valuation"], as_index=False)
+            .agg(
+                observations=("actual", "size"),
+                actual=("actual", "sum"),
+                predicted=("predicted", "sum"),
+                error=("error", "sum"),
+                absolute_error=("absolute_error", "sum"),
+                mean_absolute_percentage_error=("absolute_percentage_error", "mean"),
+            )
+        )
+        self.summary_["absolute_percentage_error"] = np.where(
+            self.summary_["actual"] == 0,
+            np.nan,
+            self.summary_["absolute_error"] / self.summary_["actual"].abs(),
+        )
+        return self

--- a/chainladder/workflow/tests/test_backtesting.py
+++ b/chainladder/workflow/tests/test_backtesting.py
@@ -32,6 +32,14 @@ def test_backtest_uses_most_recent_periods(raa):
     assert result.summary_["observations"].gt(0).all()
 
 
+def test_backtest_supports_multi_period_horizons(raa):
+    result = cl.Backtest(valuation_periods="1987", horizon=2).fit(raa)
+
+    target = pd.Period(result.summary_.loc[0, "target_valuation"], freq="Y")
+    assert str(target) == "1989"
+    assert result.summary_.loc[0, "horizon"] == 2
+
+
 def test_backtest_compares_the_next_observed_diagonal(raa):
     result = cl.Backtest(n_periods=1).fit(raa)
     target = result.summary_.loc[0, "target_valuation"]
@@ -57,3 +65,8 @@ def test_backtest_accepts_a_pipeline_estimator(raa):
 def test_backtest_rejects_period_without_following_valuation(raa):
     with pytest.raises(ValueError, match="following valuation period"):
         cl.Backtest(valuation_periods="1990").fit(raa)
+
+
+def test_backtest_rejects_invalid_horizon(raa):
+    with pytest.raises(ValueError, match="horizon"):
+        cl.Backtest(horizon=0).fit(raa)

--- a/chainladder/workflow/tests/test_backtesting.py
+++ b/chainladder/workflow/tests/test_backtesting.py
@@ -1,0 +1,59 @@
+import pandas as pd
+import pytest
+import chainladder as cl
+
+
+def test_backtest_uses_requested_valuation_periods(raa):
+    result = cl.Backtest(valuation_periods=["1987", "1988"]).fit(raa)
+
+    periods = pd.PeriodIndex(result.valuation_periods_, freq="Y").astype(str)
+    targets = pd.PeriodIndex(result.summary_["target_valuation"], freq="Y").astype(str)
+
+    assert periods.tolist() == ["1987", "1988"]
+    assert targets.tolist() == ["1988", "1989"]
+    assert {"actual", "predicted", "error"}.issubset(result.results_.columns)
+
+
+def test_backtest_accepts_quarterly_valuation_periods():
+    quarterly = cl.load_sample("quarterly")
+
+    result = cl.Backtest(valuation_periods="2005Q3").fit(quarterly)
+
+    period = pd.PeriodIndex(result.valuation_periods_, freq="Q").astype(str)
+    assert period.tolist() == ["2005Q3"]
+
+
+def test_backtest_uses_most_recent_periods(raa):
+    result = cl.Backtest(n_periods=2).fit(raa)
+
+    periods = pd.PeriodIndex(result.valuation_periods_, freq="Y").astype(str)
+
+    assert periods.tolist() == ["1988", "1989"]
+    assert result.summary_["observations"].gt(0).all()
+
+
+def test_backtest_compares_the_next_observed_diagonal(raa):
+    result = cl.Backtest(n_periods=1).fit(raa)
+    target = result.summary_.loc[0, "target_valuation"]
+    next_diagonal = raa[raa.valuation == target].to_frame(keepdims=True)
+
+    expected_actual = next_diagonal.loc[
+        next_diagonal["origin"].isin(result.results_["origin"]), "values"
+    ]
+    assert result.results_["actual"].sum() == expected_actual.sum()
+
+
+def test_backtest_accepts_a_pipeline_estimator(raa):
+    estimator = cl.Pipeline(
+        [("development", cl.Development()), ("model", cl.Chainladder())]
+    )
+
+    result = cl.Backtest(estimator=estimator, n_periods=1).fit(raa)
+
+    assert result.summary_["observations"].tolist() == [9]
+    assert len(result.models_) == 1
+
+
+def test_backtest_rejects_period_without_following_valuation(raa):
+    with pytest.raises(ValueError, match="following valuation period"):
+        cl.Backtest(valuation_periods="1990").fit(raa)

--- a/docs/library/api.md
+++ b/docs/library/api.md
@@ -145,6 +145,7 @@ Classes
   Pipeline
   VotingChainladder
   GridSearch
+  Backtest
 
 
 .. _utils_ref:


### PR DESCRIPTION
Adds a Backtest workflow for reserve validation across one or more reporting periods.\n\nUsers can backtest the latest n_periods or select valuation periods explicitly, then choose a horizon. Each run fits the reserving model using data available at that valuation and compares projected cumulative values with the observed diagonal at the selected horizon.