### PR TITLE
ENH Add reserving report workflow

### DIFF
--- a/chainladder/__init__.py
+++ b/chainladder/__init__.py
@@ -506,6 +506,7 @@ from chainladder.methods import (  # noqa (API import)
 )
 from chainladder.workflow import (  # noqa (API import)
     GridSearch,
+    ReservingReport,
     Pipeline,
     VotingChainladder,
     TriangleSelector,

--- a/chainladder/tests/test_public_api.py
+++ b/chainladder/tests/test_public_api.py
@@ -73,6 +73,7 @@ EXPECTED_PUBLIC_API = {
     "ExpectedLoss",
     # workflow
     "GridSearch",
+    "ReservingReport",
     "Pipeline",
     "VotingChainladder",
     "TriangleSelector",

--- a/chainladder/workflow/__init__.py
+++ b/chainladder/workflow/__init__.py
@@ -1,9 +1,11 @@
 from chainladder.workflow.gridsearch import GridSearch, Pipeline  # noqa (API import)
+from chainladder.workflow.reporting import ReservingReport  # noqa (API import)
 from chainladder.workflow.voting import VotingChainladder  # noqa (API import)
 from chainladder.workflow.voting import TriangleSelector  # noqa (API import)
 
 __all__ = [
     "GridSearch",
+    "ReservingReport",
     "Pipeline",
     "VotingChainladder",
     "TriangleSelector"

--- a/chainladder/workflow/reporting.py
+++ b/chainladder/workflow/reporting.py
@@ -1,0 +1,63 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+"""Portable reserving audit reports."""
+from __future__ import annotations
+
+from html import escape
+
+import pandas as pd
+from sklearn.base import BaseEstimator
+
+from chainladder.core.io import EstimatorIO
+
+
+class ReservingReport(BaseEstimator, EstimatorIO):
+    """Compile reserving outputs and assumptions into a self-contained HTML report.
+
+    Parameters
+    ----------
+    title : str, default="Reserving report"
+        Heading displayed in the report.
+    assumptions : dict, optional
+        Named assumptions such as valuation date, method, yield curve, or risk
+        adjustment approach.
+    """
+
+    def __init__(self, title: str = "Reserving report", assumptions: dict | None = None):
+        self.title = title
+        self.assumptions = assumptions
+
+    def fit(self, X, y=None):
+        """Compile a mapping of section names to report DataFrames."""
+        if not isinstance(X, dict) or not X:
+            raise ValueError("X must be a non-empty dictionary of report DataFrames.")
+        if any(not isinstance(value, pd.DataFrame) for value in X.values()):
+            raise TypeError("Every report section must be a pandas DataFrame.")
+        self.sections_ = {str(name): frame.copy() for name, frame in X.items()}
+        assumptions = self.assumptions or {}
+        if not isinstance(assumptions, dict):
+            raise TypeError("assumptions must be a dictionary.")
+        self.assumptions_ = assumptions.copy()
+        self.html_ = self.to_html()
+        return self
+
+    def to_html(self) -> str:
+        """Render the fitted report as portable HTML."""
+        if not hasattr(self, "sections_"):
+            raise ValueError("Fit the report before rendering it.")
+        assumptions = "".join(
+            f"<dt>{escape(str(key))}</dt><dd>{escape(str(value))}</dd>"
+            for key, value in self.assumptions_.items()
+        )
+        sections = "".join(
+            f"<section><h2>{escape(name)}</h2>{frame.to_html(index=False, border=0)}</section>"
+            for name, frame in self.sections_.items()
+        )
+        return (
+            "<!doctype html><html><head><meta charset='utf-8'><title>"
+            f"{escape(self.title)}</title><style>body{{font-family:system-ui;margin:2rem;}}"
+            "table{border-collapse:collapse;}th,td{padding:.4rem;border-bottom:1px solid #ddd;}"
+            "dt{font-weight:600;}dd{margin:0 0 .5rem;}</style></head><body>"
+            f"<h1>{escape(self.title)}</h1><dl>{assumptions}</dl>{sections}</body></html>"
+        )

--- a/chainladder/workflow/tests/test_reporting.py
+++ b/chainladder/workflow/tests/test_reporting.py
@@ -1,0 +1,19 @@
+import pandas as pd
+import pytest
+
+import chainladder as cl
+
+
+def test_reserving_report_renders_sections_and_assumptions():
+    report = cl.ReservingReport(
+        title="Q4 reserve review", assumptions={"Method": "Chainladder"}
+    ).fit({"Quality check": pd.DataFrame({"check": ["missing"], "count": [0]})})
+
+    assert "Q4 reserve review" in report.html_
+    assert "Quality check" in report.html_
+    assert "Chainladder" in report.html_
+
+
+def test_reserving_report_validates_sections():
+    with pytest.raises(ValueError, match="dictionary"):
+        cl.ReservingReport().fit({})


### PR DESCRIPTION
Adds ReservingReport for compiling reserving outputs and assumptions into a portable HTML audit pack.\n\nUsers supply named DataFrame sections such as quality checks, backtesting, rollforward, sensitivity, and financial measurement outputs.