### PR TITLE
New PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -27,7 +27,7 @@
 - [ ] The implementation is appropriate, maintainable, and follows ARCHITECTURE.md.
 - [ ] PR subject title has the proper prefix and the subject is appropriate.
 - [ ] Relevant issue(s) are linked.
-- [ ] AI/LLM Usage is diclosed are proper and usage is appropriate.
+- [ ] AI/LLM usage is diclosed are proper and usage is appropriate.
 - [ ] Documentation and tests are appropriate.
 - [ ] Additional reviewer is requested or not needed.
 - [ ] CI tests passed or failure are acceptable.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -19,13 +19,7 @@
 
 ## Submitter's Checklist
 - [ ] I have reviewed and am adhering to the standards outlined in the project [Governing Doc](https://github.com/casact/chainladder-python/blob/main/docs/library/governance.md).
-- [ ] The PR subject title summarizes the changes, with a proper prefix:
-    [FIX] for bug fixes
-    [FEAT] for enhancements
-    [DOCS] for documentation
-    [TST] for unit testing
-    [CHORE] for chores and maintenance tasks
-    [BRK] for breaking changes, deprecations, and removals
+- [ ] The PR subject title summarizes the changes, with one proper prefix (`[FIX]`, `[FEAT]`, `[DOCS]`, `[TST]`, `[CHORE]`, or `[BRK]`).
 - [ ] I am a human (not a bot), and this PR is not AI generated.
 
 ## Reviewer's Checklist

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -18,7 +18,7 @@
 <!-- Do not edit anything below until the ticket is open. Checklists below. -->
 
 ## Submitter's Checklist
-- [ ] I have reviewed and am adhering to the standards outlined in the project Governing Doc.
+- [ ] I have reviewed and am adhering to the standards outlined in the project [Governing Doc](https://github.com/casact/chainladder-python/blob/main/docs/library/governance.md).
 - [ ] The PR subject title summarizes the changes, with a proper prefix:
     [FIX] for bug fixes
     [FEAT] for enhancements

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,6 +2,10 @@
 
 
 ## Related GitHub Issue(s)  
+<!-- Use keywords like close/closes/closed or fix/fixes/fixed to close the issue automatically -->
+
+## AI/LLM Usage
+<!-- Declare and briefly describe any AI/LLM assistance used and the extent of usage during development. -->
 
 
 ## Additional Context for Reviewers  
@@ -9,7 +13,29 @@
 
 
 
-<!-- Do not edit anything below this. -->
+<!-- Do not edit anything below until the ticket is open. Checklists below. -->
 
-## Checklist
-- [ ] I passed tests locally for both code (`uv run pytest`) and documentation changes (`uv run --directory docs jb build . --builder=custom --custom-builder=doctest`)
+## Submitter's Checklist
+- [ ] I have reviewed and am adhering to the standards outlined in the project Governing Doc.
+- [ ] The PR subject title summarizes the changes, with a proper prefix:
+    [FIX] for bug fixes
+    [FEAT] for enhancements
+    [DOCS] for documentation
+    [TST] for unit testing
+    [CHORE] for chores and maintenance tasks
+    [BRK] for breaking changes, deprecations, and removals
+- [ ] I am a human (not a bot), and this PR is not AI generated.
+
+
+## Reviewer's Checklist
+- [ ] The implementation addresses the associated issue(s).
+- [ ] The implementation is appropriate, maintainable, and follows ARCHITECTURE.md.
+- [ ] AI disclosures are complete and usage is appropriate.
+- [ ] PR subject title is appropriate.
+- [ ] Relevant issue(s) are linked.
+- [ ] Documentation and tests are appropriate.
+- [ ] Additional reviewer is requested or not needed.
+- [ ] CI tests passed or failure are acceptable.
+
+
+

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -27,7 +27,7 @@
 - [ ] The implementation is appropriate, maintainable, and follows ARCHITECTURE.md.
 - [ ] PR subject title has the proper prefix and the subject is appropriate.
 - [ ] Relevant issue(s) are linked.
-- [ ] AI/LLM usage is diclosed are proper and usage is appropriate.
+- [ ] AI/LLM usage is disclosed and appropriate.
 - [ ] Documentation and tests are appropriate.
 - [ ] Additional reviewer is requested or not needed.
 - [ ] CI tests passed or failure are acceptable.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -20,14 +20,14 @@
 ## Submitter's Checklist
 - [ ] I have reviewed and am adhering to the standards outlined in the project [Governing Doc](https://github.com/casact/chainladder-python/blob/main/docs/library/governance.md).
 - [ ] The PR subject title summarizes the changes, with one proper prefix (`[FIX]`, `[FEAT]`, `[DOCS]`, `[TST]`, `[CHORE]`, or `[BRK]`).
-- [ ] I am a human (not a bot), and this PR is not AI generated.
+- [ ] I am a human (not a bot), and this PR form is written by a human.
 
 ## Reviewer's Checklist
 - [ ] The implementation addresses the associated issue(s).
 - [ ] The implementation is appropriate, maintainable, and follows ARCHITECTURE.md.
-- [ ] PR subject title is appropriate.
+- [ ] PR subject title has the proper prefix and the subject is appropriate.
 - [ ] Relevant issue(s) are linked.
-- [ ] AI disclosures are complete and usage is appropriate.
+- [ ] AI/LLM Usage is diclosed are proper and usage is appropriate.
 - [ ] Documentation and tests are appropriate.
 - [ ] Additional reviewer is requested or not needed.
 - [ ] CI tests passed or failure are acceptable.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,21 +1,22 @@
-## Summary of Changes  
+## Summary of Changes
 
 
 
-## Related GitHub Issue(s)  
+## Related GitHub Issue(s)
 <!-- Use keywords like close/closes/closed or fix/fixes/fixed to close the issue automatically -->
 
 
 ## AI/LLM Usage
-<!-- Declare and briefly describe any AI/LLM assistance used and the extent of usage during development. -->
+<!-- Declare and briefly describe any AI/LLM assistance used and the extent of usage during development of this PR. -->
 
 
 
-## Additional Context for Reviewers  
+## Additional Context for Reviewers
 
 
 
 <!-- Do not edit anything below until the ticket is open. Checklists below. -->
+
 ## Submitter's Checklist
 - [ ] I have reviewed and am adhering to the standards outlined in the project Governing Doc.
 - [ ] The PR subject title summarizes the changes, with a proper prefix:
@@ -30,9 +31,9 @@
 ## Reviewer's Checklist
 - [ ] The implementation addresses the associated issue(s).
 - [ ] The implementation is appropriate, maintainable, and follows ARCHITECTURE.md.
-- [ ] AI disclosures are complete and usage is appropriate.
 - [ ] PR subject title is appropriate.
 - [ ] Relevant issue(s) are linked.
+- [ ] AI disclosures are complete and usage is appropriate.
 - [ ] Documentation and tests are appropriate.
 - [ ] Additional reviewer is requested or not needed.
 - [ ] CI tests passed or failure are acceptable.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,20 +1,21 @@
 ## Summary of Changes  
 
 
+
 ## Related GitHub Issue(s)  
 <!-- Use keywords like close/closes/closed or fix/fixes/fixed to close the issue automatically -->
 
+
 ## AI/LLM Usage
 <!-- Declare and briefly describe any AI/LLM assistance used and the extent of usage during development. -->
+
 
 
 ## Additional Context for Reviewers  
 
 
 
-
 <!-- Do not edit anything below until the ticket is open. Checklists below. -->
-
 ## Submitter's Checklist
 - [ ] I have reviewed and am adhering to the standards outlined in the project Governing Doc.
 - [ ] The PR subject title summarizes the changes, with a proper prefix:
@@ -25,7 +26,6 @@
     [CHORE] for chores and maintenance tasks
     [BRK] for breaking changes, deprecations, and removals
 - [ ] I am a human (not a bot), and this PR is not AI generated.
-
 
 ## Reviewer's Checklist
 - [ ] The implementation addresses the associated issue(s).

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -29,8 +29,6 @@
 - [ ] Relevant issue(s) are linked.
 - [ ] AI/LLM usage is disclosed and appropriate.
 - [ ] Documentation and tests are appropriate.
-- [ ] Additional reviewer is requested or not needed.
-- [ ] CI tests passed or failure are acceptable.
-
-
+- [ ] CI tests passed, or any failures are acceptable.
+- [ ] Leave a comment with the final recommendation (e.g. approve as is, request a secondary review, or flag an area for more review).
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -6,6 +6,7 @@
 <!-- Use keywords like close/closes/closed or fix/fixes/fixed to close the issue automatically -->
 
 
+
 ## AI/LLM Usage
 <!-- Declare and briefly describe any AI/LLM assistance used and the extent of usage during development of this PR. -->
 
@@ -15,7 +16,7 @@
 
 
 
-<!-- Checklists should be completed, but do not edit any words below. -->
+<!-- Checklists below should be completed, but do not edit any words below. -->
 
 ## Submitter's Checklist
 - [ ] I have reviewed and am adhering to the standards outlined in the project [Governing Doc](https://github.com/casact/chainladder-python/blob/main/docs/library/governance.md).

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -15,7 +15,7 @@
 
 
 
-<!-- Do not edit anything below until the ticket is open. Checklists below. -->
+<!-- Checklists should be completed, but do not edit any words below. -->
 
 ## Submitter's Checklist
 - [ ] I have reviewed and am adhering to the standards outlined in the project [Governing Doc](https://github.com/casact/chainladder-python/blob/main/docs/library/governance.md).


### PR DESCRIPTION
## Summary of Changes  
Updated the PR template in accordance with the governing doc

## Related GitHub Issue(s)  
Closes #1240 
Closes #1043 

## Additional Context for Reviewers  
There's not really a way for me to preview this, so I hope it goes well. Please let me know if something looks weird (don't know how to preview)



<!-- Do not edit anything below this. -->

## Checklist
- [x] I passed tests locally for both code (`uv run pytest`) and documentation changes (`uv run --directory docs jb build . --builder=custom --custom-builder=doctest`)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Process/documentation-only change to the GitHub PR template with no runtime or application code impact.
> 
> **Overview**
> Updates **`.github/pull_request_template.md`** to match the contribution requirements in the **Governing Doc**.
> 
> Adds an **AI/LLM Usage** section and guidance on linking issues (close/fix keywords). Replaces the old single checklist (local pytest/doctest) with separate **Submitter's** and **Reviewer's** checklists covering governance adherence, PR title prefixes (`[FIX]`, `[FEAT]`, etc.), human/bot attestation, AI disclosure, ARCHITECTURE.md, tests/docs, and CI. Minor heading/format cleanup and a note that checklist wording below the fold should not be edited.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 445a2eff2ee46e658ef8cfe96047f4f7b4a978c7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->