### PR TITLE
fix(correlation): keep empty diagonals when building z_critical (#320)

### DIFF
--- a/chainladder/core/correlation.py
+++ b/chainladder/core/correlation.py
@@ -140,20 +140,23 @@ class DevelopmentCorrelation:
         numerator.values = numerator.values[..., :-1]
         numerator.ddims = numerator.ddims[:-1]
 
-        # I is the number of development periods in the triangle
-        I = len(triangle.development)
+        # num_dev_periods is the number of development periods in the
+        # triangle, denoted I in the Mack 97 paper
+        num_dev_periods = len(triangle.development)
 
         # k values are the column indexes for which we are calculating T_k
         k = xp.array(range(2, 2 + numerator.shape[3]))
 
         # denominator is the one in formula G4 of the Mack 97 paper
-        denominator = ((I - k) ** 3 - I + k)[None, None, None]
+        denominator = ((num_dev_periods - k) ** 3 - num_dev_periods + k)[
+            None, None, None
+        ]
 
         # complete formula G4, results in array of each T_k value
         self.t = 1 - 6 * xp.nan_to_num(numerator.values) / denominator
 
         # per Mack, weight is one less than the number of pairs for each T_k
-        weight = (I - k - 1)[None, None, None]
+        weight = (num_dev_periods - k - 1)[None, None, None]
 
         # Calculate big T, the weighted average of the T_k values
         t_expectation = (
@@ -163,7 +166,7 @@ class DevelopmentCorrelation:
         idx = triangle.index.set_index(triangle.key_labels).index
 
         # variance is result of formula G6
-        self.t_variance = 2 / ((I - 2) * (I - 3))
+        self.t_variance = 2 / ((num_dev_periods - 2) * (num_dev_periods - 3))
 
         # array of t values
         self.t = pd.DataFrame(self.t[0, 0, ...], columns=k, index=["T_k"])
@@ -317,19 +320,18 @@ class ValuationCorrelation:
         if not self.total:
             T = []
             for i in range(0, xp.max(m1large.shape[2:]) + 1):
-                T.append(
-                    [
-                        pZlower(i, j, 0.5)
-                        for j in range(0, xp.max(m1large.shape[2:]) + 1)
-                    ]
-                )
+                T.append([
+                    pZlower(i, j, 0.5) for j in range(0, xp.max(m1large.shape[2:]) + 1)
+                ])
             T = np.array(T)
             z_idx, n_idx = z.astype(int), n.astype(int)
             self.probs = T[z_idx, n_idx]
-            z_critical = triangle[triangle.valuation > triangle.valuation.min()]
-            # z_critical = z_critical[z_critical.development > z_critical.development.min()].dev_to_val().sum(
-            #     "origin") * 0
-            z_critical = z_critical.dev_to_val().dropna().sum("origin") * 0
+            # One column per link-ratio diagonal, labeled by ending valuation.
+            # Slicing by valuation (rather than dropna) keeps diagonals that
+            # are entirely NaN, so the columns stay aligned with self.probs
+            # when a triangle is missing its earliest diagonals (#320).
+            z_critical = triangle.dev_to_val().sum("origin")
+            z_critical = z_critical[z_critical.valuation > triangle.valuation.min()] * 0
             z_critical.values = np.array(self.probs) < p_critical
             z_critical.odims = triangle.odims[0:1]
             self.z_critical = z_critical

--- a/chainladder/core/tests/test_correlation.py
+++ b/chainladder/core/tests/test_correlation.py
@@ -3,18 +3,34 @@ import pytest
 
 raa = cl.load_sample("RAA")
 
+
 def test_val_corr_total_true():
     assert raa.valuation_correlation(p_critical=0.5, total=True)
+
 
 def test_val_corr_total_false():
     assert raa.valuation_correlation(p_critical=0.5, total=False)
 
+
 def test_dev_corr():
     assert raa.development_correlation(p_critical=0.5)
 
+
 def test_dev_corr_sparse():
-    assert raa.set_backend('sparse').development_correlation(p_critical=0.5)
+    assert raa.set_backend("sparse").development_correlation(p_critical=0.5)
+
 
 def test_validate_critical():
     with pytest.raises(ValueError):
         raa.valuation_correlation(p_critical=1.5, total=True)
+
+
+def test_val_corr_incomplete_triangle(xyz):
+    # GH #320: a triangle missing its earliest diagonals raised a
+    # ValueError on repr because z_critical dropped all-NaN diagonals
+    # while its values kept one entry per link-ratio diagonal.
+    z_critical = (
+        xyz["Paid"].valuation_correlation(p_critical=0.1, total=False).z_critical
+    )
+    assert z_critical.values.shape[-1] == len(z_critical.ddims)
+    assert repr(z_critical)


### PR DESCRIPTION
## Summary of Changes

Fixes the `ValueError` from #320: `valuation_correlation(total=False).z_critical` crashed
on any triangle whose earliest diagonals are entirely missing (e.g. `load_sample('xyz')`,
the Friedland XYZ insurer data from the issue).

`self.probs` always has one column per link-ratio diagonal, but the `z_critical` frame it
is written into was built with `.dropna()`, which also drops interior all-NaN diagonals.
On triangles with missing leading diagonals the frame ended up with fewer ddims than value
columns, and repr (or anything else that walks ddims) raised
`ValueError: Shape of passed values is (1, 10), indices imply (1, 9)`.

The fix builds the frame by valuation slicing instead, so empty diagonals keep their
column and stay aligned with `probs`:

- Complete triangles produce identical output to before (checked ddims/odims/values
  against the old construction on raa, clrd, quarterly and genins).
- Incomplete triangles now return a well-formed boolean triangle; diagonals with no data
  test non-significant (False). If you'd rather surface those as NaN it would need a dtype
  change away from bool — happy to discuss, this PR keeps the minimal behavior.
- Removed the stale commented-out construction above these lines.

Because the Ruff workflow lints changed files with per-file-ignores cleared, this also
fixes the pre-existing E741 in `DevelopmentCorrelation` (`I` → `num_dev_periods`, pure
rename), removes the corresponding per-file-ignore from `pyproject.toml`, and applies
`ruff format` (0.16.1) to the two touched files.

Added `test_val_corr_incomplete_triangle` using the existing `xyz` fixture, which runs on
both the numpy and sparse backends. It fails on main and passes with this change.

## Related GitHub Issue(s)

#320

## Additional Context for Reviewers

The one behavioral question worth a reviewer's eye: for diagonals with no data,
`z_critical` now reports False (not significant) rather than being silently dropped from
the output. That matches the "partial results" option discussed in the issue, and keeps
the column count consistent with `z`, `z_expectation` and `z_variance`.

Local runs: `uv run pytest` → 1129 passed, 8 skipped. `ruff check` (with per-file-ignores
cleared) and `ruff format --check` are clean on the changed files with ruff 0.16.1.
