### PR TITLE
ruff fix

### DIFF
--- a/chainladder/core/base.py
+++ b/chainladder/core/base.py
@@ -601,7 +601,7 @@ class TriangleBase(
             del self.sigma_
         if "std_err_" in sub_tris:
             del self.std_err_
-        #w_ is currently stored as an ndarray
+        # w_ is currently stored as an ndarray
         if hasattr(self, "w_"):
             del self.w_
 

--- a/chainladder/utils/data/_manifest.py
+++ b/chainladder/utils/data/_manifest.py
@@ -268,7 +268,16 @@ SAMPLES: dict = {
         "origin": "Accident Year",
         "development": "Calendar Year",
         "index": None,
-        "columns": ["Paid Claims", "Reported Claims", "Closed Claim Counts", "Reported Claim Counts", "Case Outstanding", "Reported Severities", "Earned Premium","Incremental Paid Severity"],
+        "columns": [
+            "Paid Claims",
+            "Reported Claims",
+            "Closed Claim Counts",
+            "Reported Claim Counts",
+            "Case Outstanding",
+            "Reported Severities",
+            "Earned Premium",
+            "Incremental Paid Severity"
+        ],
         "cumulative": True,
     },
     "genins": {

--- a/chainladder/utils/tests/test_utilities.py
+++ b/chainladder/utils/tests/test_utilities.py
@@ -12,7 +12,6 @@ import pandas as pd
 from chainladder import (
     __dt64_unit__
 )
-from chainladder.utils.utility_functions import date_delta_adjustment
 from chainladder.utils.data._manifest import SAMPLES
 from chainladder.utils.utility_functions import (
     date_delta_adjustment,
@@ -59,7 +58,6 @@ class _FakeDaskBag:
 
 
 def test_triangle_json_io(clrd):
-    xp = clrd.get_array_module()
     clrd2 = cl.read_json(clrd.to_json(), array_backend=clrd.array_backend)
     assert clrd == clrd2
     assert np.all(clrd.kdims == clrd2.kdims)
@@ -153,7 +151,7 @@ def test_concat(clrd):
     )
 
 
-def test_model_diagnostics_erorr(raa,atol):
+def test_model_diagnostics_erorr(raa, atol):
     with pytest.raises(ValueError):
         cl.model_diagnostics(raa)
     dev = cl.Development().fit_transform(raa)
@@ -162,7 +160,7 @@ def test_model_diagnostics_erorr(raa,atol):
     md = cl.model_diagnostics(est)
     assert np.allclose(
         md['Run Off 1'].values,
-        emerg[emerg.valuation.year==1991].latest_diagonal.values,
+        emerg[emerg.valuation.year == 1991].latest_diagonal.values,
         atol=atol,
         equal_nan=True
     )
@@ -186,13 +184,13 @@ def test_model_diagnostics_erorr(raa,atol):
     )
 
 
-def test_model_diagnostics_groupby(prism,atol):
+def test_model_diagnostics_groupby(prism, atol):
     dev = cl.Development().fit(prism["Incurred"].sum())
     est = cl.Chainladder().fit(dev.transform(prism["Incurred"]))
-    lhs = cl.model_diagnostics(est,groupby=['Line'])
+    lhs = cl.model_diagnostics(est, groupby=['Line'])
     rhs = cl.model_diagnostics(cl.Chainladder().fit(dev.transform(prism["Incurred"].groupby('Line').sum())))
-    assert np.allclose(lhs['Ultimate'].values,rhs['Ultimate'].values,atol=atol,equal_nan=True)
-    assert np.allclose(np.nan_to_num(lhs['IBNR'].values),np.nan_to_num(rhs['IBNR'].values),atol=atol,equal_nan=True)
+    assert np.allclose(lhs['Ultimate'].values,rhs['Ultimate'].values,atol=atol, equal_nan=True)
+    assert np.allclose(np.nan_to_num(lhs['IBNR'].values),np.nan_to_num(rhs['IBNR'].values),atol=atol, equal_nan=True)
 
 
 def test_concat_immutability(raa):


### PR DESCRIPTION
## Summary of Changes  


## Related GitHub Issue(s)  


## Additional Context for Reviewers  




<!-- Do not edit anything below this. -->

## Checklist
- [ ] I passed tests locally for both code (`uv run pytest`) and documentation changes (`uv run --directory docs jb build . --builder=custom --custom-builder=doctest`)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Formatting and import cleanup only; no logic or API changes.
> 
> **Overview**
> Applies **Ruff** auto-fixes across a few files with **no intended behavior changes**.
> 
> In `test_utilities.py`, imports are consolidated (duplicate `date_delta_adjustment` removed), an unused `get_array_module()` call is dropped from `test_triangle_json_io`, and spacing is normalized around operators and keyword arguments in model-diagnostics tests. In `_manifest.py`, the `friedland_xyz_auto_bi` `columns` list is reformatted to one entry per line. In `base.py`, a comment is adjusted to `# w_` after `#`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 51ad44329aefc11c2a5587c44205988f08b0f4c9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->