### PR TITLE
Implement review roulette

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
 ## code changes will send PR to following users
-* @jbogaardt @kennethshsu @genedan @henrydingliu
+* @casact/chainladder-maintainers


### PR DESCRIPTION
## Summary of Changes  
This should setup the roulette properly. Reviewer will be randomly selected from `chainladder-maintainers`, using the load balance method (if you already have a lot of pending work, you'll less likely to be selected).

For anyone interested in becoming a reviewer, they'll just need to be added as a member to `chainladder-maintainers`. Still only `chainladder-codeowners` can merge to a protected branch.

## Related GitHub Issue(s)  
Closes #1239 

## Additional Context for Reviewers  
The only "code change" here is to the file CODEOWNERS, which is the random selection pool of PR roulette, and it should point to `chainladder-maintainers`.



<!-- Do not edit anything below this. -->

## Checklist
- [x] I passed tests locally for both code (`uv run pytest`) and documentation changes (`uv run --directory docs jb build . --builder=custom --custom-builder=doctest`)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only updates GitHub review routing in CODEOWNERS; no application or library code changes.
> 
> **Overview**
> **Review roulette** for this repo now draws reviewers from the **`@casact/chainladder-maintainers`** GitHub team instead of four named individuals.
> 
> The only change is **`.github/CODEOWNERS`**: the wildcard owner line is updated so automated review assignment (with load balancing across pending reviews) uses the team pool described in the PR.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f5d751601fe02a16ebc0b9b61273e4a26583d992. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->