### PR TITLE
ruff fix

### DIFF
--- a/docs/friedland/chapter_11.ipynb
+++ b/docs/friedland/chapter_11.ipynb
@@ -3017,7 +3017,7 @@
    },
    "outputs": [],
    "source": [
-    "# ruff: noqa: E241\n",
+    "# ruff: noqa: E231, E241, E242\n",
     "# Exhibit V Sheet 1\n",
     "assert np.all(\n",
     "    e5_ccc_selected.cdf_.round(3).values\n",
@@ -3602,6 +3602,7 @@
    },
    "outputs": [],
    "source": [
+    "# ruff: noqa: E231, E241, E242\n",
     "# Exhibit VI Sheet 1\n",
     "assert np.all(\n",
     "    e6_dr_selected.disposal_rate_.values\n",


### PR DESCRIPTION
## Summary of Changes  


## Related GitHub Issue(s)  


## Additional Context for Reviewers  




<!-- Do not edit anything below this. -->

## Checklist
- [ ] I passed tests locally for both code (`uv run pytest`) and documentation changes (`uv run --directory docs jb build . --builder=custom --custom-builder=doctest`)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only notebook edits that add lint suppressions; no runtime or library behavior changes.
> 
> **Overview**
> Updates **ruff** lint suppressions in the Friedland Chapter 11 notebook so reconciliation `assert` cells that use visually aligned `np.array` literals pass the linter.
> 
> In the **Exhibit V** assertion cell, the existing `# ruff: noqa: E241` line is broadened to `# ruff: noqa: E231, E241, E242`. The **Exhibit VI** assertion cell gets the same comment added at the top. No assertion values or exhibit logic change—only per-cell noqa directives.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bf15c163862397a1243bfbe5f4f2414b286f78b3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->