### PR TITLE
[FIX] Apply Ruff fixes to berqsherm.py.

### DIFF
--- a/chainladder/adjustments/berqsherm.py
+++ b/chainladder/adjustments/berqsherm.py
@@ -179,7 +179,7 @@ class BerquistSherman(BaseEstimator, TransformerMixin, EstimatorIO):
         y0 = xp.log(y.values[..., :-1])
         y1 = xp.log(y.values[..., 1:])
         b = ((x0 * y0 + x1 * y1) / 2 - (x0 + x1) / 2 * (y0 + y1) / 2) / (
-            (x0 ** 2 + x1 ** 2) / 2 - ((x0 + x1) / 2) ** 2
+            (x0**2 + x1**2) / 2 - ((x0 + x1) / 2) ** 2
         )
         a = np.exp((y0 + y1) / 2 - b * (x0 + x1) / 2)
 
@@ -206,27 +206,39 @@ class BerquistSherman(BaseEstimator, TransformerMixin, EstimatorIO):
         # Don't allow lookup values beyond the final value.
         n = min(lookup.shape[-1], lookup.shape[-2])
         for j in range(n - 1):
-            lookup[:, :, j, :] = np.clip(lookup[:, :, j, :], 0,  n - j - 2)
+            lookup[:, :, j, :] = np.clip(lookup[:, :, j, :], 0, n - j - 2)
 
         a = (
-            xp.concatenate([
-                xp.concatenate(
-                    [a[j:j+1, ..., i, lookup[j, 0, i:i+1, :]] for i in range(lookup.shape[-2])],
-                    axis=-2
-                )
-                for j in range(a.shape[0]) # Process each batch independently
-            ], axis=0)
-        * adj_closed_clm.nan_triangle[None, None, ...]
+            xp.concatenate(
+                [
+                    xp.concatenate(
+                        [
+                            a[j : j + 1, ..., i, lookup[j, 0, i : i + 1, :]]
+                            for i in range(lookup.shape[-2])
+                        ],
+                        axis=-2,
+                    )
+                    for j in range(a.shape[0])  # Process each batch independently
+                ],
+                axis=0,
+            )
+            * adj_closed_clm.nan_triangle[None, None, ...]
         )
         b = (
-            xp.concatenate([
-                xp.concatenate(
-                    [b[j:j+1, ..., i, lookup[j, 0, i:i+1, :]] for i in range(lookup.shape[-2])],
-                    axis=-2
-                )
-                for j in range(b.shape[0]) # Process each batch independently
-            ], axis=0)
-        * adj_closed_clm.nan_triangle[None, None, ...]
+            xp.concatenate(
+                [
+                    xp.concatenate(
+                        [
+                            b[j : j + 1, ..., i, lookup[j, 0, i : i + 1, :]]
+                            for i in range(lookup.shape[-2])
+                        ],
+                        axis=-2,
+                    )
+                    for j in range(b.shape[0])  # Process each batch independently
+                ],
+                axis=0,
+            )
+            * adj_closed_clm.nan_triangle[None, None, ...]
         )
         # Adjust paids
         adj_paid_claims = adj_closed_clm * 0 + xp.exp(adj_closed_clm.values * b) * a
@@ -251,7 +263,8 @@ class BerquistSherman(BaseEstimator, TransformerMixin, EstimatorIO):
         return self
 
     def transform(self, X):
-        """ If X and self are of different shapes, align self to X, else
+        """
+        If X and self are of different shapes, align self to X, else
         return self.
 
         Parameters

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -113,7 +113,6 @@ select = ["E2", "E4", "E7", "E9", "F", "B018", "UP034", "N802"]
 # check can be required without blocking unrelated PRs. Remove entries as
 # files are cleaned up.
 [tool.ruff.lint.per-file-ignores]
-"chainladder/adjustments/berqsherm.py" = ["E226", "E241", "E261"]
 "chainladder/adjustments/bootstrap.py" = ["E231", "E721", "E722", "F841"]
 "chainladder/adjustments/disposal.py" = ["E226", "E227", "E231", "E251", "E252", "E265", "F401"]
 "chainladder/adjustments/tests/test_berqsherm.py" = ["F841"]


### PR DESCRIPTION
## Summary of Changes  

Knocking out `chainladder/adjustments/berqsherm.py` from the Ruff list. Yeah...we got a long way to go. I tried getting started on bootstrap.py but stopped when the linter was uncovering bugs.

## Related GitHub Issue(s)  

#1216 

## Additional Context for Reviewers  




<!-- Do not edit anything below this. -->

## Checklist
- [x] I passed tests locally for both code (`uv run pytest`) and documentation changes (`uv run --directory docs jb build . --builder=custom --custom-builder=doctest`)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Lint-only edits to Berquist–Sherman adjustment code with no intended behavioral change.
> 
> **Overview**
> Brings `chainladder/adjustments/berqsherm.py` into compliance with the project Ruff rules so it no longer needs a per-file ignore entry in `pyproject.toml`.
> 
> Changes are **formatting and docstring style only**: operator spacing in the exponential regression denominator, whitespace in `np.clip`, and clearer line breaks around the nested `xp.concatenate` batching for `a` and `b`. The `transform` docstring is normalized to a standard multi-line form (no logic change in `fit` or `transform`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 660ab7e0e743a1102d60828cfced0dcdcc8eb54e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->