### PR TITLE
[FIX] Apply Ruff fix to chainladder/adjustments.

### DIFF
--- a/chainladder/adjustments/bootstrap.py
+++ b/chainladder/adjustments/bootstrap.py
@@ -166,12 +166,19 @@ class BootstrapODPSample(DevelopmentBase):
     def fit(self, X, y=None, sample_weight=None):
         if X.shape[1] > 1:
             from chainladder.utils.utility_functions import concat
-            out = [BootstrapODPSample(**self.get_params()).fit(X.iloc[:, i])
-                   for i in range(X.shape[1])]
+
+            out = [
+                BootstrapODPSample(**self.get_params()).fit(X.iloc[:, i])
+                for i in range(X.shape[1])
+            ]
             xp = X.get_array_module(out[0].design_matrix_)
-            self.design_matrix_ = xp.concatenate([i.design_matrix_[None] for i in out], axis=0)
+            self.design_matrix_ = xp.concatenate(
+                [i.design_matrix_[None] for i in out], axis=0
+            )
             self.hat_ = xp.concatenate([i.hat_[None] for i in out], axis=0)
-            self.resampled_triangles_ = concat([i.resampled_triangles_ for i in out], axis=1)
+            self.resampled_triangles_ = concat(
+                [i.resampled_triangles_ for i in out], axis=1
+            )
             self.scale_ = xp.array([i.scale_ for i in out])
             self.w_ = out[0].w_
         else:
@@ -183,7 +190,7 @@ class BootstrapODPSample(DevelopmentBase):
             xp = X.get_array_module()
             if len(X) != 1:
                 raise ValueError("Only single index triangles are supported")
-            if type(X.ddims) != np.ndarray:
+            if type(X.ddims) is not np.ndarray:
                 raise ValueError("Triangle must be expressed with development lags")
             obj = Development(
                 n_periods=self.n_periods,
@@ -203,7 +210,7 @@ class BootstrapODPSample(DevelopmentBase):
             if self.hat_adj:
                 try:
                     self.hat_ = self._get_hat(X, exp_incr_triangle)
-                except:
+                except np.linalg.LinAlgError:
                     warn("Could not compute hat matrix.  Setting hat_adj to False")
                     self.had_adj = False
                     self.hat_ = None
@@ -212,11 +219,11 @@ class BootstrapODPSample(DevelopmentBase):
             self.resampled_triangles_, self.scale_ = self._get_simulation(
                 X, exp_incr_triangle
             )
-            n_obs = xp.nansum(self.w_)
-            n_origin_params = X.shape[2]
-            n_dev_params = X.shape[3] - 1
-            deg_free = n_obs - n_origin_params - n_dev_params
-            deg_free_adj_fctr = xp.sqrt(n_obs / deg_free)
+            # n_obs = xp.nansum(self.w_)
+            # n_origin_params = X.shape[2]
+            # n_dev_params = X.shape[3] - 1
+            # deg_free = n_obs - n_origin_params - n_dev_params
+            # deg_free_adj_fctr = xp.sqrt(n_obs / deg_free)
         return self
 
     def _get_simulation(self, X, exp_incr_triangle):
@@ -224,7 +231,7 @@ class BootstrapODPSample(DevelopmentBase):
         k_value = 1  # for ODP Poisson
         unscaled_residuals = (
             (X.cum_to_incr().values - exp_incr_triangle)
-            / xp.sqrt(xp.abs(exp_incr_triangle ** k_value))
+            / xp.sqrt(xp.abs(exp_incr_triangle**k_value))
         )[0, 0, ...]
         w_ = self.w_[0, 0]
         w_[:, 1:] * w_[:, 1:]
@@ -264,19 +271,24 @@ class BootstrapODPSample(DevelopmentBase):
         resampled_triangles = (resampled_residual * xp.sqrt(abs(b)) + b).cumsum(2)
         resampled_triangles = resampled_triangles[None, ...].swapaxes(0, 1)
         obj = X.copy()
-        if X.key_labels == ['Total']:
+        if X.key_labels == ["Total"]:
             obj.kdims = np.arange(self.n_sims)
-            obj.key_labels = ['Simulation_#']
+            obj.key_labels = ["Simulation_#"]
         else:
-            obj.kdims = np.concat([np.tile(X.kdims,(self.n_sims,1)),np.arange(self.n_sims).reshape(-1,1)],axis=1)
-            obj.key_labels = X.key_labels + ['Simulation_#']
+            obj.kdims = np.concat(
+                [
+                    np.tile(X.kdims, (self.n_sims, 1)),
+                    np.arange(self.n_sims).reshape(-1, 1),
+                ],
+                axis=1,
+            )
+            obj.key_labels = X.key_labels + ["Simulation_#"]
         obj.values = resampled_triangles
         obj._set_slicers()
         return obj, scale_phi
 
     def _get_design_matrix(self, X):
-        """ The design matrix used in hat matrix adjustment (Shapland eq3.12)
-        """
+        """The design matrix used in hat matrix adjustment (Shapland eq3.12)"""
         xp = X.get_array_module()
         w = X.nan_triangle
         arr = xp.diag(w[:, 0])
@@ -292,7 +304,7 @@ class BootstrapODPSample(DevelopmentBase):
         return arr
 
     def _get_hat(self, X, exp_incr_triangle):
-        """ The hat matrix adjustment (Shapland eq3.23)"""
+        """The hat matrix adjustment (Shapland eq3.23)"""
         xp = X.get_array_module()
         weight_matrix = xp.diag(
             pd.DataFrame(exp_incr_triangle).unstack().dropna().values
@@ -332,7 +344,7 @@ class BootstrapODPSample(DevelopmentBase):
         pass
 
     def transform(self, X):
-        """ If X and self are of different shapes, align self to X, else
+        """If X and self are of different shapes, align self to X, else
         return self.
 
         Parameters
@@ -353,7 +365,7 @@ class BootstrapODPSample(DevelopmentBase):
 
 
 def _get_process_variance(self, full_triangle):
-    """ Inserts random noise into the full triangles and full expectations """
+    """Inserts random noise into the full triangles and full expectations"""
     # if self.process_dist == 'od poisson':
     #    process_triangle = np.nan_to_num(np.array([random_state.poisson(lam=abs(item))*np.sign(np.nan_to_num(item))for item in sim_exp_incr_triangle]))
     xp = full_triangle.get_array_module()

--- a/chainladder/adjustments/disposal.py
+++ b/chainladder/adjustments/disposal.py
@@ -3,7 +3,7 @@
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 from __future__ import annotations
 
-from chainladder.methods import Chainladder, MethodBase
+from chainladder.methods import MethodBase
 from chainladder.development import DevelopmentBase
 import numpy as np
 import copy
@@ -14,26 +14,27 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from chainladder.core import Triangle
 
+
 class DisposalMixin:
-    '''
-    This class provides attributes for the DisposalRate adjustment method and transformed `Triangle`    
-    '''
+    """
+    This class provides attributes for the DisposalRate adjustment method and transformed `Triangle`
+    """
 
     @property
     def disposal_rate_(self) -> Triangle:
-        '''
+        """
         Gets the estimated disposal rate
-        '''
+        """
         if not hasattr(self, "_disposal_rate_"):
             x = self.__class__.__name__
             raise AttributeError("'" + x + "' object has no attribute 'disposal_rate_'")
         return self._disposal_rate_
-    
+
     @disposal_rate_.setter
-    def disposal_rate_(self,value) -> None:
-        '''
+    def disposal_rate_(self, value) -> None:
+        """
         Sets disposal_rate_
-        '''
+        """
         obj = copy.deepcopy(value)
         obj.is_pattern = True
         obj.is_disposal_rate = True
@@ -42,21 +43,22 @@ class DisposalMixin:
 
     @property
     def incr_disposal_rate_(self) -> Triangle:
-        '''
+        """
         Gets the incremental of the estimated disposal rate
-        '''
+        """
         return self.disposal_rate_.cum_to_incr()
 
     @incr_disposal_rate_.setter
-    def incr_disposal_rate_(self,value) -> None:
-        '''
+    def incr_disposal_rate_(self, value) -> None:
+        """
         Sets incr_disposal_rate_
-        '''
+        """
         obj = copy.deepcopy(value)
         obj.is_pattern = True
         obj.is_disposal_rate = True
         obj.is_cumulative = False
         self._disposal_rate_ = obj.incr_to_cum()
+
 
 class DisposalRate(DevelopmentBase, DisposalMixin):
     """
@@ -97,11 +99,11 @@ class DisposalRate(DevelopmentBase, DisposalMixin):
         See order of operations below when combined with multiple drop parameters.
 
         .. note ::
-    
+
             (Order of Drop Operations)
-            
+
             When multiple drop parameters are used together, the weights are built in this order (steps 4 and 5 are reversed from `Development`):
-        
+
             1. ``n_periods`` — limit to the most recent origin periods.
             2. ``drop`` — remove specific origin/development cells.
             3. ``drop_valuation`` — remove entire valuation diagonal in the triangle.
@@ -123,9 +125,9 @@ class DisposalRate(DevelopmentBase, DisposalMixin):
 
     Examples
     --------
-    This adjustment method re-apportions future loss emergence based on a '% of ultimate' emergence pattern. 
+    This adjustment method re-apportions future loss emergence based on a '% of ultimate' emergence pattern.
     The ultimate can come from another triangle. A common use case is to forecast payment pattern based on incurred ultimate.
-    
+
     .. testsetup::
 
         import chainladder as cl
@@ -137,14 +139,14 @@ class DisposalRate(DevelopmentBase, DisposalMixin):
         ult = cl.Chainladder().fit(clrd['IncurLoss']).ultimate_
         dr = cl.DisposalRate().fit_transform(clrd['CumPaidLoss'],sample_weight = ult)
 
-    Once we apply this adjustment method via a `fit_transform`, we can examine the emergence pattern via `disposal_rate_tri`. 
+    Once we apply this adjustment method via a `fit_transform`, we can examine the emergence pattern via `disposal_rate_tri`.
 
     .. testcode::
-    
+
         dr.disposal_rate_tri
 
     .. testoutput::
-        
+
                 12        24        36        48        60        72        84        96        108       120
         1988  0.313923  0.619459  0.774429  0.865377  0.919077  0.948898  0.964643  0.973184  0.980224  0.983063
         1989  0.321526  0.626023  0.781086  0.872345  0.924842  0.952533  0.967690  0.977373  0.981938       NaN
@@ -157,23 +159,23 @@ class DisposalRate(DevelopmentBase, DisposalMixin):
         1996  0.395603  0.688621       NaN       NaN       NaN       NaN       NaN       NaN       NaN       NaN
         1997  0.393820       NaN       NaN       NaN       NaN       NaN       NaN       NaN       NaN       NaN
 
-    The estimated pattern is stored in `disposal_rate_`. 
+    The estimated pattern is stored in `disposal_rate_`.
 
     .. testcode::
 
         dr.disposal_rate_
-        
+
     .. testoutput::
 
                 12-Ult    24-Ult    36-Ult    48-Ult    60-Ult    72-Ult    84-Ult    96-Ult   108-Ult  120-Ult  132-Ult
         (All)  0.112105  0.336242  0.545897  0.693774  0.812877  0.905045  0.942998  0.974365  0.990868      1.0      1.0
 
-    `full_triangle_` now reflects the disposal-rate-based forecast. 
+    `full_triangle_` now reflects the disposal-rate-based forecast.
 
     .. testcode::
 
         dr.full_triangle_
-        
+
     .. testoutput::
 
                 12            24            36            48            60            72            84            96            108           120           9999
@@ -193,7 +195,7 @@ class DisposalRate(DevelopmentBase, DisposalMixin):
     def __init__(
         self,
         n_periods: int = -1,
-        average: str | list[str] = 'volume',
+        average: str | list[str] = "volume",
         drop: tuple | list[tuple] | None = None,
         drop_high: bool | int | list[bool] | list[int] | None = None,
         drop_low: bool | int | list[bool] | list[int] | None = None,
@@ -212,12 +214,7 @@ class DisposalRate(DevelopmentBase, DisposalMixin):
         self.drop_below = drop_below
         self.drop = drop
 
-    def fit(
-            self, 
-            X:Triangle, 
-            y:None=None, 
-            sample_weight:Triangle|None=None
-    ):
+    def fit(self, X: Triangle, y: None = None, sample_weight: Triangle | None = None):
         """
         Estimate disposal rate for a given Triangle and ultimate
 
@@ -238,9 +235,9 @@ class DisposalRate(DevelopmentBase, DisposalMixin):
         """
         if sample_weight is None:
             raise ValueError("sample_weight is required.")
-        #validate dimensions of sample weight
+        # validate dimensions of sample weight
         MethodBase().validate_weight(X, sample_weight)
-        #set backeneds to numpy
+        # set backeneds to numpy
         if X.array_backend == "sparse":
             X = X.set_backend("numpy")
         else:
@@ -249,38 +246,46 @@ class DisposalRate(DevelopmentBase, DisposalMixin):
             ult = sample_weight.set_backend("numpy")
         else:
             ult = sample_weight.copy()
-        #calculate disposal rate triangle
+        # calculate disposal rate triangle
         self.xp = X.get_array_module()
         self.X_ = X.incr_to_cum().sort_index()
         self.X_.ultimate_ = ult
-        #get weights for estimation
+        # get weights for estimation
         tw = TriangleWeight(
-            n_periods = self.n_periods,
-            drop_high = self.drop_high,
-            drop_low = self.drop_low,
-            drop_above = self.drop_above,
-            drop_below = self.drop_below,
-            drop_valuation = self.drop_valuation,
-            preserve = self.preserve,
-            drop = self.drop
+            n_periods=self.n_periods,
+            drop_high=self.drop_high,
+            drop_low=self.drop_low,
+            drop_above=self.drop_above,
+            drop_below=self.drop_below,
+            drop_valuation=self.drop_valuation,
+            preserve=self.preserve,
+            drop=self.drop,
         )
         if hasattr(self.X_, "disposal_w_"):
-            self.disposal_w_ = tw.fit(X=self.X_.disposal_rate_tri * self.X_.disposal_w_).w_.values
+            self.disposal_w_ = tw.fit(
+                X=self.X_.disposal_rate_tri * self.X_.disposal_w_
+            ).w_.values
         else:
             self.disposal_w_ = tw.fit(X=self.X_.disposal_rate_tri).w_.values
-        #calculate factors
-        super().fit(ult.values,self.X_.values,self.disposal_w_)
-        #keep attributes
-        disposal = self._param_property(self.X_.disposal_rate_tri,self.params_.slope_[...,0][..., None, :])
-        self.disposal_rate_ = concat((disposal,(self.X_.latest_diagonal*0 + 1).iloc[:,:,0,:].rename("development", [9999])),axis=3)
+        # calculate factors
+        super().fit(ult.values, self.X_.values, self.disposal_w_)
+        # keep attributes
+        disposal = self._param_property(
+            self.X_.disposal_rate_tri, self.params_.slope_[..., 0][..., None, :]
+        )
+        self.disposal_rate_ = concat(
+            (
+                disposal,
+                (self.X_.latest_diagonal * 0 + 1)
+                .iloc[:, :, 0, :]
+                .rename("development", [9999]),
+            ),
+            axis=3,
+        )
         return self
 
-    def transform(
-            self, 
-            X: Triangle, 
-            sample_weight: Triangle | None = None
-    ) -> Triangle:
-        """ If X and self are of different shapes, align self to X, else
+    def transform(self, X: Triangle, sample_weight: Triangle | None = None) -> Triangle:
+        """If X and self are of different shapes, align self to X, else
         return self.
 
         Parameters
@@ -298,18 +303,20 @@ class DisposalRate(DevelopmentBase, DisposalMixin):
         if sample_weight is None:
             raise ValueError("sample_weight is required.")
         X_new = copy.deepcopy(X)
-        #validate dimensions of sample weight
+        # validate dimensions of sample weight
         MethodBase().validate_weight(X, sample_weight)
-        #align backeneds
+        # align backeneds
         X_new.disposal_w_ = self.disposal_w_
-        X_new.ultimate_ = sample_weight.set_backend(self.X_.array_backend).latest_diagonal
+        X_new.ultimate_ = sample_weight.set_backend(
+            self.X_.array_backend
+        ).latest_diagonal
         X_new.disposal_rate_ = self.disposal_rate_
         ibnr_pct = 1 - X_new.disposal_rate_.align_pattern(X_new.disposal_rate_tri)
         run_off = X_new.incr_disposal_rate_ / ibnr_pct * X_new.ibnr_
         run_off = run_off[run_off.valuation > X_new.valuation_date]
         X_new.ldf_ = (X_new.cum_to_incr() + run_off).incr_to_cum().age_to_age
         return X_new
-    
+
     def fit_transform(self, X, y=None, sample_weight=None):
         """Fit and return transformed full_triangle_ based on the Disposal Rate
 

--- a/chainladder/adjustments/tests/test_berqsherm.py
+++ b/chainladder/adjustments/tests/test_berqsherm.py
@@ -18,9 +18,9 @@ def test_preserve_diagonal():
     )
     assert berq_triangle != triangle
 
+
 def test_adjusted_values():
     triangle = cl.load_sample("berqsherm").loc["MedMal"]
-    xp = triangle.get_array_module()
     berq = cl.BerquistSherman(
         paid_amount="Paid",
         incurred_amount="Incurred",
@@ -36,8 +36,6 @@ def test_adjusted_values():
 
     # Ensure that the incurred, paid, and closed count columns are as expected
     berq_triangle.values[np.isnan(berq_triangle.values)] = 0
-    assert np.isclose(
-        berq_triangle["Incurred"].values.sum(), 1126985253.661, atol=1e-2
-    )
+    assert np.isclose(berq_triangle["Incurred"].values.sum(), 1126985253.661, atol=1e-2)
     assert np.isclose(berq_triangle["Paid"].values.sum(), 182046766.054, atol=1e-2)
     assert np.isclose(berq_triangle["Closed"].values.sum(), 8798.982, atol=1e-2)

--- a/chainladder/adjustments/tests/test_disposal.py
+++ b/chainladder/adjustments/tests/test_disposal.py
@@ -9,103 +9,136 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from chainladder.core import Triangle
 
+
 def test_friedland_fidelity() -> None:
-    '''
+    """
     Reconciles to Chapter 11 Exhibit 5 of the Friedland reserving textbook
-    '''
-    tri = cl.load_sample('friedland_gl_insurer')
-    ccc_dev = cl.Development(n_periods=3, average='volume').fit_transform(tri['Closed Claim Counts'])
+    """
+    tri = cl.load_sample("friedland_gl_insurer")
+    ccc_dev = cl.Development(n_periods=3, average="volume").fit_transform(
+        tri["Closed Claim Counts"]
+    )
     ccc_dev.ldf_ = ccc_dev.ldf_.round(3)
-    ccc_dev_wtail = cl.TailConstant(tail = 1.100, projection_period = 0).fit_transform(ccc_dev)
+    ccc_dev_wtail = cl.TailConstant(tail=1.100, projection_period=0).fit_transform(
+        ccc_dev
+    )
     ccc_ult = cl.Chainladder().fit(ccc_dev_wtail).ultimate_
-    rcc_dev = cl.Development(n_periods=3, average='volume').fit_transform(tri['Reported Claim Counts'])
+    rcc_dev = cl.Development(n_periods=3, average="volume").fit_transform(
+        tri["Reported Claim Counts"]
+    )
     rcc_dev.ldf_ = rcc_dev.ldf_.round(3)
     rcc_ult = cl.Chainladder().fit(rcc_dev).ultimate_
     ult = (ccc_ult + rcc_ult) / 2
-    dr_transformer = cl.DisposalRate(n_periods = 5, average = 'simple', drop_high = 1, drop_low = 1).fit(X=tri['Closed Claim Counts'],sample_weight=ult)
+    dr_transformer = cl.DisposalRate(
+        n_periods=5, average="simple", drop_high=1, drop_low=1
+    ).fit(X=tri["Closed Claim Counts"], sample_weight=ult)
     dr_transformer.disposal_rate_ = dr_transformer.disposal_rate_.round(3)
-    assert np.all(dr_transformer.disposal_rate_.values.flatten() == [.200,.433,.585,.710,.791,.862,.882,.912,1.000])
-    #Friedland uses rounded ultimates to calculate bottom half of the triangle, which introduces some rounding discrepancies with the implementation
-    dr = dr_transformer.transform(X=tri['Closed Claim Counts'],sample_weight=ult.round(0))
-    lhs = (dr.full_triangle_.cum_to_incr()-tri['Closed Claim Counts'].cum_to_incr()).round(0).values.flatten()
+    assert np.all(
+        dr_transformer.disposal_rate_.values.flatten()
+        == [0.200, 0.433, 0.585, 0.710, 0.791, 0.862, 0.882, 0.912, 1.000]
+    )
+    # Friedland uses rounded ultimates to calculate bottom half of the triangle, which introduces some rounding discrepancies with the implementation
+    dr = dr_transformer.transform(
+        X=tri["Closed Claim Counts"], sample_weight=ult.round(0)
+    )
+    lhs = (
+        (dr.full_triangle_.cum_to_incr() - tri["Closed Claim Counts"].cum_to_incr())
+        .round(0)
+        .values.flatten()
+    )
+    # fmt: off
     rhs = np.array([
-                                                            77.,  
-                                                    24.,    70.,  
-                                            12.,    18.,    54.,  
-                                    46.,    13.,    19.,    57.,  
-                            52.,    45.,    13.,    19.,    56.,  
-                    76.,    49.,    43.,    12.,    18.,    54.,  
-            67.,    55.,    36.,    31.,    9.,     13.,    39.,  
-    140.,   91.,    75.,    49.,    43.,    12.,    18.,    53.
+                                                            77.,
+                                                    24.,    70.,  # noqa: E241
+                                            12.,    18.,    54.,  # noqa: E241
+                                    46.,    13.,    19.,    57.,  # noqa: E241
+                            52.,    45.,    13.,    19.,    56.,  # noqa: E241
+                    76.,    49.,    43.,    12.,    18.,    54.,  # noqa: E241
+            67.,    55.,    36.,    31.,    9.,     13.,    39.,  # noqa: E241
+    140.,   91.,    75.,    49.,    43.,    12.,    18.,    53.  # noqa: E241
     ])
+    # fmt: on
     assert np.all(abs(lhs[~np.isnan(lhs)] - rhs <= 1))
 
-def test_no_weight_exception(raa:Triangle) -> None:
-    '''
-    sample_weight is optional in the default sklearn API. however, we require sample_weight to provide the a priori ultimate. 
-    '''
+
+def test_no_weight_exception(raa: Triangle) -> None:
+    """
+    sample_weight is optional in the default sklearn API. however, we require sample_weight to provide the a priori ultimate.
+    """
     with pytest.raises(ValueError):
         dr = cl.DisposalRate().fit(raa)
     ult = cl.Chainladder().fit(raa).ultimate_
-    dr = cl.DisposalRate().fit(raa,sample_weight=ult)
+    dr = cl.DisposalRate().fit(raa, sample_weight=ult)
     with pytest.raises(ValueError):
-        est = dr.transform(raa)
+        dr.transform(raa)
 
-def test_no_disposal_exception(raa:Triangle) -> None:
-    '''
-    disposal attributes are available in Triangle through the mixin, but not available before fitting 
-    '''
+
+def test_no_disposal_exception(raa: Triangle) -> None:
+    """
+    disposal attributes are available in Triangle through the mixin, but not available before fitting
+    """
     with pytest.raises(AttributeError):
         _ = raa.disposal_rate_
     with pytest.raises(AttributeError):
         _ = raa.incr_disposal_rate_
 
+
 def test_full_disposal_rate_tri(clrd) -> None:
-    '''
+    """
     tests disposal rate for full triangle
-    '''
+    """
     total = clrd.sum()
-    est = cl.Chainladder().fit(total['CumPaidLoss'])
+    est = cl.Chainladder().fit(total["CumPaidLoss"])
     ult = est.ultimate_
     full_tri = est.full_triangle_
     full_tri.ultimate_ = ult
-    assert full_tri.disposal_rate_tri.iat[-1,-1,-1,-1] == 1.
+    assert full_tri.disposal_rate_tri.iat[-1, -1, -1, -1] == 1.0
+
 
 def test_weighted_disposal_rate_tri(clrd) -> None:
-    '''
+    """
     tests disposal rate triangle when there are weights
-    '''
+    """
     total = clrd.sum()
-    ult = cl.Chainladder().fit(total['CumPaidLoss']).ultimate_
-    dr = cl.DisposalRate(n_periods = 4).fit_transform(total['CumPaidLoss'],sample_weight = ult)
-    assert np.all(np.isnan(dr.disposal_rate_tri.values[:,:,0:6,0:1]))
+    ult = cl.Chainladder().fit(total["CumPaidLoss"]).ultimate_
+    dr = cl.DisposalRate(n_periods=4).fit_transform(
+        total["CumPaidLoss"], sample_weight=ult
+    )
+    assert np.all(np.isnan(dr.disposal_rate_tri.values[:, :, 0:6, 0:1]))
 
-def test_cl_parity(raa:Triangle) -> None:
+
+def test_cl_parity(raa: Triangle) -> None:
     """
-    A no-tail, full-triangle, volume-weighted Chainladder estimator coincides with the disposal rate adjustment. 
+    A no-tail, full-triangle, volume-weighted Chainladder estimator coincides with the disposal rate adjustment.
     """
-    tri = raa.set_backend('sparse')
+    tri = raa.set_backend("sparse")
     dev = cl.Development().fit_transform(tri)
     est = cl.Chainladder().fit(dev)
-    dr = cl.DisposalRate().fit_transform(raa,sample_weight=est.ultimate_)
-    assert np.all(dr.full_triangle_.round(3).values[...,:-1] == est.full_triangle_.round(3).values[...,:-2])
+    dr = cl.DisposalRate().fit_transform(raa, sample_weight=est.ultimate_)
+    assert np.all(
+        dr.full_triangle_.round(3).values[..., :-1]
+        == est.full_triangle_.round(3).values[..., :-2]
+    )
 
-def test_sparse_transform(raa:Triangle) -> None:
+
+def test_sparse_transform(raa: Triangle) -> None:
     """
-    if the supplied Triangle is sparse, then the resulting full_triangle_ is also sparse 
+    if the supplied Triangle is sparse, then the resulting full_triangle_ is also sparse
     """
-    raa_sparse = raa.set_backend('sparse')
-    ult = cl.Chainladder().fit(raa_sparse).ultimate_.set_backend('sparse')
-    dr = cl.DisposalRate().fit_transform(raa_sparse,sample_weight=ult)
+    raa_sparse = raa.set_backend("sparse")
+    ult = cl.Chainladder().fit(raa_sparse).ultimate_.set_backend("sparse")
+    dr = cl.DisposalRate().fit_transform(raa_sparse, sample_weight=ult)
     from chainladder.utils.sparse import sp
-    assert isinstance(dr.full_triangle_.values,sp.COO)
-    
-def test_setting_incr(raa:Triangle) -> None:
+
+    assert isinstance(dr.full_triangle_.values, sp.COO)
+
+
+def test_setting_incr(raa: Triangle) -> None:
     """
-    DisposalMixin allows setting incremental disposal rates. Validating that the setting function works properly. 
+    DisposalMixin allows setting incremental disposal rates. Validating that the setting function works properly.
     """
     ult = cl.Chainladder().fit(raa).ultimate_
-    dr = cl.DisposalRate(n_periods = 4).fit(raa,sample_weight=ult)
+    dr = cl.DisposalRate(n_periods=4).fit(raa, sample_weight=ult)
     orig_disposal_rate_ = dr.disposal_rate_
     dr.incr_disposal_rate_ = dr.incr_disposal_rate_ * 2
     assert dr.disposal_rate_ == orig_disposal_rate_ * 2

--- a/chainladder/adjustments/trend.py
+++ b/chainladder/adjustments/trend.py
@@ -4,7 +4,6 @@
 
 from sklearn.base import BaseEstimator, TransformerMixin
 from chainladder.core.io import EstimatorIO
-import pandas as pd
 
 
 class Trend(BaseEstimator, TransformerMixin, EstimatorIO):
@@ -271,7 +270,8 @@ class TrendConstant(BaseEstimator, TransformerMixin, EstimatorIO):
         print("base_trend", self.base_trend)
 
         self.trendedvalues_ = X.copy().trend(
-            self.base_trend, self.axis  # , start=dates[i][0], end=dates[i][1]
+            self.base_trend,
+            self.axis,  # , start=dates[i][0], end=dates[i][1]
         )
         print("self.trendedvalues_\n", self.trendedvalues_)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -113,11 +113,6 @@ select = ["E2", "E4", "E7", "E9", "F", "B018", "UP034", "N802"]
 # check can be required without blocking unrelated PRs. Remove entries as
 # files are cleaned up.
 [tool.ruff.lint.per-file-ignores]
-"chainladder/adjustments/bootstrap.py" = ["E231", "E721", "E722", "F841"]
-"chainladder/adjustments/disposal.py" = ["E226", "E227", "E231", "E251", "E252", "E265", "F401"]
-"chainladder/adjustments/tests/test_berqsherm.py" = ["F841"]
-"chainladder/adjustments/tests/test_disposal.py" = ["E226", "E231", "E241", "E251", "E265", "F841"]
-"chainladder/adjustments/trend.py" = ["F401"]
 "chainladder/core/tests/rtest_correlation.py" = ["E266", "E722", "F821"]
 "chainladder/core/tests/test_display.py" = ["E722"]
 "chainladder/development/tests/rtest_clark.py" = ["E266", "E722"]


### PR DESCRIPTION
## Summary of Changes  

Stacked PR on top of #1290. Fixes files in `chainladder/adjustments`.

I commented out some lines per #1298. Also added an exception for the disposal rate array to keep it in triangle format (rather than one element per line).


## Related GitHub Issue(s)  

#1216 


## Additional Context for Reviewers  




<!-- Do not edit anything below this. -->

## Checklist
- [x] I passed tests locally for both code (`uv run pytest`) and documentation changes (`uv run --directory docs jb build . --builder=custom --custom-builder=doctest`)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mostly style and lint; the only functional tweak is narrower exception handling in bootstrap hat-matrix fitting, which may surface errors that were previously swallowed.
> 
> **Overview**
> Brings **`chainladder/adjustments`** (and its tests) in line with the project Ruff rules and **drops the per-file Ruff exemptions** for those paths in `pyproject.toml`.
> 
> In **`BootstrapODPSample.fit`**, hat-matrix failure handling is tightened from a bare `except` to **`np.linalg.LinAlgError`**, and the unused degree-of-freedom adjustment factor calculation is **commented out** (per #1298). The rest of the bootstrap/disposal/trend changes are formatting, quote/docstring style, and small cleanups (e.g. unused imports in `disposal.py` and `trend.py`).
> 
> **`test_disposal.py`** keeps the Friedland triangle assertion in a readable multi-line layout via `# fmt: off` / `noqa: E241`, with expected disposal rates written as explicit floats.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a48f60ba44b597e80a30ef942405bd9c542df1cc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->