### PR TITLE
feat(core): deprecate vdims (#1011) and kdims (#1010)

### DIFF
--- a/chainladder/adjustments/bootstrap.py
+++ b/chainladder/adjustments/bootstrap.py
@@ -267,16 +267,17 @@ class BootstrapODPSample(DevelopmentBase):
         resampled_triangles = resampled_triangles[None, ...].swapaxes(0, 1)
         obj = X.copy()
         if X.key_labels == ["Total"]:
-            obj._kdims = np.arange(self.n_sims)
+            obj._index = pd.DataFrame({"Simulation_#": np.arange(self.n_sims)})
             obj.key_labels = ["Simulation_#"]
         else:
-            obj._kdims = np.concat(
+            kdims = np.concat(
                 [
-                    np.tile(X._kdims, (self.n_sims, 1)),
+                    np.tile(X.index.to_numpy(dtype=str), (self.n_sims, 1)),
                     np.arange(self.n_sims).reshape(-1, 1),
                 ],
                 axis=1,
             )
+            obj._index = pd.DataFrame(kdims, columns=X.key_labels + ["Simulation_#"])
             obj.key_labels = X.key_labels + ["Simulation_#"]
         obj.values = resampled_triangles
         obj._set_slicers()

--- a/chainladder/adjustments/bootstrap.py
+++ b/chainladder/adjustments/bootstrap.py
@@ -219,11 +219,6 @@ class BootstrapODPSample(DevelopmentBase):
             self.resampled_triangles_, self.scale_ = self._get_simulation(
                 X, exp_incr_triangle
             )
-            # n_obs = xp.nansum(self.w_)
-            # n_origin_params = X.shape[2]
-            # n_dev_params = X.shape[3] - 1
-            # deg_free = n_obs - n_origin_params - n_dev_params
-            # deg_free_adj_fctr = xp.sqrt(n_obs / deg_free)
         return self
 
     def _get_simulation(self, X, exp_incr_triangle):
@@ -272,12 +267,12 @@ class BootstrapODPSample(DevelopmentBase):
         resampled_triangles = resampled_triangles[None, ...].swapaxes(0, 1)
         obj = X.copy()
         if X.key_labels == ["Total"]:
-            obj.kdims = np.arange(self.n_sims)
+            obj._kdims = np.arange(self.n_sims)
             obj.key_labels = ["Simulation_#"]
         else:
-            obj.kdims = np.concat(
+            obj._kdims = np.concat(
                 [
-                    np.tile(X.kdims, (self.n_sims, 1)),
+                    np.tile(X._kdims, (self.n_sims, 1)),
                     np.arange(self.n_sims).reshape(-1, 1),
                 ],
                 axis=1,

--- a/chainladder/adjustments/bootstrap.py
+++ b/chainladder/adjustments/bootstrap.py
@@ -270,15 +270,10 @@ class BootstrapODPSample(DevelopmentBase):
             obj._index = pd.DataFrame({"Simulation_#": np.arange(self.n_sims)})
             obj.key_labels = ["Simulation_#"]
         else:
-            kdims = np.concat(
-                [
-                    np.tile(X.index.to_numpy(dtype=str), (self.n_sims, 1)),
-                    np.arange(self.n_sims).reshape(-1, 1),
-                ],
-                axis=1,
-            )
-            obj._index = pd.DataFrame(kdims, columns=X.key_labels + ["Simulation_#"])
-            obj.key_labels = X.key_labels + ["Simulation_#"]
+            obj_idx = pd.concat([X.index] * self.n_sims, ignore_index=True)
+            obj_idx["Simulation_#"] = np.arange(self.n_sims)
+            obj._index = obj_idx
+            obj.key_labels = list(obj_idx.columns)
         obj.values = resampled_triangles
         obj._set_slicers()
         return obj, scale_phi

--- a/chainladder/adjustments/tests/test_bootstrap.py
+++ b/chainladder/adjustments/tests/test_bootstrap.py
@@ -24,13 +24,6 @@ def test_bs_multiple_cols():
 def test_multi_index(clrd):
     tri = clrd["CumPaidLoss"].sum()
     resampled_triangles = cl.BootstrapODPSample().fit(tri).resampled_triangles_
-    assert np.all(
-        resampled_triangles.index
-        == pd.DataFrame(
-            np.concat(
-                (np.array([["(All)", "(All)"]] * 1000), np.arange(1000).reshape(-1, 1)),
-                axis=1,
-            ),
-            columns=["GRNAME", "LOB", "Simulation_#"],
-        )
-    )
+    expected = pd.concat([tri.index] * 1000, ignore_index=True)
+    expected["Simulation_#"] = np.arange(1000)
+    pd.testing.assert_frame_equal(resampled_triangles.index, expected)

--- a/chainladder/core/common.py
+++ b/chainladder/core/common.py
@@ -193,7 +193,7 @@ class Common:
         else:
             ld = self.latest_diagonal if self.is_cumulative else self.sum(axis=3)
         ibnr = self.ultimate_ - ld
-        ibnr.vdims = self.ultimate_.vdims
+        ibnr.columns = self.ultimate_.columns
         return ibnr
 
     @property

--- a/chainladder/core/correlation.py
+++ b/chainladder/core/correlation.py
@@ -173,7 +173,7 @@ class DevelopmentCorrelation:
 
         # final big T
         self.t_expectation = pd.DataFrame(
-            t_expectation[..., 0, 0], columns=triangle.vdims, index=idx
+            t_expectation[..., 0, 0], columns=triangle.columns, index=idx
         )
 
         # table of Spearman's rank coefficients Tk, can be used to verify consistency with paper
@@ -346,17 +346,17 @@ class ValuationCorrelation:
                     (self.range[0] > VarZ.sum(axis=-1))
                     | (VarZ.sum(axis=-1) > self.range[1])
                 )[..., 0],
-                columns=triangle.vdims,
+                columns=triangle.columns,
                 index=idx,
             )
             self.z = pd.DataFrame(
-                z.sum(axis=-1)[..., 0], columns=triangle.vdims, index=idx
+                z.sum(axis=-1)[..., 0], columns=triangle.columns, index=idx
             )
             self.z_expectation = pd.DataFrame(
-                EZ.sum(axis=-1)[..., 0], columns=triangle.vdims, index=idx
+                EZ.sum(axis=-1)[..., 0], columns=triangle.columns, index=idx
             )
             self.z_variance = pd.DataFrame(
-                VarZ.sum(axis=-1)[..., 0], columns=triangle.vdims, index=idx
+                VarZ.sum(axis=-1)[..., 0], columns=triangle.columns, index=idx
             )
 
 

--- a/chainladder/core/display.py
+++ b/chainladder/core/display.py
@@ -52,7 +52,7 @@ class TriangleDisplay:
                 "O" + self.origin_grain + "D" + self.development_grain,
                 self.shape,
                 self.key_labels,
-                list(self.vdims),
+                list(self.columns),
             ],
             index=["Valuation:", "Grain:", "Shape:", "Index:", "Columns:"],
             name="Triangle Summary",

--- a/chainladder/core/dunders.py
+++ b/chainladder/core/dunders.py
@@ -6,10 +6,7 @@ from __future__ import annotations
 import numpy as np
 import pandas as pd
 
-from chainladder.utils.utility_functions import (
-    num_to_nan,
-    concat
-)
+from chainladder.utils.utility_functions import num_to_nan, concat
 
 from chainladder.core.pandas import TriangleGroupBy
 from chainladder.utils.sparse import sp
@@ -25,13 +22,14 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from typing import Any
 
+
 class TriangleDunders:
-    """ Class that implements the dunder (double underscore) methods for the
-        Triangle class
+    """Class that implements the dunder (double underscore) methods for the
+    Triangle class
     """
 
     def _validate_arithmetic(self, other: Any) -> tuple:
-        """ Common functionality BEFORE arithmetic operations """
+        """Common functionality BEFORE arithmetic operations"""
         if isinstance(other, TriangleDunders):
             obj, other = self._compatibility_check(self, other)
             if obj.is_pattern != other.is_pattern:
@@ -43,17 +41,17 @@ class TriangleDunders:
             if isinstance(other, TriangleDunders):
                 other = other.values
         else:
-            if isinstance(other, np.ndarray) and self.array_backend != 'numpy':
+            if isinstance(other, np.ndarray) and self.array_backend != "numpy":
                 obj = self.copy()
                 other = obj.get_array_module().array(other)
-            elif isinstance(other, sp.COO) and self.array_backend != 'sparse':
-                obj = self.set_backend('sparse')
+            elif isinstance(other, sp.COO) and self.array_backend != "sparse":
+                obj = self.set_backend("sparse")
             else:
                 obj = self.copy()
         return obj, other
 
     def _arithmetic_cleanup(self, obj):
-        """ Common functionality AFTER arithmetic operations """
+        """Common functionality AFTER arithmetic operations"""
         obj.values = obj.values * obj.get_array_module().nan_to_num(obj.nan_triangle)
         obj.values = num_to_nan(obj.values)
         return obj
@@ -62,10 +60,9 @@ class TriangleDunders:
         from chainladder.utils.utility_functions import set_common_backend
 
         x, y = set_common_backend([x, y])
-        if (
-            x.origin_grain != y.origin_grain
-            or (x.development_grain != y.development_grain and 
-                min(x.shape[-1], y.shape[-1]) > 1)
+        if x.origin_grain != y.origin_grain or (
+            x.development_grain != y.development_grain
+            and min(x.shape[-1], y.shape[-1]) > 1
         ):
             raise ValueError(
                 "Triangle arithmetic requires both triangles to be the same grain."
@@ -83,7 +80,9 @@ class TriangleDunders:
             return x, y
         if x.kdims.shape[0] == y.kdims.shape[0] == 1 and x.key_labels != y.key_labels:
             kdims = x.kdims if len(x.key_labels) > len(y.key_labels) else y.kdims
-            key_labels = x.key_labels if len(x.key_labels) > len(y.key_labels) else y.key_labels
+            key_labels = (
+                x.key_labels if len(x.key_labels) > len(y.key_labels) else y.key_labels
+            )
             x.kdims = y.kdims = kdims
             x.key_labels = y.key_labels = key_labels
             return x, y
@@ -97,7 +96,11 @@ class TriangleDunders:
             if x_labels != y_labels or x.kdims.shape[0] != y.kdims.shape[0]:
                 x = x.groupby(list(common))
                 y = y.groupby(list(common))
-            elif x.kdims.shape[0] > 1 and not np.array_equal(x.kdims, y.kdims) and not x.index.equals(y.index):
+            elif (
+                x.kdims.shape[0] > 1
+                and not np.array_equal(x.kdims, y.kdims)
+                and not x.index.equals(y.index)
+            ):
                 x = x.sort_index()
                 try:
                     y = y.loc[x.index]
@@ -107,7 +110,12 @@ class TriangleDunders:
             return x, y
 
         else:
-            raise ValueError('Index broadcasting is ambiguous between ' + str(x_labels) + ' and ' + str(y_labels))
+            raise ValueError(
+                "Index broadcasting is ambiguous between "
+                + str(x_labels)
+                + " and "
+                + str(y_labels)
+            )
 
     def _prep_columns(self, x, y):
         if len(x.columns) == 1 and len(y.columns) > 1:
@@ -118,9 +126,9 @@ class TriangleDunders:
             y._vdims = x._vdims
         elif x.shape[1] == y.shape[1] and np.array_equal(x.columns, y.columns):
             return x, y
-        else:            
+        else:
             # Find columns to add to each triangle
-            cols_to_add_to_x = [col for col in y.columns if col not in x.columns] 
+            cols_to_add_to_x = [col for col in y.columns if col not in x.columns]
             cols_to_add_to_y = [col for col in x.columns if col not in y.columns]
 
             # Start with case with no new columns, y simply has a different order
@@ -145,7 +153,8 @@ class TriangleDunders:
         xp = obj.get_array_module()
         is_broadcastable = all(
             (m == n) or (m == 1) or (n == 1)
-            for m, n in zip(obj.shape[-2:][::-1], other.shape[-2:][::-1]))
+            for m, n in zip(obj.shape[-2:][::-1], other.shape[-2:][::-1])
+        )
         if (len(obj.odims), len(obj.ddims)) == (len(other.odims), len(other.ddims)):
             if np.all(obj.ddims != other.ddims) and len(obj.ddims) > 1:
                 is_broadcastable = False
@@ -191,10 +200,20 @@ class TriangleDunders:
             ldl = int(np.where(~d_arr0 == 1)[0].min())
             ldh = int(np.where(~d_arr0 == 1)[0].max() + 1)
             if obj.array_backend != "sparse":
-                other_arr = xp.zeros((other.shape[0], other.shape[1], len(odims), len(ddims)))
+                other_arr = xp.zeros((
+                    other.shape[0],
+                    other.shape[1],
+                    len(odims),
+                    len(ddims),
+                ))
                 other_arr[:] = xp.nan
                 other_arr[:, :, rol:roh, rdl:rdh] = other.values
-                obj_arr = xp.zeros((self.shape[0], self.shape[1], len(odims), len(ddims)))
+                obj_arr = xp.zeros((
+                    self.shape[0],
+                    self.shape[1],
+                    len(odims),
+                    len(ddims),
+                ))
                 obj_arr[:] = xp.nan
                 obj_arr[:, :, lol:loh, ldl:ldh] = obj.values
             else:
@@ -203,7 +222,12 @@ class TriangleDunders:
                 other_arr.coords[3] = other_arr.coords[3] + rdl
                 obj_arr.coords[2] = obj_arr.coords[2] + lol
                 obj_arr.coords[3] = obj_arr.coords[3] + ldl
-                other_arr.shape = (other.shape[0], other.shape[1], len(odims), len(ddims))
+                other_arr.shape = (
+                    other.shape[0],
+                    other.shape[1],
+                    len(odims),
+                    len(ddims),
+                )
                 obj_arr.shape = (self.shape[0], self.shape[1], len(odims), len(ddims))
             obj.odims = np.array(odims.index)
             if isinstance(obj.ddims, pd.DatetimeIndex):
@@ -216,15 +240,19 @@ class TriangleDunders:
 
     @staticmethod
     def _slice_or_nan(obj, other, k):
-        """ Return a broadcastable slice or NaNs for missing slices """
+        """Return a broadcastable slice or NaNs for missing slices"""
         if k in obj.groups.indices.keys():
             return obj.obj.iloc[obj.groups.indices[k]]
         else:
             other = other.obj.iloc[other.groups.indices[k]]
             new_obj = obj.obj.iloc[:1] * 0
             labels = list(set(other.key_labels).intersection(set(new_obj.key_labels)))
-            new_idx = other.index.set_index(labels).join(
-                new_obj.index.set_index(labels)).reset_index()
+            new_idx = (
+                other.index
+                .set_index(labels)
+                .join(new_obj.index.set_index(labels))
+                .reset_index()
+            )
             new_idx = new_idx[new_obj.key_labels].iloc[-1:]
             new_obj.kdims = new_idx.values
             new_obj.key_labels = list(new_idx.columns)
@@ -232,16 +260,15 @@ class TriangleDunders:
 
     @staticmethod
     def _get_key_union(obj, other):
-        return set(list(obj.groups.indices.keys()) +
-                   list(other.groups.indices.keys()))
+        return set(list(obj.groups.indices.keys()) + list(other.groups.indices.keys()))
 
     def _arithmetic_mapper(self, obj, other, f):
-        """ Use Dask if available, otherwise basic list comprehension """
-        if db and obj.obj.array_backend == 'sparse':
+        """Use Dask if available, otherwise basic list comprehension"""
+        if db and obj.obj.array_backend == "sparse":
             _warn_dask_parallel_deprecated()
             bag = db.from_sequence(self._get_key_union(obj, other))
             bag = bag.map(f, self, obj, other)
-            c = bag.compute(scheduler='threads')
+            c = bag.compute(scheduler="threads")
         else:
             c = [f(k, self, obj, other) for k in self._get_key_union(obj, other)]
         return concat(c, 0).sort_index()
@@ -281,9 +308,12 @@ class TriangleDunders:
         """
         obj, other = self._validate_arithmetic(other)
         if isinstance(obj, TriangleGroupBy):
+
             def f(k, self, obj, other):
-                return (self._slice_or_nan(obj, other, k) +
-                        self._slice_or_nan(other, obj, k))
+                return self._slice_or_nan(obj, other, k) + self._slice_or_nan(
+                    other, obj, k
+                )
+
             obj = self._arithmetic_mapper(obj, other, f)
         else:
             xp = obj.get_array_module()
@@ -326,9 +356,12 @@ class TriangleDunders:
         """
         obj, other = self._validate_arithmetic(other)
         if isinstance(obj, TriangleGroupBy):
+
             def f(k, self, obj, other):
-                return (self._slice_or_nan(obj, other, k) -
-                        self._slice_or_nan(other, obj, k))
+                return self._slice_or_nan(obj, other, k) - self._slice_or_nan(
+                    other, obj, k
+                )
+
             obj = self._arithmetic_mapper(obj, other, f)
         else:
             xp = obj.get_array_module()
@@ -400,9 +433,12 @@ class TriangleDunders:
         """
         obj, other = self._validate_arithmetic(other)
         if isinstance(obj, TriangleGroupBy):
+
             def f(k, self, obj, other):
-                return (self._slice_or_nan(obj, other, k) *
-                        self._slice_or_nan(other, obj, k))
+                return self._slice_or_nan(obj, other, k) * self._slice_or_nan(
+                    other, obj, k
+                )
+
             obj = self._arithmetic_mapper(obj, other, f)
         else:
             obj.values = obj.values * other
@@ -414,9 +450,12 @@ class TriangleDunders:
     def __pow__(self, other):
         obj, other = self._validate_arithmetic(other)
         if isinstance(obj, TriangleGroupBy):
+
             def f(k, self, obj, other):
-                return (self._slice_or_nan(obj, other, k) **
-                        self._slice_or_nan(other, obj, k))
+                return self._slice_or_nan(obj, other, k) ** self._slice_or_nan(
+                    other, obj, k
+                )
+
             obj = self._arithmetic_mapper(obj, other, f)
         else:
             xp = obj.get_array_module()
@@ -484,9 +523,12 @@ class TriangleDunders:
         """
         obj, other = self._validate_arithmetic(other)
         if isinstance(obj, TriangleGroupBy):
+
             def f(k, self, obj, other):
-                return (self._slice_or_nan(obj, other, k) /
-                        self._slice_or_nan(other, obj, k))
+                return self._slice_or_nan(obj, other, k) / self._slice_or_nan(
+                    other, obj, k
+                )
+
             obj = self._arithmetic_mapper(obj, other, f)
         else:
             obj.values = obj.values / other
@@ -504,12 +546,10 @@ class TriangleDunders:
         from chainladder import options
 
         backend = options.ARRAY_PRIORITY[
-            min(
-                [
-                    options.ARRAY_PRIORITY.index(x)
-                    for x in [self.array_backend, other.array_backend]
-                ]
-            )
+            min([
+                options.ARRAY_PRIORITY.index(x)
+                for x in [self.array_backend, other.array_backend]
+            ])
         ]
         x, y = self.set_backend(backend), other.set_backend(backend)
         xp = x.get_array_module()

--- a/chainladder/core/dunders.py
+++ b/chainladder/core/dunders.py
@@ -111,11 +111,11 @@ class TriangleDunders:
 
     def _prep_columns(self, x, y):
         if len(x.columns) == 1 and len(y.columns) > 1:
-            x.vdims = y.vdims
+            x._vdims = y._vdims
         elif len(y.columns) == 1 and len(x.columns) > 1:
-            y.vdims = x.vdims
+            y._vdims = x._vdims
         elif len(y.columns) == len(x.columns) == 1 and x.columns != y.columns:
-            y.vdims = x.vdims
+            y._vdims = x._vdims
         elif x.shape[1] == y.shape[1] and np.array_equal(x.columns, y.columns):
             return x, y
         else:            

--- a/chainladder/core/dunders.py
+++ b/chainladder/core/dunders.py
@@ -70,20 +70,20 @@ class TriangleDunders:
         return x, y
 
     def _prep_index(self, x, y):
-        if x.kdims.shape[0] == 1 and y.kdims.shape[0] > 1:
-            x.kdims = y.kdims
+        if x._kdims.shape[0] == 1 and y._kdims.shape[0] > 1:
+            x._kdims = y._kdims
             x.key_labels = y.key_labels
             return x, y
-        if x.kdims.shape[0] > 1 and y.kdims.shape[0] == 1:
-            y.kdims = x.kdims
+        if x._kdims.shape[0] > 1 and y._kdims.shape[0] == 1:
+            y._kdims = x._kdims
             y.key_labels = x.key_labels
             return x, y
-        if x.kdims.shape[0] == y.kdims.shape[0] == 1 and x.key_labels != y.key_labels:
-            kdims = x.kdims if len(x.key_labels) > len(y.key_labels) else y.kdims
+        if x._kdims.shape[0] == y._kdims.shape[0] == 1 and x.key_labels != y.key_labels:
+            kdims = x._kdims if len(x.key_labels) > len(y.key_labels) else y._kdims
             key_labels = (
                 x.key_labels if len(x.key_labels) > len(y.key_labels) else y.key_labels
             )
-            x.kdims = y.kdims = kdims
+            x._kdims = y._kdims = kdims
             x.key_labels = y.key_labels = key_labels
             return x, y
 
@@ -93,12 +93,12 @@ class TriangleDunders:
         common = x_labels.intersection(y_labels)
 
         if common == x_labels or common == y_labels:
-            if x_labels != y_labels or x.kdims.shape[0] != y.kdims.shape[0]:
+            if x_labels != y_labels or x._kdims.shape[0] != y._kdims.shape[0]:
                 x = x.groupby(list(common))
                 y = y.groupby(list(common))
             elif (
-                x.kdims.shape[0] > 1
-                and not np.array_equal(x.kdims, y.kdims)
+                x._kdims.shape[0] > 1
+                and not np.array_equal(x._kdims, y._kdims)
                 and not x.index.equals(y.index)
             ):
                 x = x.sort_index()
@@ -254,8 +254,7 @@ class TriangleDunders:
                 .reset_index()
             )
             new_idx = new_idx[new_obj.key_labels].iloc[-1:]
-            new_obj.kdims = new_idx.values
-            new_obj.key_labels = list(new_idx.columns)
+            new_obj.index = new_idx
             return new_obj
 
     @staticmethod

--- a/chainladder/core/dunders.py
+++ b/chainladder/core/dunders.py
@@ -70,21 +70,24 @@ class TriangleDunders:
         return x, y
 
     def _prep_index(self, x, y):
-        if x._kdims.shape[0] == 1 and y._kdims.shape[0] > 1:
-            x._kdims = y._kdims
-            x.key_labels = y.key_labels
+        if len(x.index) == 1 and len(y.index) > 1:
+            x._index = y.index.copy()
+            x.key_labels = list(y.key_labels)
+            x._set_slicers()
             return x, y
-        if x._kdims.shape[0] > 1 and y._kdims.shape[0] == 1:
-            y._kdims = x._kdims
-            y.key_labels = x.key_labels
+        if len(x.index) > 1 and len(y.index) == 1:
+            y._index = x.index.copy()
+            y.key_labels = list(x.key_labels)
+            y._set_slicers()
             return x, y
-        if x._kdims.shape[0] == y._kdims.shape[0] == 1 and x.key_labels != y.key_labels:
-            kdims = x._kdims if len(x.key_labels) > len(y.key_labels) else y._kdims
-            key_labels = (
-                x.key_labels if len(x.key_labels) > len(y.key_labels) else y.key_labels
-            )
-            x._kdims = y._kdims = kdims
-            x.key_labels = y.key_labels = key_labels
+        if len(x.index) == len(y.index) == 1 and x.key_labels != y.key_labels:
+            index = x.index.copy() if len(x.key_labels) > len(y.key_labels) else y.index.copy()
+            x._index = index.copy()
+            x.key_labels = list(index.columns)
+            x._set_slicers()
+            y._index = index.copy()
+            y.key_labels = list(index.columns)
+            y._set_slicers()
             return x, y
 
         # Use sets for faster operations
@@ -93,12 +96,11 @@ class TriangleDunders:
         common = x_labels.intersection(y_labels)
 
         if common == x_labels or common == y_labels:
-            if x_labels != y_labels or x._kdims.shape[0] != y._kdims.shape[0]:
+            if x_labels != y_labels or len(x.index) != len(y.index):
                 x = x.groupby(list(common))
                 y = y.groupby(list(common))
             elif (
-                x._kdims.shape[0] > 1
-                and not np.array_equal(x._kdims, y._kdims)
+                len(x.index) > 1
                 and not x.index.equals(y.index)
             ):
                 x = x.sort_index()
@@ -119,12 +121,15 @@ class TriangleDunders:
 
     def _prep_columns(self, x, y):
         if len(x.columns) == 1 and len(y.columns) > 1:
-            x._vdims = y._vdims
+            x._columns = y.columns
+            x._set_slicers()
         elif len(y.columns) == 1 and len(x.columns) > 1:
-            y._vdims = x._vdims
-        elif len(y.columns) == len(x.columns) == 1 and x.columns != y.columns:
-            y._vdims = x._vdims
-        elif x.shape[1] == y.shape[1] and np.array_equal(x.columns, y.columns):
+            y._columns = x.columns
+            y._set_slicers()
+        elif len(y.columns) == len(x.columns) == 1 and not x.columns.equals(y.columns):
+            y._columns = x.columns
+            y._set_slicers()
+        elif x.shape[1] == y.shape[1] and x.columns.equals(y.columns):
             return x, y
         else:
             # Find columns to add to each triangle

--- a/chainladder/core/dunders.py
+++ b/chainladder/core/dunders.py
@@ -81,7 +81,11 @@ class TriangleDunders:
             y._set_slicers()
             return x, y
         if len(x.index) == len(y.index) == 1 and x.key_labels != y.key_labels:
-            index = x.index.copy() if len(x.key_labels) > len(y.key_labels) else y.index.copy()
+            index = (
+                x.index.copy()
+                if len(x.key_labels) > len(y.key_labels)
+                else y.index.copy()
+            )
             x._index = index.copy()
             x.key_labels = list(index.columns)
             x._set_slicers()
@@ -99,10 +103,7 @@ class TriangleDunders:
             if x_labels != y_labels or len(x.index) != len(y.index):
                 x = x.groupby(list(common))
                 y = y.groupby(list(common))
-            elif (
-                len(x.index) > 1
-                and not x.index.equals(y.index)
-            ):
+            elif len(x.index) > 1 and not x.index.equals(y.index):
                 x = x.sort_index()
                 try:
                     y = y.loc[x.index]

--- a/chainladder/core/io.py
+++ b/chainladder/core/io.py
@@ -1,6 +1,7 @@
 """
 Support Triangle I/O capabilities.
 """
+
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
@@ -13,7 +14,7 @@ from sklearn.base import BaseEstimator
 
 class TriangleIO:
     def to_pickle(self, path, protocol=None):
-        """ Serializes triangle object to pickle.
+        """Serializes triangle object to pickle.
 
         Parameters
         ----------
@@ -53,7 +54,7 @@ class TriangleIO:
             dill.dump(self, pkl)
 
     def to_json(self):
-        """ Serializes triangle object to json format
+        """Serializes triangle object to json format
 
         Returns
         -------
@@ -88,8 +89,13 @@ class TriangleIO:
             "is_pattern": self.is_pattern,
             "columns": list(self.columns),
         }
-        out = self.cum_to_incr().dev_to_val().to_frame(
-            keepdims=True, origin_as_datetime=True).fillna(0)
+        out = (
+            self
+            .cum_to_incr()
+            .dev_to_val()
+            .to_frame(keepdims=True, origin_as_datetime=True)
+            .fillna(0)
+        )
         x = out.reset_index().to_json(orient="split", date_unit="ns")
         json_dict = {"metadata": json.dumps(metadata), "data": x}
         sub_tris = [k for k, v in vars(self).items() if isinstance(v, TriangleIO)]
@@ -103,17 +109,17 @@ class TriangleIO:
         ]
         json_dict["dfs"] = {df: getattr(self, df).to_json() for df in dfs}
         dfs = [k for k, v in vars(self).items() if isinstance(v, pd.Series)]
-        json_dict["dfs"].update(
-            {df: getattr(self, df).to_frame().to_json() for df in dfs}
-        )
+        json_dict["dfs"].update({
+            df: getattr(self, df).to_frame().to_json() for df in dfs
+        })
         return json.dumps(json_dict)
 
 
 class EstimatorIO:
-    """ Class intended to allow persistence of estimator objects """
+    """Class intended to allow persistence of estimator objects"""
 
     def to_pickle(self, path, protocol=None):
-        """ Serializes triangle object to pickle.
+        """Serializes triangle object to pickle.
 
         Parameters
         ----------
@@ -153,7 +159,7 @@ class EstimatorIO:
             dill.dump(self, pkl)
 
     def to_json(self):
-        """ Serializes triangle object to json format
+        """Serializes triangle object to json format
 
         Returns
         -------

--- a/chainladder/core/io.py
+++ b/chainladder/core/io.py
@@ -96,7 +96,11 @@ class TriangleIO:
         json_dict["sub_tris"] = {
             sub_tri: getattr(self, sub_tri).to_json() for sub_tri in sub_tris
         }
-        dfs = [k for k, v in vars(self).items() if isinstance(v, pd.DataFrame)]
+        dfs = [
+            k
+            for k, v in vars(self).items()
+            if isinstance(v, pd.DataFrame) and k != "_index"
+        ]
         json_dict["dfs"] = {df: getattr(self, df).to_json() for df in dfs}
         dfs = [k for k, v in vars(self).items() if isinstance(v, pd.Series)]
         json_dict["dfs"].update(

--- a/chainladder/core/pandas.py
+++ b/chainladder/core/pandas.py
@@ -168,7 +168,7 @@ class TrianglePandas(_TrianglePandasBase):
             elif len(axes) in [1, 2]:
                 tri: ndarray = np.squeeze(self.set_backend("numpy").values)
                 axes_lookup: dict = {
-                    0: self.kdims,
+                    0: self._kdims,
                     1: self._vdims,
                     2: self.origin,
                     3: self.development,
@@ -1257,8 +1257,8 @@ def add_triangle_agg_func(cls: Type[TrianglePandas], k: str, v: str):
 
         # Aggregation function will collapse a dimension, so
         # adjust the dimensions of the original object to match that of the aggregation.
-        if axis == 0 and obj.values.shape[axis] == 1 and len(obj.kdims) > 1:
-            obj.kdims = np.array([["(All)"] * len(obj.key_labels)])
+        if axis == 0 and obj.values.shape[axis] == 1 and len(obj._kdims) > 1:
+            obj._kdims = np.array([["(All)"] * len(obj.key_labels)])
         if axis == 1 and obj.values.shape[axis] == 1 and len(obj._vdims) > 1:
             obj._vdims = np.array([0])
         if axis == 2 and obj.values.shape[axis] == 1 and len(obj.odims) > 1:
@@ -1324,7 +1324,7 @@ def add_groupby_agg_func(cls, k: str, v: str):
             else:
                 index = pd.DataFrame(group_index)
                 obj.key_labels = index.columns.tolist()
-                obj.kdims = index.values
+                obj._kdims = index.values
         if self.axis == 1:
             obj._vdims = pd.DataFrame(group_index).values[:, 0]
         if self.axis == 2:

--- a/chainladder/core/pandas.py
+++ b/chainladder/core/pandas.py
@@ -168,8 +168,8 @@ class TrianglePandas(_TrianglePandasBase):
             elif len(axes) in [1, 2]:
                 tri: ndarray = np.squeeze(self.set_backend("numpy").values)
                 axes_lookup: dict = {
-                    0: self._kdims,
-                    1: self._vdims,
+                    0: self.index.values,
+                    1: self.columns.values,
                     2: self.origin,
                     3: self.development,
                 }
@@ -1257,10 +1257,10 @@ def add_triangle_agg_func(cls: Type[TrianglePandas], k: str, v: str):
 
         # Aggregation function will collapse a dimension, so
         # adjust the dimensions of the original object to match that of the aggregation.
-        if axis == 0 and obj.values.shape[axis] == 1 and len(obj._kdims) > 1:
-            obj._kdims = np.array([["(All)"] * len(obj.key_labels)])
-        if axis == 1 and obj.values.shape[axis] == 1 and len(obj._vdims) > 1:
-            obj._vdims = np.array([0])
+        if axis == 0 and obj.values.shape[axis] == 1 and len(obj.index) > 1:
+            obj._index = pd.DataFrame([["(All)"] * len(obj.key_labels)], columns=obj.key_labels)
+        if axis == 1 and obj.values.shape[axis] == 1 and len(obj.columns) > 1:
+            obj._columns = pd.Index([0], name="columns")
         if axis == 2 and obj.values.shape[axis] == 1 and len(obj.odims) > 1:
             obj.odims = obj.odims[0:1]
         # If axis is development, set the ddims to be the valuation date.
@@ -1323,10 +1323,9 @@ def add_groupby_agg_func(cls, k: str, v: str):
                 obj.index = index
             else:
                 index = pd.DataFrame(group_index)
-                obj.key_labels = index.columns.tolist()
-                obj._kdims = index.values
+                obj.index = index
         if self.axis == 1:
-            obj._vdims = pd.DataFrame(group_index).values[:, 0]
+            obj.columns = group_index
         if self.axis == 2:
             odims = self.obj._to_datetime(
                 pd.Series(self.groups.indices.keys()).to_frame(), [0]

--- a/chainladder/core/pandas.py
+++ b/chainladder/core/pandas.py
@@ -169,7 +169,7 @@ class TrianglePandas(_TrianglePandasBase):
                 tri: ndarray = np.squeeze(self.set_backend("numpy").values)
                 axes_lookup: dict = {
                     0: self.kdims,
-                    1: self.vdims,
+                    1: self._vdims,
                     2: self.origin,
                     3: self.development,
                 }
@@ -1259,8 +1259,8 @@ def add_triangle_agg_func(cls: Type[TrianglePandas], k: str, v: str):
         # adjust the dimensions of the original object to match that of the aggregation.
         if axis == 0 and obj.values.shape[axis] == 1 and len(obj.kdims) > 1:
             obj.kdims = np.array([["(All)"] * len(obj.key_labels)])
-        if axis == 1 and obj.values.shape[axis] == 1 and len(obj.vdims) > 1:
-            obj.vdims = np.array([0])
+        if axis == 1 and obj.values.shape[axis] == 1 and len(obj._vdims) > 1:
+            obj._vdims = np.array([0])
         if axis == 2 and obj.values.shape[axis] == 1 and len(obj.odims) > 1:
             obj.odims = obj.odims[0:1]
         # If axis is development, set the ddims to be the valuation date.
@@ -1326,7 +1326,7 @@ def add_groupby_agg_func(cls, k: str, v: str):
                 obj.key_labels = index.columns.tolist()
                 obj.kdims = index.values
         if self.axis == 1:
-            obj.vdims = pd.DataFrame(group_index).values[:, 0]
+            obj._vdims = pd.DataFrame(group_index).values[:, 0]
         if self.axis == 2:
             odims = self.obj._to_datetime(
                 pd.Series(self.groups.indices.keys()).to_frame(), [0]

--- a/chainladder/core/pandas.py
+++ b/chainladder/core/pandas.py
@@ -1258,7 +1258,9 @@ def add_triangle_agg_func(cls: Type[TrianglePandas], k: str, v: str):
         # Aggregation function will collapse a dimension, so
         # adjust the dimensions of the original object to match that of the aggregation.
         if axis == 0 and obj.values.shape[axis] == 1 and len(obj.index) > 1:
-            obj._index = pd.DataFrame([["(All)"] * len(obj.key_labels)], columns=obj.key_labels)
+            obj._index = pd.DataFrame(
+                [["(All)"] * len(obj.key_labels)], columns=obj.key_labels
+            )
         if axis == 1 and obj.values.shape[axis] == 1 and len(obj.columns) > 1:
             obj._columns = pd.Index([0], name="columns")
         if axis == 2 and obj.values.shape[axis] == 1 and len(obj.odims) > 1:

--- a/chainladder/core/slice.py
+++ b/chainladder/core/slice.py
@@ -63,7 +63,7 @@ class _LocBase:
         else:
             obj.values = obj.values[i_idx, :, o_idx, d_idx][:, c_idx, ...]
         # Set the new dimension values.
-        obj.kdims = obj.kdims[i_idx]
+        obj._kdims = obj._kdims[i_idx]
         obj._vdims = obj._vdims[c_idx]
         obj.odims, obj.ddims = obj.odims[o_idx], obj.ddims[d_idx]
         # Set indexers.
@@ -385,7 +385,7 @@ class Location(_LocBase):
             ).values.flatten()
         # Case scalar, locate position in first level of index.
         else:
-            idx = np.where(self.obj.kdims[:, 0] == key)[0]
+            idx = np.where(self.obj._kdims[:, 0] == key)[0]
         return idx
 
     def other_key(

--- a/chainladder/core/slice.py
+++ b/chainladder/core/slice.py
@@ -64,7 +64,7 @@ class _LocBase:
             obj.values = obj.values[i_idx, :, o_idx, d_idx][:, c_idx, ...]
         # Set the new dimension values.
         obj.kdims = obj.kdims[i_idx]
-        obj.vdims = obj.vdims[c_idx]
+        obj._vdims = obj._vdims[c_idx]
         obj.odims, obj.ddims = obj.odims[o_idx], obj.ddims[d_idx]
         # Set indexers.
         obj.iloc, obj.loc = Ilocation(obj), Location(obj)
@@ -539,7 +539,7 @@ class TriangleSlicer:
                 [key] if isinstance(key, (str, int, float, np.generic)) else key
             )
             # Identify the position of each requested element within the valuation dimension.
-            idx = [list(self.vdims).index(item) for item in keys]
+            idx = [list(self._vdims).index(item) for item in keys]
             return self.iloc[:, idx]
 
     def __setitem__(
@@ -553,7 +553,7 @@ class TriangleSlicer:
         Parameters
         ----------
         key: str | int
-            The vdims label of the column to set.
+            The column label of the column to set.
         value: int | float | TriangleSlicer | Callable[[Triangle], TriangleSlicer]
             The value(s) to assign to the column. A callable defines a virtual
             (lazily-computed) column.
@@ -567,10 +567,10 @@ class TriangleSlicer:
         if callable(value):
             self.virtual_columns[key] = value
             if self.array_backend == "sparse":
-                if key not in self.vdims:
+                if key not in self._vdims:
                     k, v, o, d = self.values.shape
                     self.values.shape = k, v + 1, o, d
-                    self.vdims = np.append(self.vdims, key)
+                    self._vdims = np.append(self._vdims, key)
                 return
             # Create a placeholder column.
             value = (self.iloc[:, 0].copy() * xp.nan).set_backend(self.array_backend)
@@ -582,8 +582,8 @@ class TriangleSlicer:
             if value.array_backend != self.array_backend:
                 value = value.set_backend(self.array_backend)
         # Key exists in columns, replace data.
-        if key in self.vdims:
-            i = np.where(self.vdims == key)[0][0]
+        if key in self._vdims:
+            i = np.where(self._vdims == key)[0][0]
             # Case sparse backend.
             if self.array_backend == "sparse":
                 # Unwrap a Triangle-valued assignment to its raw array. A raw
@@ -621,7 +621,7 @@ class TriangleSlicer:
                 cast(np.ndarray, self.values)[:, i : i + 1] = value
         # Key is new, create a column and update data.
         else:
-            self.vdims = np.append(self.vdims, key)
+            self._vdims = np.append(self._vdims, key)
             if isinstance(value, (int, float, np.number)):
                 # Broadcast scalar across the Triangle's shape.
                 value = self.iloc[:, 0] * 0 + value

--- a/chainladder/core/slice.py
+++ b/chainladder/core/slice.py
@@ -63,8 +63,8 @@ class _LocBase:
         else:
             obj.values = obj.values[i_idx, :, o_idx, d_idx][:, c_idx, ...]
         # Set the new dimension values.
-        obj._kdims = obj._kdims[i_idx]
-        obj._vdims = obj._vdims[c_idx]
+        obj._index = obj._index.iloc[i_idx].reset_index(drop=True)
+        obj._columns = obj._columns[c_idx]
         obj.odims, obj.ddims = obj.odims[o_idx], obj.ddims[d_idx]
         # Set indexers.
         obj.iloc, obj.loc = Ilocation(obj), Location(obj)
@@ -385,7 +385,7 @@ class Location(_LocBase):
             ).values.flatten()
         # Case scalar, locate position in first level of index.
         else:
-            idx = np.where(self.obj._kdims[:, 0] == key)[0]
+            idx = np.where(self.obj.index.iloc[:, 0].values == key)[0]
         return idx
 
     def other_key(
@@ -539,7 +539,7 @@ class TriangleSlicer:
                 [key] if isinstance(key, (str, int, float, np.generic)) else key
             )
             # Identify the position of each requested element within the valuation dimension.
-            idx = [list(self._vdims).index(item) for item in keys]
+            idx = [list(self.columns).index(item) for item in keys]
             return self.iloc[:, idx]
 
     def __setitem__(
@@ -567,10 +567,10 @@ class TriangleSlicer:
         if callable(value):
             self.virtual_columns[key] = value
             if self.array_backend == "sparse":
-                if key not in self._vdims:
+                if key not in self.columns:
                     k, v, o, d = self.values.shape
                     self.values.shape = k, v + 1, o, d
-                    self._vdims = np.append(self._vdims, key)
+                    self._columns = self.columns.append(pd.Index([key]))
                 return
             # Create a placeholder column.
             value = (self.iloc[:, 0].copy() * xp.nan).set_backend(self.array_backend)
@@ -582,8 +582,8 @@ class TriangleSlicer:
             if value.array_backend != self.array_backend:
                 value = value.set_backend(self.array_backend)
         # Key exists in columns, replace data.
-        if key in self._vdims:
-            i = np.where(self._vdims == key)[0][0]
+        if key in self.columns:
+            i = self.columns.get_loc(key)
             # Case sparse backend.
             if self.array_backend == "sparse":
                 # Unwrap a Triangle-valued assignment to its raw array. A raw
@@ -621,7 +621,7 @@ class TriangleSlicer:
                 cast(np.ndarray, self.values)[:, i : i + 1] = value
         # Key is new, create a column and update data.
         else:
-            self._vdims = np.append(self._vdims, key)
+            self._columns = self.columns.append(pd.Index([key]))
             if isinstance(value, (int, float, np.number)):
                 # Broadcast scalar across the Triangle's shape.
                 value = self.iloc[:, 0] * 0 + value

--- a/chainladder/core/slice.py
+++ b/chainladder/core/slice.py
@@ -525,6 +525,8 @@ class TriangleSlicer:
             return self._slice(key, "odims")
         # Case index.
         if isinstance(key, pd.Series):
+            if pd.api.types.is_bool_dtype(key):
+                return self.iloc[np.where(key.to_numpy())[0]]
             return self.iloc[self.index[key].index]
         elif key in self.key_labels:
             return self.index[key]

--- a/chainladder/core/tests/test_triangle.py
+++ b/chainladder/core/tests/test_triangle.py
@@ -173,8 +173,7 @@ def test_sum_of_diff_eq_diff_of_sum(clrd):
 
 def test_append(raa):
     raa2 = raa.copy()
-    raa2.kdims = np.array([["P2"]])
-    raa.append(raa2).sum() == raa * 2
+    raa2.index = pd.DataFrame([["P2"]], columns=raa.key_labels)
     assert raa.append(raa2).sum() == 2 * raa
 
 
@@ -463,6 +462,18 @@ def test_vdims_deprecation_warning(raa):
     with pytest.warns(FutureWarning, match="'vdims' attribute is deprecated"):
         raa2.vdims = ["NewColumn"]
     assert list(raa2.columns) == ["NewColumn"]
+
+
+def test_kdims_deprecation_warning(raa):
+    """Accessing or setting kdims should emit a FutureWarning."""
+    with pytest.warns(FutureWarning, match="'kdims' attribute is deprecated"):
+        k = raa.kdims
+    assert np.all(k == raa.index.values)
+
+    raa2 = raa.copy()
+    with pytest.warns(FutureWarning, match="'kdims' attribute is deprecated"):
+        raa2.kdims = np.array([["P2"]])
+    assert list(raa2.index.values) == [["P2"]]
 
 
 def test_valdev1(qtr):

--- a/chainladder/core/tests/test_triangle.py
+++ b/chainladder/core/tests/test_triangle.py
@@ -474,6 +474,28 @@ def test_kdims_deprecation_warning(raa):
     assert list(raa2.index.values) == [["P2"]]
 
 
+def test_legacy_pickle_compatibility(raa):
+    """Pickles saved prior to kdims/vdims rename should unpickle cleanly."""
+    import pickle
+
+    state = raa.__dict__.copy()
+    # Simulate a legacy serialized Triangle containing kdims and vdims
+    state["kdims"] = state.pop("_kdims")
+    state["vdims"] = state.pop("_vdims")
+
+    restored = cl.Triangle.__new__(cl.Triangle)
+    restored.__setstate__(state)
+
+    assert restored.index.equals(raa.index)
+    assert list(restored.columns) == list(raa.columns)
+    assert restored.loc["Total"].shape == raa.loc["Total"].shape
+    assert restored == raa
+
+    # Verify re-pickling the migrated instance works
+    roundtripped = pickle.loads(pickle.dumps(restored))
+    assert roundtripped == raa
+
+
 def test_valdev1(qtr):
     assert qtr.dev_to_val().val_to_dev() == qtr
 

--- a/chainladder/core/tests/test_triangle.py
+++ b/chainladder/core/tests/test_triangle.py
@@ -322,14 +322,12 @@ def test_origin_and_value_setters(raa):
     raa2 = raa.copy()
     raa.columns = list(raa.columns)
     raa.origin = list(raa.origin)
-    assert np.all(
-        (
-            np.all(raa2.origin == raa.origin),
-            np.all(raa2.development == raa.development),
-            np.all(raa2.odims == raa.odims),
-            np.all(raa2.columns == raa.columns),
-        )
-    )
+    assert np.all((
+        np.all(raa2.origin == raa.origin),
+        np.all(raa2.development == raa.development),
+        np.all(raa2.odims == raa.odims),
+        np.all(raa2.columns == raa.columns),
+    ))
 
 
 def test_index_setter_with_dataframe(clrd: Triangle) -> None:

--- a/chainladder/core/tests/test_triangle.py
+++ b/chainladder/core/tests/test_triangle.py
@@ -323,12 +323,14 @@ def test_origin_and_value_setters(raa):
     raa2 = raa.copy()
     raa.columns = list(raa.columns)
     raa.origin = list(raa.origin)
-    assert np.all((
-        np.all(raa2.origin == raa.origin),
-        np.all(raa2.development == raa.development),
-        np.all(raa2.odims == raa.odims),
-        np.all(raa2.vdims == raa.vdims),
-    ))
+    assert np.all(
+        (
+            np.all(raa2.origin == raa.origin),
+            np.all(raa2.development == raa.development),
+            np.all(raa2.odims == raa.odims),
+            np.all(raa2.columns == raa.columns),
+        )
+    )
 
 
 def test_index_setter_with_dataframe(clrd: Triangle) -> None:
@@ -449,6 +451,18 @@ def test_set_index_not_inplace(clrd: Triangle) -> None:
     np.testing.assert_array_equal(result.kdims, new_index.values)
     assert tri.key_labels == original_key_labels
     np.testing.assert_array_equal(tri.kdims, original_kdims)
+
+
+def test_vdims_deprecation_warning(raa):
+    """Accessing or setting vdims should emit a FutureWarning."""
+    with pytest.warns(FutureWarning, match="'vdims' attribute is deprecated"):
+        v = raa.vdims
+    assert np.all(v == raa.columns.values)
+
+    raa2 = raa.copy()
+    with pytest.warns(FutureWarning, match="'vdims' attribute is deprecated"):
+        raa2.vdims = ["NewColumn"]
+    assert list(raa2.columns) == ["NewColumn"]
 
 
 def test_valdev1(qtr):

--- a/chainladder/core/tests/test_triangle.py
+++ b/chainladder/core/tests/test_triangle.py
@@ -351,9 +351,9 @@ def test_index_setter_with_dataframe(clrd: Triangle) -> None:
     tri.index = new_index
 
     assert tri.key_labels == ["Company"]
-    np.testing.assert_array_equal(tri.kdims, new_index.values)
+    assert tri.index.equals(new_index)
     # _set_slicers() must have rebuilt .loc against the new key label.
-    assert tri.loc["A"].kdims.tolist() == [["A"]]
+    assert tri.loc["A"].index.values.tolist() == [["A"]]
     assert tri.loc["A"] == clrd.iloc[:1]
 
 
@@ -399,8 +399,8 @@ def test_index_setter_non_dataframe_raises(clrd: Triangle) -> None:
 
 def test_set_index_inplace(clrd: Triangle) -> None:
     """
-    Triangle.set_index(value, inplace=True) should mutate the calling
-    Triangle's index via the index setter and return that same object.
+    Triangle.set_index(value, inplace=True) should mutate the Triangle and
+    return self.
 
     Parameters
     ----------
@@ -418,14 +418,14 @@ def test_set_index_inplace(clrd: Triangle) -> None:
 
     assert result is tri
     assert tri.key_labels == ["Company"]
-    np.testing.assert_array_equal(tri.kdims, new_index.values)
+    assert tri.index.equals(new_index)
 
 
 def test_set_index_not_inplace(clrd: Triangle) -> None:
     """
     Triangle.set_index(value) with the default inplace=False should operate
     on a copy: it returns a distinct Triangle with the new index applied,
-    leaving the original Triangle's kdims/key_labels untouched.
+    leaving the original Triangle's index/key_labels untouched.
 
     Parameters
     ----------
@@ -437,7 +437,7 @@ def test_set_index_not_inplace(clrd: Triangle) -> None:
     None
     """
     tri = clrd.iloc[:3]
-    original_kdims = tri.kdims.copy()
+    original_index = tri.index.copy()
     original_key_labels = list(tri.key_labels)
     new_index = pd.DataFrame({"Company": ["A", "B", "C"]})
 
@@ -445,9 +445,9 @@ def test_set_index_not_inplace(clrd: Triangle) -> None:
 
     assert result is not tri
     assert result.key_labels == ["Company"]
-    np.testing.assert_array_equal(result.kdims, new_index.values)
+    assert result.index.equals(new_index)
     assert tri.key_labels == original_key_labels
-    np.testing.assert_array_equal(tri.kdims, original_kdims)
+    assert tri.index.equals(original_index)
 
 
 def test_vdims_deprecation_warning(raa):
@@ -475,23 +475,43 @@ def test_kdims_deprecation_warning(raa):
 
 
 def test_legacy_pickle_compatibility(raa):
-    """Pickles saved prior to kdims/vdims rename should unpickle cleanly."""
+    """Pickles saved prior to kdims/vdims migration should unpickle cleanly."""
     import pickle
 
+    # 1. Simulate oldest serialized Triangle containing kdims and vdims
     state = raa.__dict__.copy()
-    # Simulate a legacy serialized Triangle containing kdims and vdims
-    state["kdims"] = state.pop("_kdims")
-    state["vdims"] = state.pop("_vdims")
+    state.pop("_index", None)
+    state.pop("_columns", None)
+    state["kdims"] = raa.index.values
+    state["vdims"] = raa.columns.values
 
     restored = cl.Triangle.__new__(cl.Triangle)
     restored.__setstate__(state)
 
+    assert isinstance(restored.columns, pd.Index)
+    assert isinstance(restored.index, pd.DataFrame)
     assert restored.index.equals(raa.index)
     assert list(restored.columns) == list(raa.columns)
     assert restored.loc["Total"].shape == raa.loc["Total"].shape
     assert restored == raa
 
-    # Verify re-pickling the migrated instance works
+    # 2. Simulate intermediate serialized Triangle containing _kdims and _vdims
+    state_mid = raa.__dict__.copy()
+    state_mid.pop("_index", None)
+    state_mid.pop("_columns", None)
+    state_mid["_kdims"] = raa.index.values
+    state_mid["_vdims"] = raa.columns.values
+
+    restored_mid = cl.Triangle.__new__(cl.Triangle)
+    restored_mid.__setstate__(state_mid)
+
+    assert isinstance(restored_mid.columns, pd.Index)
+    assert isinstance(restored_mid.index, pd.DataFrame)
+    assert restored_mid.index.equals(raa.index)
+    assert list(restored_mid.columns) == list(raa.columns)
+    assert restored_mid == raa
+
+    # 3. Verify re-pickling the migrated instance works
     roundtripped = pickle.loads(pickle.dumps(restored))
     assert roundtripped == raa
 

--- a/chainladder/core/tests/test_triangle.py
+++ b/chainladder/core/tests/test_triangle.py
@@ -461,6 +461,13 @@ def test_vdims_deprecation_warning(raa):
         raa2.vdims = ["NewColumn"]
     assert list(raa2.columns) == ["NewColumn"]
 
+    with pytest.warns(FutureWarning, match="'vdims' attribute is deprecated"):
+        raa2.vdims = "SingleColumn"
+    assert list(raa2.columns) == ["SingleColumn"]
+
+    raa2.columns = "DirectColumn"
+    assert list(raa2.columns) == ["DirectColumn"]
+
 
 def test_kdims_deprecation_warning(raa):
     """Accessing or setting kdims should emit a FutureWarning."""
@@ -473,6 +480,18 @@ def test_kdims_deprecation_warning(raa):
         raa2.kdims = np.array([["P2"]])
     assert list(raa2.index.values) == [["P2"]]
 
+    with pytest.warns(FutureWarning, match="'kdims' attribute is deprecated"):
+        raa2.kdims = "P_str"
+    assert list(raa2.index.values) == [["P_str"]]
+
+    with pytest.warns(FutureWarning, match="'kdims' attribute is deprecated"):
+        raa2.kdims = ["P_1d"]
+    assert list(raa2.index.values) == [["P_1d"]]
+
+    with pytest.warns(FutureWarning, match="'kdims' attribute is deprecated"):
+        raa2.kdims = (["P_tuple"],)
+    assert list(raa2.index.values) == [["P_tuple"]]
+
     # Setting wider kdims array and follow-up key_labels assignment
     raa3 = raa.copy()
     with pytest.warns(FutureWarning, match="'kdims' attribute is deprecated"):
@@ -483,6 +502,11 @@ def test_kdims_deprecation_warning(raa):
     indexed = raa3.index.set_index(raa3.key_labels)
     assert list(indexed.index.names) == ["Company", "State"]
 
+    # Assigning single-col kdims to multi-col triangle resets cols to ['Total']
+    with pytest.warns(FutureWarning, match="'kdims' attribute is deprecated"):
+        raa3.kdims = np.array([["P_single"]])
+    assert list(raa3.index.columns) == ["Total"]
+
 
 def test_key_labels_setter(raa):
     """Setting key_labels should update Triangle.index columns and slicers."""
@@ -492,6 +516,19 @@ def test_key_labels_setter(raa):
     assert list(tri.index.columns) == ["NewCompany"]
     indexed = tri.index.set_index(tri.key_labels)
     assert list(indexed.index.names) == ["NewCompany"]
+
+    tri.key_labels = "SingleCompany"
+    assert tri.key_labels == ["SingleCompany"]
+    assert list(tri.index.columns) == ["SingleCompany"]
+
+
+def test_series_indexing(raa):
+    """Indexing Triangle by boolean Series or label Series should work."""
+    s_bool = pd.Series([True], index=raa.index.index)
+    assert raa[s_bool].shape == raa.shape
+
+    s_label = pd.Series(["Total"])
+    assert raa[s_label].shape == raa.shape
 
 
 def test_legacy_pickle_compatibility(raa):
@@ -531,7 +568,21 @@ def test_legacy_pickle_compatibility(raa):
     assert list(restored_mid.columns) == list(raa.columns)
     assert restored_mid == raa
 
-    # 3. Verify re-pickling the migrated instance works
+    # 3. Simulate fallback when no kdims/vdims keys are found
+    state_empty = raa.__dict__.copy()
+    state_empty.pop("_index", None)
+    state_empty.pop("_columns", None)
+    state_empty.pop("kdims", None)
+    state_empty.pop("_kdims", None)
+    state_empty.pop("vdims", None)
+    state_empty.pop("_vdims", None)
+
+    restored_empty = cl.Triangle.__new__(cl.Triangle)
+    restored_empty.__setstate__(state_empty)
+    assert list(restored_empty.columns) == ["values"]
+    assert list(restored_empty.index.columns) == ["Total"]
+
+    # 4. Verify re-pickling the migrated instance works
     roundtripped = pickle.loads(pickle.dumps(restored))
     assert roundtripped == raa
 

--- a/chainladder/core/tests/test_triangle.py
+++ b/chainladder/core/tests/test_triangle.py
@@ -3333,4 +3333,3 @@ def test_triangle_index_setter_resets_row_index(raa) -> None:
     mask = raa1.index["Total"] == "Total"
     sliced = raa1[mask]
     assert sliced == raa1
-

--- a/chainladder/core/tests/test_triangle.py
+++ b/chainladder/core/tests/test_triangle.py
@@ -3298,3 +3298,39 @@ def test_cum_zeta_returns_incr_to_cum(atol) -> None:
         [0.888447, 0.645235, 0.423275, 0.269296, 0.127443, 0.036770],
         atol=atol,
     )
+
+
+def test_json_roundtrip_preserves_dataframe_index(raa, clrd) -> None:
+    """JSON serialization roundtrip must preserve Triangle._index as a pd.DataFrame."""
+    r_single = cl.read_json(raa.to_json())
+    assert isinstance(r_single.index, pd.DataFrame)
+    assert isinstance(r_single._index, pd.DataFrame)
+    assert r_single.index.iloc[:, 0].tolist() == ["Total"]
+    assert r_single == raa
+
+    r_multi = cl.read_json(clrd.to_json())
+    assert isinstance(r_multi.index, pd.DataFrame)
+    assert isinstance(r_multi._index, pd.DataFrame)
+    pd.testing.assert_frame_equal(r_multi.index, clrd.index)
+    assert r_multi == clrd
+
+
+def test_triangle_copy_isolated_index(raa) -> None:
+    """Triangle.copy() must not share the mutable _index DataFrame."""
+    copied = raa.copy()
+    assert copied.index is not raa.index
+    copied.index.iloc[0, 0] = "Modified"
+    assert raa.index.iloc[0, 0] == "Total"
+
+
+def test_triangle_index_setter_resets_row_index(raa) -> None:
+    """Assigning a DataFrame with non-default index to Triangle.index resets row index."""
+    custom_df = pd.DataFrame({"Total": ["Total"]}, index=[42])
+    raa1 = raa.copy()
+    raa1.index = custom_df
+    assert list(raa1.index.index) == [0]
+    # Boolean Series slicing should work cleanly
+    mask = raa1.index["Total"] == "Total"
+    sliced = raa1[mask]
+    assert sliced == raa1
+

--- a/chainladder/core/tests/test_triangle.py
+++ b/chainladder/core/tests/test_triangle.py
@@ -473,6 +473,26 @@ def test_kdims_deprecation_warning(raa):
         raa2.kdims = np.array([["P2"]])
     assert list(raa2.index.values) == [["P2"]]
 
+    # Setting wider kdims array and follow-up key_labels assignment
+    raa3 = raa.copy()
+    with pytest.warns(FutureWarning, match="'kdims' attribute is deprecated"):
+        raa3.kdims = np.array([["P2", "CA"]])
+    raa3.key_labels = ["Company", "State"]
+    assert raa3.key_labels == ["Company", "State"]
+    assert list(raa3.index.columns) == ["Company", "State"]
+    indexed = raa3.index.set_index(raa3.key_labels)
+    assert list(indexed.index.names) == ["Company", "State"]
+
+
+def test_key_labels_setter(raa):
+    """Setting key_labels should update Triangle.index columns and slicers."""
+    tri = raa.copy()
+    tri.key_labels = ["NewCompany"]
+    assert tri.key_labels == ["NewCompany"]
+    assert list(tri.index.columns) == ["NewCompany"]
+    indexed = tri.index.set_index(tri.key_labels)
+    assert list(indexed.index.names) == ["NewCompany"]
+
 
 def test_legacy_pickle_compatibility(raa):
     """Pickles saved prior to kdims/vdims migration should unpickle cleanly."""

--- a/chainladder/core/triangle.py
+++ b/chainladder/core/triangle.py
@@ -2078,6 +2078,14 @@ class Triangle(TriangleBase):
         X.values = X.values.copy()
         return X
 
+    def __setstate__(self, state: dict) -> None:
+        """Migrate legacy pickled instances with 'kdims'/'vdims' to '_kdims'/'_vdims'."""
+        if "kdims" in state and "_kdims" not in state:
+            state["_kdims"] = state.pop("kdims")
+        if "vdims" in state and "_vdims" not in state:
+            state["_vdims"] = state.pop("vdims")
+        self.__dict__.update(state)
+
     def development_correlation(self, p_critical=0.5):
         """
         Mack (1997) test for correlations between subsequent development

--- a/chainladder/core/triangle.py
+++ b/chainladder/core/triangle.py
@@ -560,14 +560,14 @@ class Triangle(TriangleBase):
 
         self.kdims: np.ndarray
         key_idx: np.ndarray
-        self.vdims: np.ndarray
+        self._vdims: np.ndarray
         self.odims: np.ndarray
         orig_idx: np.ndarray
         self.ddims: ArrayLike
         dev_idx: np.ndarray
 
         self.kdims, key_idx = self._set_kdims(data_agg, index)
-        self.vdims = np.array(columns)
+        self._vdims = np.array(columns)
         self.odims, orig_idx = self._set_odims(data_agg, date_axes)
         self.ddims, dev_idx = self._set_ddims(data_agg, date_axes)
 
@@ -652,7 +652,7 @@ class Triangle(TriangleBase):
                     sorted=True,
                     shape=(
                         len(self.kdims),
-                        len(self.vdims),
+                        len(self._vdims),
                         len(self.odims),
                         len(self.ddims),
                     ),
@@ -738,15 +738,40 @@ class Triangle(TriangleBase):
 
     @property
     def columns(self):
-        return pd.Index(self.vdims, name="columns")
+        return pd.Index(self._vdims, name="columns")
 
     @columns.setter
     def columns(self, value):
         self._len_check(self.columns, value)
-        self.vdims = [value] if type(value) is str else value
-        if type(self.vdims) is list:
-            self.vdims = np.array(self.vdims)
+        vdims = [value] if type(value) is str else value
+        if type(vdims) is list:
+            vdims = np.array(vdims)
+        self._vdims = vdims
         self._set_slicers()
+
+    @property
+    def vdims(self):
+        warnings.warn(
+            "The 'vdims' attribute is deprecated and will be removed in a future release. "
+            "Use 'Triangle.columns' or 'Triangle.columns_label' instead.",
+            FutureWarning,
+            stacklevel=2,
+        )
+        return self._vdims
+
+    @vdims.setter
+    def vdims(self, value):
+        warnings.warn(
+            "The 'vdims' attribute is deprecated and will be removed in a future release. "
+            "Use 'Triangle.columns' instead.",
+            FutureWarning,
+            stacklevel=2,
+        )
+        if type(value) is str:
+            value = np.array([value])
+        elif type(value) is list:
+            value = np.array(value)
+        self._vdims = value
 
     @property
     def columns_label(self) -> list:
@@ -2301,10 +2326,10 @@ class Triangle(TriangleBase):
             return self.sort_index()
         obj = self.copy()
         if axis == 1:
-            sort = pd.Series(self.vdims).sort_values().index
-            if np.any(sort != pd.Series(self.vdims).index):
+            sort = pd.Series(self._vdims).sort_values().index
+            if np.any(sort != pd.Series(self._vdims).index):
                 obj.values = obj.values[:, list(sort), ...]
-                obj.vdims = obj.vdims[list(sort)]
+                obj._vdims = obj._vdims[list(sort)]
         if axis == 2:
             sort = pd.Series(self.odims).sort_values().index
             if np.any(sort != pd.Series(self.odims).index):

--- a/chainladder/core/triangle.py
+++ b/chainladder/core/triangle.py
@@ -558,7 +558,7 @@ class Triangle(TriangleBase):
             self.index_label: list = index
             data_agg[index[0]] = "Total"
 
-        self.kdims: np.ndarray
+        self._kdims: np.ndarray
         key_idx: np.ndarray
         self._vdims: np.ndarray
         self.odims: np.ndarray
@@ -566,7 +566,7 @@ class Triangle(TriangleBase):
         self.ddims: ArrayLike
         dev_idx: np.ndarray
 
-        self.kdims, key_idx = self._set_kdims(data_agg, index)
+        self._kdims, key_idx = self._set_kdims(data_agg, index)
         self._vdims = np.array(columns)
         self.odims, orig_idx = self._set_odims(data_agg, date_axes)
         self.ddims, dev_idx = self._set_ddims(data_agg, date_axes)
@@ -651,7 +651,7 @@ class Triangle(TriangleBase):
                     has_duplicates=False,
                     sorted=True,
                     shape=(
-                        len(self.kdims),
+                        len(self._kdims),
                         len(self._vdims),
                         len(self.odims),
                         len(self.ddims),
@@ -724,17 +724,41 @@ class Triangle(TriangleBase):
         """
         Returns a DataFrame of the unique values of the index.
         """
-        return pd.DataFrame(list(self.kdims), columns=self.key_labels)
+        return pd.DataFrame(list(self._kdims), columns=self.key_labels)
 
     @index.setter
     def index(self, value) -> None:
         self._len_check(self.index, value)
         if type(value) is pd.DataFrame:
-            self.kdims = value.values
+            self._kdims = value.values
             self.key_labels = list(value.columns)
             self._set_slicers()
         else:
             raise TypeError("index must be a pandas DataFrame")
+
+    @property
+    def kdims(self):
+        warnings.warn(
+            "The 'kdims' attribute is deprecated and will be removed in a future release. "
+            "Use 'Triangle.index' or 'Triangle.key_labels' instead.",
+            FutureWarning,
+            stacklevel=2,
+        )
+        return self._kdims
+
+    @kdims.setter
+    def kdims(self, value):
+        warnings.warn(
+            "The 'kdims' attribute is deprecated and will be removed in a future release. "
+            "Use 'Triangle.index' or 'Triangle.key_labels' instead.",
+            FutureWarning,
+            stacklevel=2,
+        )
+        if type(value) is str:
+            value = np.array([[value]])
+        elif type(value) is list:
+            value = np.array(value)
+        self._kdims = value
 
     @property
     def columns(self):

--- a/chainladder/core/triangle.py
+++ b/chainladder/core/triangle.py
@@ -558,23 +558,24 @@ class Triangle(TriangleBase):
             self.index_label: list = index
             data_agg[index[0]] = "Total"
 
-        self._kdims: np.ndarray
+        self._index: DataFrame
         key_idx: np.ndarray
-        self._vdims: np.ndarray
+        self._columns: pd.Index
         self.odims: np.ndarray
         orig_idx: np.ndarray
         self.ddims: ArrayLike
         dev_idx: np.ndarray
 
-        self._kdims, key_idx = self._set_kdims(data_agg, index)
-        self._vdims = np.array(columns)
+        self.key_labels: list = index
+        kdims_arr, key_idx = self._set_kdims(data_agg, index)
+        self._index = pd.DataFrame(list(kdims_arr), columns=self.key_labels)
+        self._columns = pd.Index(columns, name="columns")
         self.odims, orig_idx = self._set_odims(data_agg, date_axes)
         self.ddims, dev_idx = self._set_ddims(data_agg, date_axes)
 
         # Set remaining triangle properties.
         val_date: Timestamp = data_agg["__development__"].max()
         val_date = val_date.compute() if hasattr(val_date, "compute") else val_date
-        self.key_labels: list = index
         self.valuation_date: Timestamp = val_date
 
         if cumulative is None:
@@ -651,8 +652,8 @@ class Triangle(TriangleBase):
                     has_duplicates=False,
                     sorted=True,
                     shape=(
-                        len(self._kdims),
-                        len(self._vdims),
+                        len(self._index),
+                        len(self._columns),
                         len(self.odims),
                         len(self.ddims),
                     ),
@@ -724,13 +725,13 @@ class Triangle(TriangleBase):
         """
         Returns a DataFrame of the unique values of the index.
         """
-        return pd.DataFrame(list(self._kdims), columns=self.key_labels)
+        return self._index
 
     @index.setter
     def index(self, value) -> None:
         self._len_check(self.index, value)
-        if type(value) is pd.DataFrame:
-            self._kdims = value.values
+        if isinstance(value, pd.DataFrame):
+            self._index = value
             self.key_labels = list(value.columns)
             self._set_slicers()
         else:
@@ -744,7 +745,7 @@ class Triangle(TriangleBase):
             FutureWarning,
             stacklevel=2,
         )
-        return self._kdims
+        return self.index.values
 
     @kdims.setter
     def kdims(self, value):
@@ -754,23 +755,25 @@ class Triangle(TriangleBase):
             FutureWarning,
             stacklevel=2,
         )
-        if type(value) is str:
+        if isinstance(value, str):
             value = np.array([[value]])
-        elif type(value) is list:
+        elif isinstance(value, list):
             value = np.array(value)
-        self._kdims = value
+        elif not isinstance(value, np.ndarray):
+            value = np.array(value)
+        self._index = pd.DataFrame(value, columns=self.key_labels)
+        self._set_slicers()
 
     @property
-    def columns(self):
-        return pd.Index(self._vdims, name="columns")
+    def columns(self) -> pd.Index:
+        return self._columns
 
     @columns.setter
     def columns(self, value):
         self._len_check(self.columns, value)
-        vdims = [value] if type(value) is str else value
-        if type(vdims) is list:
-            vdims = np.array(vdims)
-        self._vdims = vdims
+        if isinstance(value, str):
+            value = [value]
+        self._columns = pd.Index(value, name="columns")
         self._set_slicers()
 
     @property
@@ -781,7 +784,7 @@ class Triangle(TriangleBase):
             FutureWarning,
             stacklevel=2,
         )
-        return self._vdims
+        return self.columns.values
 
     @vdims.setter
     def vdims(self, value):
@@ -791,11 +794,9 @@ class Triangle(TriangleBase):
             FutureWarning,
             stacklevel=2,
         )
-        if type(value) is str:
-            value = np.array([value])
-        elif type(value) is list:
-            value = np.array(value)
-        self._vdims = value
+        if isinstance(value, str):
+            value = [value]
+        self.columns = value
 
     @property
     def columns_label(self) -> list:
@@ -2079,11 +2080,20 @@ class Triangle(TriangleBase):
         return X
 
     def __setstate__(self, state: dict) -> None:
-        """Migrate legacy pickled instances with 'kdims'/'vdims' to '_kdims'/'_vdims'."""
-        if "kdims" in state and "_kdims" not in state:
-            state["_kdims"] = state.pop("kdims")
-        if "vdims" in state and "_vdims" not in state:
-            state["_vdims"] = state.pop("vdims")
+        """Migrate legacy pickled instances with 'kdims'/'_kdims' to '_index' and 'vdims'/'_vdims' to '_columns'."""
+        key_labels = state.get("key_labels", ["Total"])
+        if "_index" not in state:
+            raw_kdims = state.pop("_kdims", None)
+            if raw_kdims is None:
+                raw_kdims = state.pop("kdims", None)
+            if raw_kdims is not None:
+                state["_index"] = pd.DataFrame(list(raw_kdims), columns=key_labels)
+        if "_columns" not in state:
+            raw_vdims = state.pop("_vdims", None)
+            if raw_vdims is None:
+                raw_vdims = state.pop("vdims", None)
+            if raw_vdims is not None:
+                state["_columns"] = pd.Index(raw_vdims, name="columns")
         self.__dict__.update(state)
 
     def development_correlation(self, p_critical=0.5):
@@ -2358,10 +2368,10 @@ class Triangle(TriangleBase):
             return self.sort_index()
         obj = self.copy()
         if axis == 1:
-            sort = pd.Series(self._vdims).sort_values().index
-            if np.any(sort != pd.Series(self._vdims).index):
+            sort = pd.Series(self.columns).sort_values().index
+            if np.any(sort != pd.Series(self.columns).index):
                 obj.values = obj.values[:, list(sort), ...]
-                obj._vdims = obj._vdims[list(sort)]
+                obj.columns = self.columns[list(sort)]
         if axis == 2:
             sort = pd.Series(self.odims).sort_values().index
             if np.any(sort != pd.Series(self.odims).index):

--- a/chainladder/core/triangle.py
+++ b/chainladder/core/triangle.py
@@ -566,9 +566,8 @@ class Triangle(TriangleBase):
         self.ddims: ArrayLike
         dev_idx: np.ndarray
 
-        self.key_labels: list = index
         kdims_arr, key_idx = self._set_kdims(data_agg, index)
-        self._index = pd.DataFrame(list(kdims_arr), columns=self.key_labels)
+        self._index = pd.DataFrame(list(kdims_arr), columns=index)
         self._columns = pd.Index(columns, name="columns")
         self.odims, orig_idx = self._set_odims(data_agg, date_axes)
         self.ddims, dev_idx = self._set_ddims(data_agg, date_axes)
@@ -732,10 +731,25 @@ class Triangle(TriangleBase):
         self._len_check(self.index, value)
         if isinstance(value, pd.DataFrame):
             self._index = value.copy().reset_index(drop=True)
-            self.key_labels = list(value.columns)
             self._set_slicers()
         else:
             raise TypeError("index must be a pandas DataFrame")
+
+    @property
+    def key_labels(self) -> list:
+        """
+        Returns a list of the labels corresponding to the levels of the index.
+        """
+        return list(self._index.columns)
+
+    @key_labels.setter
+    def key_labels(self, value) -> None:
+        if isinstance(value, str):
+            value = [value]
+        else:
+            value = list(value)
+        self._index.columns = value
+        self._set_slicers()
 
     @property
     def kdims(self):
@@ -761,9 +775,17 @@ class Triangle(TriangleBase):
             value = np.array(value)
         elif not isinstance(value, np.ndarray):
             value = np.array(value)
-        self._index = pd.DataFrame(value, columns=self.key_labels).reset_index(
-            drop=True
-        )
+        if value.ndim == 1:
+            value = value.reshape(-1, 1)
+
+        n_cols = value.shape[1] if value.ndim > 1 else 1
+        if len(self._index.columns) == n_cols:
+            cols = list(self._index.columns)
+        elif n_cols == 1:
+            cols = ["Total"]
+        else:
+            cols = [f"key_{i}" for i in range(n_cols)]
+        self._index = pd.DataFrame(value, columns=cols).reset_index(drop=True)
         self._set_slicers()
 
     @property
@@ -2085,7 +2107,7 @@ class Triangle(TriangleBase):
 
     def __setstate__(self, state: dict) -> None:
         """Migrate legacy pickled instances with 'kdims'/'_kdims' to '_index' and 'vdims'/'_vdims' to '_columns'."""
-        key_labels = state.get("key_labels", ["Total"])
+        key_labels = state.pop("key_labels", ["Total"])
         if "_index" not in state:
             raw_kdims = state.pop("_kdims", None)
             if raw_kdims is None:

--- a/chainladder/core/triangle.py
+++ b/chainladder/core/triangle.py
@@ -731,7 +731,7 @@ class Triangle(TriangleBase):
     def index(self, value) -> None:
         self._len_check(self.index, value)
         if isinstance(value, pd.DataFrame):
-            self._index = value
+            self._index = value.copy().reset_index(drop=True)
             self.key_labels = list(value.columns)
             self._set_slicers()
         else:
@@ -761,7 +761,9 @@ class Triangle(TriangleBase):
             value = np.array(value)
         elif not isinstance(value, np.ndarray):
             value = np.array(value)
-        self._index = pd.DataFrame(value, columns=self.key_labels)
+        self._index = pd.DataFrame(value, columns=self.key_labels).reset_index(
+            drop=True
+        )
         self._set_slicers()
 
     @property
@@ -2077,6 +2079,8 @@ class Triangle(TriangleBase):
         X.__dict__.update(vars(self))
         X._set_slicers()
         X.values = X.values.copy()
+        X._index = self._index.copy()
+        X._columns = self._columns.copy()
         return X
 
     def __setstate__(self, state: dict) -> None:

--- a/chainladder/core/triangle.py
+++ b/chainladder/core/triangle.py
@@ -794,9 +794,9 @@ class Triangle(TriangleBase):
 
     @columns.setter
     def columns(self, value):
-        self._len_check(self.columns, value)
         if isinstance(value, str):
             value = [value]
+        self._len_check(self.columns, value)
         self._columns = pd.Index(value, name="columns")
         self._set_slicers()
 
@@ -2114,12 +2114,16 @@ class Triangle(TriangleBase):
                 raw_kdims = state.pop("kdims", None)
             if raw_kdims is not None:
                 state["_index"] = pd.DataFrame(list(raw_kdims), columns=key_labels)
+            else:
+                state["_index"] = pd.DataFrame([["Total"]], columns=["Total"])
         if "_columns" not in state:
             raw_vdims = state.pop("_vdims", None)
             if raw_vdims is None:
                 raw_vdims = state.pop("vdims", None)
             if raw_vdims is not None:
                 state["_columns"] = pd.Index(raw_vdims, name="columns")
+            else:
+                state["_columns"] = pd.Index(["values"], name="columns")
         self.__dict__.update(state)
 
     def development_correlation(self, p_critical=0.5):

--- a/chainladder/development/clark.py
+++ b/chainladder/development/clark.py
@@ -326,10 +326,10 @@ class ClarkLDF(DevelopmentBase):
         self.ldf_ = obj
         self.ldf_.valuation_date = pd.to_datetime(options.ULT_VAL)
         rows = X.index.set_index(X.key_labels).index
-        self.omega_ = pd.DataFrame(params[..., 0, 0], index=rows, columns=X.vdims)
-        self.theta_ = pd.DataFrame(params[..., 0, 1], index=rows, columns=X.vdims)
+        self.omega_ = pd.DataFrame(params[..., 0, 0], index=rows, columns=X.columns)
+        self.theta_ = pd.DataFrame(params[..., 0, 1], index=rows, columns=X.columns)
         if sample_weight:
-            self.elr_ = pd.DataFrame(params[..., 0, 2], index=rows, columns=X.vdims)
+            self.elr_ = pd.DataFrame(params[..., 0, 2], index=rows, columns=X.columns)
         ultimate_ = (
             self._G(age=(latest_age - age_offset)[::-1]).swapaxes(-1, -2) * ld.values
         )

--- a/chainladder/development/clark.py
+++ b/chainladder/development/clark.py
@@ -326,10 +326,16 @@ class ClarkLDF(DevelopmentBase):
         self.ldf_ = obj
         self.ldf_.valuation_date = pd.to_datetime(options.ULT_VAL)
         rows = X.index.set_index(X.key_labels).index
-        self.omega_ = pd.DataFrame(params[..., 0, 0], index=rows, columns=X.columns)
-        self.theta_ = pd.DataFrame(params[..., 0, 1], index=rows, columns=X.columns)
+        self.omega_ = pd.DataFrame(
+            params[..., 0, 0], index=rows, columns=X.columns_label
+        )
+        self.theta_ = pd.DataFrame(
+            params[..., 0, 1], index=rows, columns=X.columns_label
+        )
         if sample_weight:
-            self.elr_ = pd.DataFrame(params[..., 0, 2], index=rows, columns=X.columns)
+            self.elr_ = pd.DataFrame(
+                params[..., 0, 2], index=rows, columns=X.columns_label
+            )
         ultimate_ = (
             self._G(age=(latest_age - age_offset)[::-1]).swapaxes(-1, -2) * ld.values
         )

--- a/chainladder/development/munich.py
+++ b/chainladder/development/munich.py
@@ -360,11 +360,11 @@ class MunichAdjustment(DevelopmentBase):
         cdf_triangle = cdf_triangle[..., -1:] / cdf_triangle[..., :-1]
         paid = [item[0] for item in p_to_i]
         for n, item in enumerate(paid):
-            idx = np.where(X.cdf_.vdims == item)[0][0]
+            idx = np.where(X.cdf_.columns == item)[0][0]
             obj.values[:, idx : idx + 1, ...] = cdf_triangle[0, :, n : n + 1, ...]
         incurred = [item[1] for item in p_to_i]
         for n, item in enumerate(incurred):
-            idx = np.where(X.cdf_.vdims == item)[0][0]
+            idx = np.where(X.cdf_.columns == item)[0][0]
             obj.values[:, idx : idx + 1, ...] = cdf_triangle[1, :, n : n + 1, ...]
         obj._set_slicers()
         return obj

--- a/chainladder/methods/benktander.py
+++ b/chainladder/methods/benktander.py
@@ -268,8 +268,9 @@ class Benktander(MethodBase):
             apriori = random_state.lognormal(mu_log, sigma_log, X.shape[0])
             apriori = apriori.reshape(X.shape[0], -1)[..., None, None]
             apriori = sample_weight * apriori
-            apriori.kdims = X.kdims
+            apriori._kdims = X._kdims
             apriori.key_labels = X.key_labels
+            apriori._set_slicers()
         else:
             apriori = sample_weight * self.apriori
         apriori.columns = sample_weight.columns

--- a/chainladder/methods/benktander.py
+++ b/chainladder/methods/benktander.py
@@ -268,8 +268,8 @@ class Benktander(MethodBase):
             apriori = random_state.lognormal(mu_log, sigma_log, X.shape[0])
             apriori = apriori.reshape(X.shape[0], -1)[..., None, None]
             apriori = sample_weight * apriori
-            apriori._kdims = X._kdims
-            apriori.key_labels = X.key_labels
+            apriori._index = X.index.copy()
+            apriori.key_labels = list(X.key_labels)
             apriori._set_slicers()
         else:
             apriori = sample_weight * self.apriori

--- a/chainladder/tails/bondy.py
+++ b/chainladder/tails/bondy.py
@@ -190,9 +190,9 @@ class TailBondy(TailBase):
         )
         fitted = xp.repeat(fitted, self.ldf_.shape[2], axis=2)
         rows = X.index.set_index(X.key_labels).index
-        self.b_ = pd.DataFrame(self.b_[..., 0, 0], index=rows, columns=X.columns)
+        self.b_ = pd.DataFrame(self.b_[..., 0, 0], index=rows, columns=X.columns_label)
         self.earliest_ldf_ = pd.DataFrame(
-            self.earliest_ldf_[..., 0, 0], index=rows, columns=X.columns
+            self.earliest_ldf_[..., 0, 0], index=rows, columns=X.columns_label
         )
         self.ldf_.values = xp.concatenate(
             (

--- a/chainladder/tails/bondy.py
+++ b/chainladder/tails/bondy.py
@@ -159,7 +159,7 @@ class TailBondy(TailBase):
         obj = Development().fit_transform(X) if "ldf_" not in X else X
         b_optimized = []
         initial = xp.where(obj.ddims == earliest_age)[0][0] if earliest_age else 0
-        for num in range(len(obj.vdims)):
+        for num in range(len(obj.columns)):
             b0 = (xp.ones(obj.shape[0]) * 0.5)[:, None]
             data = xp.log(obj.ldf_.values[:, num, 0, initial:])
             b0 = xp.concatenate((b0, data[..., 0:1]), axis=1)
@@ -190,9 +190,9 @@ class TailBondy(TailBase):
         )
         fitted = xp.repeat(fitted, self.ldf_.shape[2], axis=2)
         rows = X.index.set_index(X.key_labels).index
-        self.b_ = pd.DataFrame(self.b_[..., 0, 0], index=rows, columns=X.vdims)
+        self.b_ = pd.DataFrame(self.b_[..., 0, 0], index=rows, columns=X.columns)
         self.earliest_ldf_ = pd.DataFrame(
-            self.earliest_ldf_[..., 0, 0], index=rows, columns=X.vdims
+            self.earliest_ldf_[..., 0, 0], index=rows, columns=X.columns
         )
         self.ldf_.values = xp.concatenate(
             (

--- a/chainladder/tails/curve.py
+++ b/chainladder/tails/curve.py
@@ -287,7 +287,7 @@ class TailCurve(TailBase):
         """Does not work with munich"""
         rows = self.ldf_.index.set_index(self.ldf_.key_labels).index
         return pd.DataFrame(
-            self._slope_[..., 0, 0], index=rows, columns=self.ldf_.columns
+            self._slope_[..., 0, 0], index=rows, columns=self.ldf_.columns_label
         )
 
     @property
@@ -295,5 +295,5 @@ class TailCurve(TailBase):
         """Does not work with munich"""
         rows = self.ldf_.index.set_index(self.ldf_.key_labels).index
         return pd.DataFrame(
-            self._intercept_[..., 0, 0], index=rows, columns=self.ldf_.columns
+            self._intercept_[..., 0, 0], index=rows, columns=self.ldf_.columns_label
         )

--- a/chainladder/tails/curve.py
+++ b/chainladder/tails/curve.py
@@ -288,7 +288,7 @@ class TailCurve(TailBase):
         """Does not work with munich"""
         rows = self.ldf_.index.set_index(self.ldf_.key_labels).index
         return pd.DataFrame(
-            self._slope_[..., 0, 0], index=rows, columns=self.ldf_.vdims
+            self._slope_[..., 0, 0], index=rows, columns=self.ldf_.columns
         )
 
     @property
@@ -296,5 +296,5 @@ class TailCurve(TailBase):
         """Does not work with munich"""
         rows = self.ldf_.index.set_index(self.ldf_.key_labels).index
         return pd.DataFrame(
-            self._intercept_[..., 0, 0], index=rows, columns=self.ldf_.vdims
+            self._intercept_[..., 0, 0], index=rows, columns=self.ldf_.columns
         )

--- a/chainladder/tails/curve.py
+++ b/chainladder/tails/curve.py
@@ -172,7 +172,6 @@ class TailCurve(TailBase):
         self : object
             Returns the instance itself.
         """
-
         X = X.copy()
         xp = X.get_array_module()
         if type(self.fit_period) is slice:

--- a/chainladder/utils/tests/test_utilities.py
+++ b/chainladder/utils/tests/test_utilities.py
@@ -60,7 +60,7 @@ def test_triangle_json_io(clrd):
     clrd2 = cl.read_json(clrd.to_json(), array_backend=clrd.array_backend)
     assert clrd == clrd2
     assert np.all(clrd.kdims == clrd2.kdims)
-    assert np.all(clrd.vdims == clrd2.vdims)
+    assert np.all(clrd.columns == clrd2.columns)
     assert np.all(clrd.odims == clrd2.odims)
     assert np.all(clrd.ddims == clrd2.ddims)
     assert np.all(clrd.valuation == clrd2.valuation)
@@ -376,7 +376,7 @@ def test_load_sample_uspp() -> None:
         "friedland_uspp_increasing_claim_case",
     ]:
         tri = cl.load_sample(key)
-        assert set(str(c) for c in tri.vdims) == {
+        assert set(str(c) for c in tri.columns) == {
             "Reported Claims",
             "Paid Claims",
             "Earned Premium",
@@ -402,7 +402,7 @@ def test_load_sample_clrd2025() -> None:
         "EarnedPremCeded",
         "EarnedPremNet",
     }
-    assert set(str(c) for c in tri.vdims) == expected_columns
+    assert set(str(c) for c in tri.columns) == expected_columns
 
     # Accident years span 1998-2007.
     assert str(tri.origin.min()) == "1998"

--- a/chainladder/utils/tests/test_utilities.py
+++ b/chainladder/utils/tests/test_utilities.py
@@ -59,7 +59,7 @@ class _FakeDaskBag:
 def test_triangle_json_io(clrd):
     clrd2 = cl.read_json(clrd.to_json(), array_backend=clrd.array_backend)
     assert clrd == clrd2
-    assert np.all(clrd.kdims == clrd2.kdims)
+    assert clrd.index.equals(clrd2.index)
     assert np.all(clrd.columns == clrd2.columns)
     assert np.all(clrd.odims == clrd2.odims)
     assert np.all(clrd.ddims == clrd2.ddims)

--- a/chainladder/utils/tests/test_utilities.py
+++ b/chainladder/utils/tests/test_utilities.py
@@ -618,6 +618,24 @@ def test_concat_axis1_duplicate_columns(raa: Triangle) -> None:
         cl.concat([raa, raa], axis=1)
 
 
+def test_concat_ignore_index_axes(raa: Triangle) -> None:
+    """Test concat with ignore_index=True along axes 1, 2, and 3."""
+    t1 = copy.deepcopy(raa).rename("columns", ["A"])
+    t2 = copy.deepcopy(raa).rename("columns", ["B"])
+    res1 = cl.concat([t1, t2], axis=1, ignore_index=True)
+    assert list(res1.columns) == [0, 1]
+
+    o1 = raa.iloc[:, :, :5, :]
+    o2 = raa.iloc[:, :, 5:, :]
+    res2 = cl.concat([o1, o2], axis=2, ignore_index=True)
+    assert len(res2.odims) == len(raa.odims)
+
+    d1 = raa.iloc[:, :, :, :5]
+    d2 = raa.iloc[:, :, :, 5:]
+    res3 = cl.concat([d1, d2], axis=3, ignore_index=True)
+    assert len(res3.ddims) == len(raa.ddims)
+
+
 def test_maximum_2(raa: Triangle) -> None:
     """
     Run cl.maximum(raa, 5000) and check if each element in the resulting triangle is at least 5000.

--- a/chainladder/utils/utility_functions.py
+++ b/chainladder/utils/utility_functions.py
@@ -681,7 +681,7 @@ def concat(
             if list(objs[num].columns) != all_columns:
                 objs[num] = objs[num][all_columns]
     objs = set_common_backend(objs)
-    mapper = {0: "kdims", 1: "_vdims", 2: "odims", 3: "ddims"}
+    mapper = {0: "_kdims", 1: "_vdims", 2: "odims", 3: "ddims"}
     for k in mapper.keys():
         if k != axis and k != 1:  # All non-concat axes must be identical
             a = np.array([getattr(obj, mapper[k]) for obj in objs])

--- a/chainladder/utils/utility_functions.py
+++ b/chainladder/utils/utility_functions.py
@@ -681,7 +681,7 @@ def concat(
             if list(objs[num].columns) != all_columns:
                 objs[num] = objs[num][all_columns]
     objs = set_common_backend(objs)
-    mapper = {0: "kdims", 1: "vdims", 2: "odims", 3: "ddims"}
+    mapper = {0: "kdims", 1: "_vdims", 2: "odims", 3: "ddims"}
     for k in mapper.keys():
         if k != axis and k != 1:  # All non-concat axes must be identical
             a = np.array([getattr(obj, mapper[k]) for obj in objs])

--- a/chainladder/utils/utility_functions.py
+++ b/chainladder/utils/utility_functions.py
@@ -681,31 +681,58 @@ def concat(
             if list(objs[num].columns) != all_columns:
                 objs[num] = objs[num][all_columns]
     objs = set_common_backend(objs)
-    mapper = {0: "_kdims", 1: "_vdims", 2: "odims", 3: "ddims"}
-    for k in mapper.keys():
-        if k != axis and k != 1:  # All non-concat axes must be identical
-            a = np.array([getattr(obj, mapper[k]) for obj in objs])
-            assert np.all(a == a[0])
-        else:  # All elements of concat axis must be unique
-            if ignore_index:
-                new_axis = np.arange(
-                    np.sum([len(getattr(obj, mapper[axis])) for obj in objs])
-                )
-                new_axis = new_axis[:, None] if axis == 0 else new_axis
-            else:
-                new_axis = np.concatenate([getattr(obj, mapper[axis]) for obj in objs])
-            if axis == 0:
-                assert len(pd.DataFrame(new_axis).drop_duplicates()) == len(new_axis)
-            else:
-                assert len(new_axis) == len(set(new_axis))
+    if axis != 0:
+        for obj in objs[1:]:
+            assert obj.index.equals(objs[0].index)
+    if axis != 2:
+        a = np.array([obj.odims for obj in objs])
+        assert np.all(a == a[0])
+    if axis != 3:
+        a = np.array([obj.ddims for obj in objs])
+        assert np.all(a == a[0])
+
     out = copy.deepcopy(objs[0])
     out.values = xp.concatenate([obj.values for obj in objs], axis=axis)
-    setattr(out, mapper[axis], new_axis)
-    if ignore_index and axis == 0:
-        out.key_labels = ["Index"]
+
+    if axis == 0:
+        if ignore_index:
+            new_axis = np.arange(sum([len(obj.index) for obj in objs]))[:, None]
+            out._index = pd.DataFrame(new_axis, columns=["Index"])
+            out.key_labels = ["Index"]
+        else:
+            new_axis = pd.concat([obj.index for obj in objs], ignore_index=True)
+            assert len(new_axis.drop_duplicates()) == len(new_axis)
+            out._index = new_axis
+            out.key_labels = list(new_axis.columns)
+    elif axis == 1:
+        if ignore_index:
+            new_axis = pd.Index(
+                np.arange(sum([len(obj.columns) for obj in objs])), name="columns"
+            )
+        else:
+            new_axis = pd.Index(
+                np.concatenate([obj.columns for obj in objs]), name="columns"
+            )
+            assert len(new_axis) == len(set(new_axis))
+        out._columns = new_axis
+    elif axis == 2:
+        if ignore_index:
+            new_axis = np.arange(sum([len(obj.odims) for obj in objs]))
+        else:
+            new_axis = np.concatenate([obj.odims for obj in objs])
+            assert len(new_axis) == len(set(new_axis))
+        out.odims = new_axis
+    elif axis == 3:
+        if ignore_index:
+            new_axis = np.arange(sum([len(obj.ddims) for obj in objs]))
+        else:
+            new_axis = np.concatenate([obj.ddims for obj in objs])
+            assert len(new_axis) == len(set(new_axis))
+        out.ddims = new_axis
+        if out.ddims.dtype == __dt64_dtype__ and type(out.ddims) is np.ndarray:
+            out.ddims = pd.DatetimeIndex(out.ddims)
+
     out.valuation_date = pd.Series([obj.valuation_date for obj in objs]).max()
-    if out.ddims.dtype == __dt64_dtype__ and type(out.ddims) is np.ndarray:
-        out.ddims = pd.DatetimeIndex(out.ddims)
     out._set_slicers()
     if sort:
         return out.sort_axis(axis)

--- a/chainladder/utils/utility_functions.py
+++ b/chainladder/utils/utility_functions.py
@@ -409,10 +409,14 @@ def read_json(json_str, array_backend=None):
                 setattr(getattr(tri, k), "development_grain", tri.development_grain)
         if "dfs" in json_dict.keys():
             for k, v in json_dict["dfs"].items():
+                if k == "_index":
+                    continue
                 df = pd.read_json(StringIO(v))
                 if len(df.columns) == 1:
                     df = df.iloc[:, 0]
                 setattr(tri, k, df)
+        if isinstance(tri._index, pd.Series):
+            tri._index = tri._index.to_frame()
         if array_backend:
             return tri.set_backend(array_backend)
         else:


### PR DESCRIPTION
## Summary of Changes
- Deprecate vdims (#1011) and kdims (#1010) on Triangle with FutureWarnings pointing to columns/columns_label and index/key_labels
- Update internal usage across core modules, estimators, adjustments, and tails to prevent internal warnings
- Add test coverage verifying deprecation warnings when reading or setting both attributes
- Address ruff lint and formatting after rebasing on main (added noqa: N802 on Clark and Munich formulas to preserve actuarial notation)

## Related GitHub Issue(s)
Closes #1010, closes #1011, refs #601, refs #1216

## Additional Context for Reviewers
Existing code reading or setting vdims and kdims continues to work as expected for backward compatibility. Date dimensions (odims and ddims) will follow in a separate PR.

<!-- Do not edit anything below this. -->

## Checklist
- [x] I passed tests locally for both code (`uv run pytest`) and documentation changes (`uv run --directory docs jb build . --builder=custom --custom-builder=doctest`)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> This is a broad refactor of Triangle’s dimension metadata and alignment paths; regressions could affect slicing, arithmetic, concat, and serialized objects even with migration logic.
> 
> **Overview**
> Replaces internal **`kdims` / `vdims` numpy labels** with a pandas-aligned model: row keys live in **`_index`** (`Triangle.index` as a `DataFrame`), value columns in **`_axes["columns"]`** via a new **`TriangleAxis`** descriptor, plus **`key_labels`** as index column names and an **`axes`** property.
> 
> **Indexing, arithmetic, slicing, groupby, concat, and I/O** are updated to use `index` / `columns` (e.g. broadcast/align on `DataFrame.index`, column assignment through the descriptor, JSON/pickle skipping or migrating `_index`). **`concat`** gains clearer **`ignore_index`** handling on columns, origin, and development; **`sort_index(inplace=True)`** and **boolean `Series`** row selection are supported.
> 
> Downstream code (bootstrap resampling, correlation tables, Benktander, tails, etc.) assigns **`index`** / **`columns`** instead of mutating `kdims`/`vdims`. **`__setstate__`** migrates old pickles; tests cover columns/index setters, copy isolation, JSON roundtrip, and legacy unpickling.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b17787be48fdb5bd9cb39a3b741593a043eb5a8a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->