### PR TITLE
Feature/deprecate date dims

### DIFF
--- a/chainladder/adjustments/bootstrap.py
+++ b/chainladder/adjustments/bootstrap.py
@@ -190,7 +190,7 @@ class BootstrapODPSample(DevelopmentBase):
             xp = X.get_array_module()
             if len(X) != 1:
                 raise ValueError("Only single index triangles are supported")
-            if type(X.ddims) is not np.ndarray:
+            if type(X._ddims) is not np.ndarray:
                 raise ValueError("Triangle must be expressed with development lags")
             obj = Development(
                 n_periods=self.n_periods,

--- a/chainladder/core/base.py
+++ b/chainladder/core/base.py
@@ -684,12 +684,12 @@ class TriangleBase(
 
     @property
     def valuation(self):
-        ddims = self.ddims
+        ddims = self._ddims
         if self.is_val_tri:
-            out = pd.DataFrame(np.repeat(self.ddims.values[None], len(self.odims), 0))
+            out = pd.DataFrame(np.repeat(self._ddims.values[None], len(self._odims), 0))
             return pd.DatetimeIndex(out.unstack().values)
         ddim_arr = ddims - ddims[0]
-        origin = np.minimum(self.odims, np.datetime64(self.valuation_date))
+        origin = np.minimum(self._odims, np.datetime64(self.valuation_date))
         val_array = origin.astype("datetime64[M]") + np.timedelta64(ddims[0], "M")
         val_array = val_array.astype(__dt64_dtype__) - np.timedelta64(1, __dt64_unit__)
         val_array = val_array[:, None]

--- a/chainladder/core/common.py
+++ b/chainladder/core/common.py
@@ -54,10 +54,11 @@ def _get_full_triangle(X, ultimate, is_cumulative=True):
     emergence.values = emergence.values.cumprod(axis=3) - 1
 
     # Shifting the CDFs by development age, and renaming the last column as 9999
-    emergence.ddims = (
-        emergence.ddims + {"Y": 12, "Q": 3, "S": 6, "M": 1}[emergence.development_grain]
+    emergence._ddims = (
+        emergence._ddims
+        + {"Y": 12, "Q": 3, "S": 6, "M": 1}[emergence.development_grain]
     )
-    emergence.ddims[-1] = 9999
+    emergence._ddims[-1] = 9999
     emergence.values = emergence.values / num_to_nan(emergence.values[..., -1:])
     ld = X.incr_to_cum().latest_diagonal
     cum_run_off = ld + emergence * (ultimate - ld)

--- a/chainladder/core/correlation.py
+++ b/chainladder/core/correlation.py
@@ -138,7 +138,7 @@ class DevelopmentCorrelation:
 
         # remove last column because it was not part of the comparison with m2
         numerator.values = numerator.values[..., :-1]
-        numerator.ddims = numerator.ddims[:-1]
+        numerator._ddims = numerator._ddims[:-1]
 
         # n_dev_periods is the number of development periods in the triangle ("I" in the Mack 97).
         n_dev_periods = len(triangle.development)
@@ -329,7 +329,7 @@ class ValuationCorrelation:
             #     "origin") * 0
             z_critical = z_critical.dev_to_val().dropna().sum("origin") * 0
             z_critical.values = np.array(self.probs) < p_critical
-            z_critical.odims = triangle.odims[0:1]
+            z_critical._odims = triangle._odims[0:1]
             self.z_critical = z_critical
             self.z = self.z_critical.copy()
             self.z.values = z

--- a/chainladder/core/dunders.py
+++ b/chainladder/core/dunders.py
@@ -161,36 +161,36 @@ class TriangleDunders:
             (m == n) or (m == 1) or (n == 1)
             for m, n in zip(obj.shape[-2:][::-1], other.shape[-2:][::-1])
         )
-        if (len(obj.odims), len(obj.ddims)) == (len(other.odims), len(other.ddims)):
-            if np.all(obj.ddims != other.ddims) and len(obj.ddims) > 1:
+        if (len(obj._odims), len(obj._ddims)) == (len(other._odims), len(other._ddims)):
+            if np.all(obj._ddims != other._ddims) and len(obj._ddims) > 1:
                 is_broadcastable = False
-            if np.all(obj.odims != other.odims) and len(obj.odims) > 1:
+            if np.all(obj._odims != other._odims) and len(obj._odims) > 1:
                 is_broadcastable = False
-        if len(other.odims) == 1 and len(obj.odims) > 1:
-            other.odims = obj.odims
+        if len(other._odims) == 1 and len(obj._odims) > 1:
+            other._odims = obj._odims
             other.origin_grain = obj.origin_grain
-        elif len(obj.odims) == 1 and len(other.odims) > 1:
-            obj.odims = other.odims
+        elif len(obj._odims) == 1 and len(other._odims) > 1:
+            obj._odims = other._odims
             obj.origin_grain = other.origin_grain
-        if len(other.ddims) == 1 and len(obj.ddims) > 1:
-            other.ddims = obj.ddims
+        if len(other._ddims) == 1 and len(obj._ddims) > 1:
+            other._ddims = obj._ddims
             other.development_grain = obj.development_grain
-        elif len(obj.ddims) == 1 and len(other.ddims) > 1:
-            obj.ddims = other.ddims
+        elif len(obj._ddims) == 1 and len(other._ddims) > 1:
+            obj._ddims = other._ddims
             obj.development_grain = other.development_grain
         if not is_broadcastable:
             # If broadcasting doesn't work, union axes similar to pandas
             ddims = pd.concat(
                 (
-                    pd.Series(obj.ddims, index=obj.ddims),
-                    pd.Series(other.ddims, index=other.ddims),
+                    pd.Series(obj._ddims, index=obj._ddims),
+                    pd.Series(other._ddims, index=other._ddims),
                 ),
                 axis=1,
             ).sort_index()
             odims = pd.concat(
                 (
-                    pd.Series(obj.odims, index=obj.odims),
-                    pd.Series(other.odims, index=other.odims),
+                    pd.Series(obj._odims, index=obj._odims),
+                    pd.Series(other._odims, index=other._odims),
                 ),
                 axis=1,
             ).sort_index()
@@ -235,11 +235,11 @@ class TriangleDunders:
                     len(ddims),
                 )
                 obj_arr.shape = (self.shape[0], self.shape[1], len(odims), len(ddims))
-            obj.odims = np.array(odims.index)
-            if isinstance(obj.ddims, pd.DatetimeIndex):
-                obj.ddims = pd.DatetimeIndex(ddims.index)
+            obj._odims = np.array(odims.index)
+            if isinstance(obj._ddims, pd.DatetimeIndex):
+                obj._ddims = pd.DatetimeIndex(ddims.index)
             else:
-                obj.ddims = np.array(ddims.index)
+                obj._ddims = np.array(ddims.index)
             obj.values = obj_arr
             other.values = other_arr
         return obj, other

--- a/chainladder/core/pandas.py
+++ b/chainladder/core/pandas.py
@@ -104,10 +104,10 @@ class TrianglePandas(_TrianglePandasBase):
             out["columns"] = obj.columns[values.coords[1]]
             missing_cols: list = list(set(self.columns) - set(out["columns"]))
             if origin_as_datetime:
-                out["origin"] = obj.odims[values.coords[2]]
+                out["origin"] = obj._odims[values.coords[2]]
             else:
                 out["origin"] = obj.origin[values.coords[2]]
-            out["development"] = obj.ddims[values.coords[3]]
+            out["development"] = obj._ddims[values.coords[3]]
             out["values"] = values.data
             out: DataFrame = pd.pivot_table(
                 out, index=obj.key_labels + ["origin", "development"], columns="columns"
@@ -119,8 +119,8 @@ class TrianglePandas(_TrianglePandasBase):
 
             valuation_series = pd.DataFrame(
                 obj.valuation.values.reshape(obj.shape[-2:], order="F"),
-                index=obj.odims if origin_as_datetime else obj.origin,
-                columns=obj.ddims,
+                index=obj._odims if origin_as_datetime else obj.origin,
+                columns=obj._ddims,
             ).unstack()
             valuation_series.name = "valuation"
             valuation: DataFrame = valuation_series.reset_index().rename(
@@ -943,7 +943,7 @@ class TrianglePandas(_TrianglePandasBase):
                 keep = self._validate_contiguous_drop(
                     result.development, ax_labels, "development", errors
                 )
-                result = result._slice(keep, "ddims")
+                result = result._slice(keep, "_ddims")
                 if result.is_val_tri:
                     result.valuation_date = min(
                         result.valuation.max(), result.valuation_date
@@ -1263,11 +1263,11 @@ def add_triangle_agg_func(cls: Type[TrianglePandas], k: str, v: str):
             )
         if axis == 1 and obj.values.shape[axis] == 1 and len(obj.columns) > 1:
             obj._columns = pd.Index([0], name="columns")
-        if axis == 2 and obj.values.shape[axis] == 1 and len(obj.odims) > 1:
-            obj.odims = obj.odims[0:1]
+        if axis == 2 and obj.values.shape[axis] == 1 and len(obj._odims) > 1:
+            obj._odims = obj._odims[0:1]
         # If axis is development, set the ddims to be the valuation date.
-        if axis == 3 and obj.values.shape[axis] == 1 and len(obj.ddims) > 1:
-            obj.ddims = pd.DatetimeIndex(
+        if axis == 3 and obj.values.shape[axis] == 1 and len(obj._ddims) > 1:
+            obj._ddims = pd.DatetimeIndex(
                 [self.valuation_date], dtype=__dt64_dtype__, freq=None
             )
         obj._set_slicers()
@@ -1335,7 +1335,7 @@ def add_groupby_agg_func(cls, k: str, v: str):
             obj.origin_grain = self.obj._get_grain(odims)
             split = obj.origin_grain.split("-")
             obj.origin_grain = {"2Q": "S"}.get(split[0], split[0])
-            obj.odims = odims.values
+            obj._odims = odims.values
         obj._set_slicers()
         if auto_sparse:
             obj = obj._auto_sparse()

--- a/chainladder/core/slice.py
+++ b/chainladder/core/slice.py
@@ -65,7 +65,7 @@ class _LocBase:
         # Set the new dimension values.
         obj._index = obj._index.iloc[i_idx].reset_index(drop=True)
         obj._columns = obj._columns[c_idx]
-        obj.odims, obj.ddims = obj.odims[o_idx], obj.ddims[d_idx]
+        obj._odims, obj._ddims = obj._odims[o_idx], obj._ddims[d_idx]
         # Set indexers.
         obj.iloc, obj.loc = Ilocation(obj), Location(obj)
         obj.valuation_date = cast(
@@ -515,14 +515,14 @@ class TriangleSlicer:
 
         # Case development axis.
         if isinstance(key, pd.Series) and key.name == "development":
-            return self._slice(key, "ddims")
+            return self._slice(key, "_ddims")
         # Case ndarray, could be valuation or origin.
         if isinstance(key, np.ndarray):
             # Case valuation, inferred by size of ndarray obtained by filtering on valuation date.
             if len(key) == np.prod(self.shape[-2:]) and self.shape[-1] > 1:
                 return self._slice_valuation(key)
             # Otherwise, assume case origin.
-            return self._slice(key, "odims")
+            return self._slice(key, "_odims")
         # Case index.
         if isinstance(key, pd.Series):
             if pd.api.types.is_bool_dtype(key):
@@ -672,7 +672,7 @@ class TriangleSlicer:
     def _slice(
         self: TriangleProtocol,
         key: pd.Series | np.ndarray,
-        axis: Literal["ddims", "odims"],
+        axis: Literal["ddims", "odims", "_ddims", "_odims"],
     ) -> Triangle:
         """
         Private method for handling of origin/development slicing.
@@ -681,16 +681,17 @@ class TriangleSlicer:
         ----------
         key: pd.Series | np.ndarray
             Array specifying the slice to extract.
-        axis: Literal['ddims', 'odims']
+        axis: Literal['ddims', 'odims', '_ddims', '_odims']
             The axis to which the slice would apply, `ddims` for development, `odims` for origin.
         """
 
         # Update the axis, then the values.
         obj = self.copy()
-        setattr(obj, axis, getattr(obj, axis)[key])
+        attr = f"_{axis}" if not axis.startswith("_") else axis
+        setattr(obj, attr, getattr(obj, attr)[key])
         # noinspection PyProtectedMember
         slicer = ..., _LocBase._contig_slice(np.arange(len(key))[key])
-        if axis == "odims":
+        if axis in ("odims", "_odims"):
             slicer = tuple(list(slicer) + [slice(None)])
         obj.values = obj.values[slicer]
         return obj

--- a/chainladder/core/tests/test_arithmetic.py
+++ b/chainladder/core/tests/test_arithmetic.py
@@ -112,7 +112,7 @@ def test_arithmetic_union_val_tri(raa: Triangle) -> None:
     a = val_raa[val_raa.valuation < "1987"]
     b = val_raa[val_raa.valuation >= "1987"]
     result = a + b
-    assert isinstance(result.ddims, pd.DatetimeIndex)
+    assert isinstance(result._ddims, pd.DatetimeIndex)
     assert result.shape == val_raa.shape
     assert result == val_raa
 

--- a/chainladder/core/tests/test_grain.py
+++ b/chainladder/core/tests/test_grain.py
@@ -91,18 +91,18 @@ def test_annual_trailing(prism):
     # (limit data to November)
     tri = tri[tri.valuation < tri.valuation_date].incr_to_cum()
     tri = tri.grain("OQDQ", trailing=True).grain("OYDY")
-    assert np.all(tri.ddims[:4] == np.array([12, 24, 36, 48]))
+    assert np.all(tri.development[:4] == np.array([12, 24, 36, 48]))
 
 
 def test_development_age():
     assert (
-        cl.load_sample("raa").ddims == [12, 24, 36, 48, 60, 72, 84, 96, 108, 120]
+        cl.load_sample("raa").development == [12, 24, 36, 48, 60, 72, 84, 96, 108, 120]
     ).all()
 
 
 def test_development_age_quarterly():
     assert (
-        cl.load_sample("quarterly").ddims
+        cl.load_sample("quarterly").development
         == [
             3,
             6,

--- a/chainladder/core/tests/test_triangle.py
+++ b/chainladder/core/tests/test_triangle.py
@@ -325,7 +325,7 @@ def test_origin_and_value_setters(raa):
     assert np.all((
         np.all(raa2.origin == raa.origin),
         np.all(raa2.development == raa.development),
-        np.all(raa2.odims == raa.odims),
+        np.all(raa2._odims == raa._odims),
         np.all(raa2.columns == raa.columns),
     ))
 
@@ -474,16 +474,42 @@ def test_kdims_deprecation_warning(raa):
     assert list(raa2.index.values) == [["P2"]]
 
 
+def test_odims_deprecation_warning(raa):
+    """Accessing or setting odims should emit a FutureWarning."""
+    with pytest.warns(FutureWarning, match="'odims' attribute is deprecated"):
+        o = raa.odims
+    assert np.all(o == raa._odims)
+
+    raa2 = raa.copy()
+    with pytest.warns(FutureWarning, match="'odims' attribute is deprecated"):
+        raa2.odims = raa._odims
+    assert np.all(raa2._odims == raa._odims)
+
+
+def test_ddims_deprecation_warning(raa):
+    """Accessing or setting ddims should emit a FutureWarning."""
+    with pytest.warns(FutureWarning, match="'ddims' attribute is deprecated"):
+        d = raa.ddims
+    assert np.all(d == raa._ddims)
+
+    raa2 = raa.copy()
+    with pytest.warns(FutureWarning, match="'ddims' attribute is deprecated"):
+        raa2.ddims = raa._ddims
+    assert np.all(raa2._ddims == raa._ddims)
+
+
 def test_legacy_pickle_compatibility(raa):
-    """Pickles saved prior to kdims/vdims migration should unpickle cleanly."""
+    """Pickles saved prior to kdims/vdims/odims/ddims migration should unpickle cleanly."""
     import pickle
 
-    # 1. Simulate oldest serialized Triangle containing kdims and vdims
+    # 1. Simulate oldest serialized Triangle containing kdims, vdims, odims, and ddims
     state = raa.__dict__.copy()
     state.pop("_index", None)
     state.pop("_columns", None)
     state["kdims"] = raa.index.values
     state["vdims"] = raa.columns.values
+    state["odims"] = state.pop("_odims")
+    state["ddims"] = state.pop("_ddims")
 
     restored = cl.Triangle.__new__(cl.Triangle)
     restored.__setstate__(state)
@@ -492,6 +518,8 @@ def test_legacy_pickle_compatibility(raa):
     assert isinstance(restored.index, pd.DataFrame)
     assert restored.index.equals(raa.index)
     assert list(restored.columns) == list(raa.columns)
+    assert restored.origin.equals(raa.origin)
+    assert (restored.development == raa.development).all()
     assert restored.loc["Total"].shape == raa.loc["Total"].shape
     assert restored == raa
 

--- a/chainladder/core/triangle.py
+++ b/chainladder/core/triangle.py
@@ -561,17 +561,17 @@ class Triangle(TriangleBase):
         self._index: DataFrame
         key_idx: np.ndarray
         self._columns: pd.Index
-        self.odims: np.ndarray
+        self._odims: np.ndarray
         orig_idx: np.ndarray
-        self.ddims: ArrayLike
+        self._ddims: ArrayLike
         dev_idx: np.ndarray
 
         self.key_labels: list = index
         kdims_arr, key_idx = self._set_kdims(data_agg, index)
         self._index = pd.DataFrame(list(kdims_arr), columns=self.key_labels)
         self._columns = pd.Index(columns, name="columns")
-        self.odims, orig_idx = self._set_odims(data_agg, date_axes)
-        self.ddims, dev_idx = self._set_ddims(data_agg, date_axes)
+        self._odims, orig_idx = self._set_odims(data_agg, date_axes)
+        self._ddims, dev_idx = self._set_ddims(data_agg, date_axes)
 
         # Set remaining triangle properties.
         val_date: Timestamp = data_agg["__development__"].max()
@@ -613,7 +613,7 @@ class Triangle(TriangleBase):
         check_origin: np.ndarray = (
             pd
             .period_range(
-                start=self.odims.min(),
+                start=self._odims.min(),
                 end=self.valuation_date,
                 freq=self.origin_grain.replace("S", "2Q")
                 + ("" if self.origin_grain == "M" else "-" + self.origin_close),
@@ -623,11 +623,11 @@ class Triangle(TriangleBase):
         )
 
         if (
-            len(check_origin) != len(self.odims)
+            len(check_origin) != len(self._odims)
             and pd.to_datetime(options.ULT_VAL) != self.valuation_date
             and not self.is_pattern
         ):
-            self.odims: np.ndarray = check_origin
+            self._odims: np.ndarray = check_origin
 
         # Set the Triangle values.
         coords: np.ndarray
@@ -654,8 +654,8 @@ class Triangle(TriangleBase):
                     shape=(
                         len(self._index),
                         len(self._columns),
-                        len(self.odims),
-                        len(self.ddims),
+                        len(self._odims),
+                        len(self._ddims),
                     ),
                 )
             ),
@@ -672,14 +672,14 @@ class Triangle(TriangleBase):
         # Deal with special properties
         if self.is_pattern:
             obj = self.dropna()
-            self.odims = obj.odims
-            self.ddims = obj.ddims
+            self._odims = obj._odims
+            self._ddims = obj._ddims
             self.values = obj.values
         if ult:
-            obj = concat((self.dev_to_val().iloc[..., : len(ult.odims), :], ult), -1)
+            obj = concat((self.dev_to_val().iloc[..., : len(ult._odims), :], ult), -1)
             obj = obj.val_to_dev()
-            self.odims = obj.odims
-            self.ddims = obj.ddims
+            self._odims = obj._odims
+            self._ddims = obj._ddims
             self.values = obj.values
             self.valuation_date = pd.Timestamp(options.ULT_VAL)
 
@@ -716,7 +716,7 @@ class Triangle(TriangleBase):
                     columns=columns,
                     index=index,
                 )
-                ult.ddims = pd.DatetimeIndex([options.ULT_VAL])
+                ult._ddims = pd.DatetimeIndex([options.ULT_VAL])
                 data = data[data[development[0]] != options.ULT_VAL]
         return data, ult
 
@@ -845,7 +845,7 @@ class Triangle(TriangleBase):
 
             True
         """
-        if self.is_pattern and len(self.odims) == 1:
+        if self.is_pattern and len(self._odims) == 1:
             return pd.Series(["(All)"])
         else:
             freq = {
@@ -853,7 +853,7 @@ class Triangle(TriangleBase):
                 "H": "2Q",
             }.get(self.origin_grain, self.origin_grain)
             freq = freq if freq == "M" else freq + "-" + self.origin_close
-            return pd.DatetimeIndex(self.odims, name="origin").to_period(freq=freq)
+            return pd.DatetimeIndex(self._odims, name="origin").to_period(freq=freq)
 
     @origin.setter
     def origin(self, value) -> None:
@@ -863,7 +863,27 @@ class Triangle(TriangleBase):
         }.get(self.origin_grain, self.origin_grain)
         freq = freq if freq == "M" else freq + "-" + self.origin_close
         value = pd.PeriodIndex(list(value), freq=freq)
-        self.odims = value.to_timestamp().values
+        self._odims = value.to_timestamp().values
+
+    @property
+    def odims(self):
+        warnings.warn(
+            "The 'odims' attribute is deprecated and will be removed in a future release. "
+            "Use 'Triangle.origin' instead.",
+            FutureWarning,
+            stacklevel=2,
+        )
+        return self._odims
+
+    @odims.setter
+    def odims(self, value):
+        warnings.warn(
+            "The 'odims' attribute is deprecated and will be removed in a future release. "
+            "Use 'Triangle.origin' instead.",
+            FutureWarning,
+            stacklevel=2,
+        )
+        self._odims = value
 
     @property
     def development(self):
@@ -919,7 +939,7 @@ class Triangle(TriangleBase):
 
             ['12-24', '24-36', '36-48', '48-60', '60-72', '72-84']
         """
-        ddims = self.ddims.copy()
+        ddims = self._ddims.copy()
         if self.is_val_tri:
             formats = {"Y": "%Y", "S": "%YQ%q", "Q": "%YQ%q", "M": "%Y-%m"}
             ddims = ddims.to_period(
@@ -941,7 +961,27 @@ class Triangle(TriangleBase):
     @development.setter
     def development(self, value):
         self._len_check(self.development, value)
-        self.ddims = np.array([value] if type(value) is str else value)
+        self._ddims = np.array([value] if type(value) is str else value)
+
+    @property
+    def ddims(self):
+        warnings.warn(
+            "The 'ddims' attribute is deprecated and will be removed in a future release. "
+            "Use 'Triangle.development' instead.",
+            FutureWarning,
+            stacklevel=2,
+        )
+        return self._ddims
+
+    @ddims.setter
+    def ddims(self, value):
+        warnings.warn(
+            "The 'ddims' attribute is deprecated and will be removed in a future release. "
+            "Use 'Triangle.development' instead.",
+            FutureWarning,
+            stacklevel=2,
+        )
+        self._ddims = value
 
     def set_index(self, value, inplace=False):
         """Sets the index of the Triangle"""
@@ -993,7 +1033,7 @@ class Triangle(TriangleBase):
 
             True
         """
-        return isinstance(self.ddims, pd.DatetimeIndex)
+        return isinstance(self._ddims, pd.DatetimeIndex)
 
     @property
     def is_full(self) -> bool:
@@ -1271,7 +1311,7 @@ class Triangle(TriangleBase):
             if not obj.is_full:
                 obj = obj[obj.valuation < obj.valuation_date]
             if hasattr(obj, "w_"):
-                w_ = obj.w_[..., : len(obj.odims), :]
+                w_ = obj.w_[..., : len(obj._odims), :]
                 obj = obj * w_ if obj.shape == w_.shape else obj
             obj.is_pattern = True
             obj.is_cumulative = False
@@ -1554,7 +1594,7 @@ class Triangle(TriangleBase):
         ddims = obj.valuation[obj.valuation <= obj.valuation_date]
         ddims = len(ddims.drop_duplicates())
         if ddims == 1 and sign == -1:
-            ddims = len(obj.odims)
+            ddims = len(obj._odims)
         if obj.values.density > 0:
             if obj.values.coords[-1].min() < 0:
                 obj.values.coords[-1] = obj.values.coords[-1] - min(
@@ -1644,10 +1684,10 @@ class Triangle(TriangleBase):
             obj = self
         obj = obj._val_dev(1, inplace)
         ddims = obj.valuation[obj.valuation <= obj.valuation_date]
-        obj.ddims = ddims.drop_duplicates().sort_values()
+        obj._ddims = ddims.drop_duplicates().sort_values()
         if self.is_full:
             if self.is_ultimate:
-                ultimate.ddims = pd.DatetimeIndex(ultimate.valuation[0:1])
+                ultimate._ddims = pd.DatetimeIndex(ultimate.valuation[0:1])
                 obj = concat((obj, ultimate), -1)
             if is_cumulative:
                 obj = obj.incr_to_cum(inplace=inplace)
@@ -1700,18 +1740,18 @@ class Triangle(TriangleBase):
                 return self.copy()
         if self.is_ultimate and self.shape[-1] > 1:
             ultimate = self.iloc[..., -1:]
-            ultimate.ddims = np.array([9999])
+            ultimate._ddims = np.array([9999])
             obj = self.iloc[..., :-1]._val_dev(-1, inplace)
         else:
             obj = self.copy()._val_dev(-1, inplace)
         val_0 = obj.valuation[0]
-        if self.ddims.shape[-1] == 1 and self.ddims[0] == self.valuation_date:
-            origin_0 = pd.to_datetime(obj.odims[-1])
+        if self._ddims.shape[-1] == 1 and self._ddims[0] == self.valuation_date:
+            origin_0 = pd.to_datetime(obj._odims[-1])
         else:
-            origin_0 = pd.to_datetime(obj.odims[0])
+            origin_0 = pd.to_datetime(obj._odims[0])
         lag_0 = (val_0.year - origin_0.year) * 12 + val_0.month - origin_0.month + 1
         scale = self._dstep()["M"][obj.development_grain]
-        obj.ddims = np.arange(obj.values.shape[-1]) * scale + lag_0
+        obj._ddims = np.arange(obj.values.shape[-1]) * scale + lag_0
         prune = obj[obj.origin == obj.origin.max()]
         if self.is_ultimate and self.shape[-1] > 1:
             obj = obj.iloc[..., : (prune.valuation <= prune.valuation_date).sum()]
@@ -1894,11 +1934,11 @@ class Triangle(TriangleBase):
             if dgrain_old == "S":
                 d_start = d_start + pd.DateOffset(months=-3)
 
-            if len(obj.ddims) > 1 and obj.origin.to_timestamp(how="s")[0] != d_start:
+            if len(obj._ddims) > 1 and obj.origin.to_timestamp(how="s")[0] != d_start:
                 addl_ts = (
                     pd
                     .period_range(
-                        obj.odims[0],
+                        obj._odims[0],
                         obj.valuation[0],
                         freq=dgrain_old.replace("S", "2Q"),
                     )[:-1]
@@ -1906,7 +1946,7 @@ class Triangle(TriangleBase):
                     .values
                 )
                 addl = obj.iloc[..., -len(addl_ts) :] * 0
-                addl.ddims = addl_ts
+                addl._ddims = addl_ts
                 obj = concat((addl, obj), axis=-1)
                 obj.values = num_to_nan(obj.values)
 
@@ -1919,10 +1959,10 @@ class Triangle(TriangleBase):
             if obj.is_cumulative:
                 obj = obj.iloc[..., d]
             else:
-                ddims = obj.ddims[d]
+                ddims = obj._ddims[d]
                 d2 = [d[0]] * (d[0] + 1) + list(np.repeat(np.array(d[1:]), step))
                 obj = obj.groupby(d2, axis=3).sum()
-                obj.ddims = ddims
+                obj._ddims = ddims
 
             obj.development_grain = dgrain_new
 
@@ -2084,7 +2124,7 @@ class Triangle(TriangleBase):
         return X
 
     def __setstate__(self, state: dict) -> None:
-        """Migrate legacy pickled instances with 'kdims'/'_kdims' to '_index' and 'vdims'/'_vdims' to '_columns'."""
+        """Migrate legacy pickled instances with 'kdims'/'_kdims' to '_index', 'vdims'/'_vdims' to '_columns', and 'odims'/'ddims' to private equivalents."""
         key_labels = state.get("key_labels", ["Total"])
         if "_index" not in state:
             raw_kdims = state.pop("_kdims", None)
@@ -2098,6 +2138,12 @@ class Triangle(TriangleBase):
                 raw_vdims = state.pop("vdims", None)
             if raw_vdims is not None:
                 state["_columns"] = pd.Index(raw_vdims, name="columns")
+        for old_key, new_key in [
+            ("odims", "_odims"),
+            ("ddims", "_ddims"),
+        ]:
+            if old_key in state and new_key not in state:
+                state[new_key] = state.pop(old_key)
         self.__dict__.update(state)
 
     def development_correlation(self, p_critical=0.5):
@@ -2377,15 +2423,15 @@ class Triangle(TriangleBase):
                 obj.values = obj.values[:, list(sort), ...]
                 obj.columns = self.columns[list(sort)]
         if axis == 2:
-            sort = pd.Series(self.odims).sort_values().index
-            if np.any(sort != pd.Series(self.odims).index):
+            sort = pd.Series(self._odims).sort_values().index
+            if np.any(sort != pd.Series(self._odims).index):
                 obj.values = obj.values[..., list(sort), :]
-                obj.odims = obj.odims[list(sort)]
+                obj._odims = obj._odims[list(sort)]
         if axis == 3:
             sort = self.development.sort_values().index
             if np.any(sort != self.development.index):
                 obj.values = obj.values[..., list(sort)]
-                obj.ddims = obj.ddims[list(sort)]
+                obj._ddims = obj._ddims[list(sort)]
         return obj
 
     def reindex(self, columns=None, fill_value=np.nan):

--- a/chainladder/core/typing.py
+++ b/chainladder/core/typing.py
@@ -11,7 +11,7 @@ from typing import (
     Protocol,
     # Self,  # Make use of this once Python 3.10 is deprecated.
     TYPE_CHECKING,
-    TypeAlias
+    TypeAlias,
 )
 
 if TYPE_CHECKING:
@@ -25,7 +25,7 @@ if TYPE_CHECKING:
         Ilocation,
         Location,
         TriangleSlicer,
-        VirtualColumns
+        VirtualColumns,
     )
     from numpy.typing import ArrayLike
     from pandas import DataFrame, Series
@@ -49,10 +49,12 @@ _AxisKey: TypeAlias = slice | int | np.int64 | np.int32 | np.ndarray
 # before index_key/other_key resolve it to a positional _AxisKey.
 _LabelKey: TypeAlias = IndexExpression | str | pd.Series | pd.DataFrame
 
+
 class TriangleProtocol(Protocol):
     """
     Common interface expected for Triangle mixins.
     """
+
     @property
     def shape(self) -> tuple[int, int, int, int]: ...
 
@@ -96,7 +98,9 @@ class TriangleProtocol(Protocol):
     def __len__(self) -> int: ...
     def get_array_module(self, arr: ArrayLike | None = None) -> ModuleType: ...
     def copy(self) -> Triangle: ...
-    def set_backend(self, backend: str, inplace: bool = False, **kwargs) -> Triangle: ...
+    def set_backend(
+        self, backend: str, inplace: bool = False, **kwargs
+    ) -> Triangle: ...
     def drop(
         self,
         labels: str | int | list | None = None,
@@ -108,7 +112,11 @@ class TriangleProtocol(Protocol):
     ) -> Triangle: ...
     def val_to_dev(self) -> Triangle: ...
     def _repr_format(self, origin_as_datetime: bool = False) -> pd.DataFrame: ...
-    def _slice(self, key: pd.Series | np.ndarray, axis: Literal['ddims', 'odims']) -> Triangle: ...
+    def _slice(
+        self,
+        key: pd.Series | np.ndarray,
+        axis: Literal["ddims", "odims", "_ddims", "_odims"],
+    ) -> Triangle: ...
     def _slice_valuation(self, key: np.ndarray) -> Triangle: ...
     def to_frame(
         self,
@@ -116,16 +124,36 @@ class TriangleProtocol(Protocol):
         keepdims: bool = False,
         implicit_axis: bool = False,
     ) -> DataFrame | Series: ...
-    def sum(self, axis: str | int | None = None, *args, **kwargs) -> TriangleProtocol: ...  # -> Self once Python 3.10 is deprecated.
-    def fillna(self, value: int | float | ndarray, inplace: bool = False) -> TriangleProtocol: ...  # -> Self once Python 3.10 is deprecated.
-    def fillzero(self, inplace: bool = False) -> TriangleProtocol: ...  # -> Self once Python 3.10 is deprecated.
-    def __round__(self, ndigits: int = 0) -> TriangleProtocol: ...  # -> Self once Python 3.10 is deprecated.
-    def __add__(self, other: Any) -> TriangleProtocol: ...  # -> Self once Python 3.10 is deprecated.
-    def __radd__(self, other: Any) -> TriangleProtocol: ...  # -> Self once Python 3.10 is deprecated.
-    def __mul__(self, other: Any) -> TriangleProtocol: ...  # -> Self once Python 3.10 is deprecated.
-    def __rmul__(self, other: Any) -> TriangleProtocol: ...  # -> Self once Python 3.10 is deprecated.
+    def sum(
+        self, axis: str | int | None = None, *args, **kwargs
+    ) -> TriangleProtocol: ...  # -> Self once Python 3.10 is deprecated.
+    def fillna(
+        self, value: int | float | ndarray, inplace: bool = False
+    ) -> TriangleProtocol: ...  # -> Self once Python 3.10 is deprecated.
+    def fillzero(
+        self, inplace: bool = False
+    ) -> TriangleProtocol: ...  # -> Self once Python 3.10 is deprecated.
+    def __round__(
+        self, ndigits: int = 0
+    ) -> TriangleProtocol: ...  # -> Self once Python 3.10 is deprecated.
+    def __add__(
+        self, other: Any
+    ) -> TriangleProtocol: ...  # -> Self once Python 3.10 is deprecated.
+    def __radd__(
+        self, other: Any
+    ) -> TriangleProtocol: ...  # -> Self once Python 3.10 is deprecated.
+    def __mul__(
+        self, other: Any
+    ) -> TriangleProtocol: ...  # -> Self once Python 3.10 is deprecated.
+    def __rmul__(
+        self, other: Any
+    ) -> TriangleProtocol: ...  # -> Self once Python 3.10 is deprecated.
     @overload
     def __getitem__(self, key: pd.Series | np.ndarray | list[str]) -> Triangle: ...
     @overload
     def __getitem__(self, key: str | int) -> Triangle | Series: ...
-    def __setitem__(self, key: str | int, value: int | float | TriangleSlicer | Callable[[Triangle], TriangleSlicer]) -> None: ...
+    def __setitem__(
+        self,
+        key: str | int,
+        value: int | float | TriangleSlicer | Callable[[Triangle], TriangleSlicer],
+    ) -> None: ...

--- a/chainladder/development/clark.py
+++ b/chainladder/development/clark.py
@@ -211,9 +211,9 @@ class ClarkLDF(DevelopmentBase):
         if isinstance(age, list):
             age = xp.array([age]).astype("float64")
         obj = self.incremental_act_.copy()
-        obj.odims = obj.odims[0:1]
+        obj._odims = obj._odims[0:1]
         obj.values = 1 / self._G(age)
-        obj.ddims = age
+        obj._ddims = age
         return obj
 
     def fit(self, X, y=None, sample_weight=None):
@@ -253,13 +253,13 @@ class ClarkLDF(DevelopmentBase):
         age_offset = {"Y": 6.0, "S": 3, "Q": 1.5, "M": 0.5}[X.development_grain]
         age_interval = {"Y": 12.0, "S": 6.0, "Q": 3.0, "M": 1.0}[X.development_grain]
         nans = nan_triangle.reshape(1, -1)[0]
-        age = xp.tile(X.ddims, len(X.odims))[~xp.isnan(nans)].astype("float64")
+        age = xp.tile(X._ddims, len(X._odims))[~xp.isnan(nans)].astype("float64")
         age_end = age - age_offset
         age_start = xp.maximum(age_end - age_interval, 0).astype("float64")
-        origin = np.repeat(X.odims, len(X.ddims))[~xp.isnan(nans)]
+        origin = np.repeat(X._odims, len(X._ddims))[~xp.isnan(nans)]
         latest_diagonal = obj[X.valuation == X.valuation_date].sum("origin")
-        latest_age = latest_diagonal.ddims.astype("float64")
-        latest_origin = X.odims
+        latest_age = latest_diagonal._ddims.astype("float64")
+        latest_origin = X._odims
         latest_diagonal = latest_diagonal.values[..., 0, :]
 
         index = xp.argsort(latest_origin)
@@ -318,8 +318,8 @@ class ClarkLDF(DevelopmentBase):
             latest_age - age_offset, theta=params[..., 1:2], omega=params[..., 0:1]
         )
         obj.values = cdf[..., :-1] / cdf[..., 1:]
-        obj.ddims = X.link_ratio.ddims
-        obj.odims = obj.odims[0:1]
+        obj._ddims = X.link_ratio._ddims
+        obj._odims = obj._odims[0:1]
         obj.is_pattern = True
         obj.is_cumulative = False
         obj._set_slicers()
@@ -343,8 +343,8 @@ class ClarkLDF(DevelopmentBase):
         self.incremental_fits_.array_backend = "numpy"
         self.incremental_fits_.values = (
             (
-                1 / self._G(X.ddims - age_offset)
-                - 1 / self._G(xp.maximum(X.ddims - age_offset - age_interval, 0))
+                1 / self._G(X._ddims - age_offset)
+                - 1 / self._G(xp.maximum(X._ddims - age_offset - age_interval, 0))
             )
             * ultimate_[..., ::-1]
             * nan_triangle
@@ -399,7 +399,7 @@ class ClarkLDF(DevelopmentBase):
         )
         df = xp.nansum(self.incremental_fits_.nan_triangle) - 2
         if self.method_ == "ldf":
-            df = df - len(self.incremental_fits_.odims)
+            df = df - len(self.incremental_fits_._odims)
         else:
             df = df - 1
         if scale.shape != ():

--- a/chainladder/development/constant.py
+++ b/chainladder/development/constant.py
@@ -129,7 +129,7 @@ class DevelopmentConstant(DevelopmentBase):
         """
         from chainladder import options
 
-        if not X.is_cumulative:
+        if X.is_cumulative is False:
             obj = self._set_fit_groups(X).incr_to_cum().val_to_dev().copy()
         else:
             obj = self._set_fit_groups(X).val_to_dev().copy()

--- a/chainladder/development/constant.py
+++ b/chainladder/development/constant.py
@@ -155,23 +155,23 @@ class DevelopmentConstant(DevelopmentBase):
             pattern_ddims = sorted(self.patterns.keys())
 
         # pattern supplied is much shorter than the triangle
-        if pattern_length < len(obj.ddims) - 1:
+        if pattern_length < len(obj._ddims) - 1:
             obj = obj.iloc[..., 0, :-1] * 0 + 1
         # pattern supplied is exactly one short of the triangle
-        elif pattern_length == len(obj.ddims) - 1:
+        elif pattern_length == len(obj._ddims) - 1:
             obj = obj.iloc[..., 0, :-1] * 0 + 1
         # pattern supplied is exactly the same length as the triangle
-        elif pattern_length == len(obj.ddims):
+        elif pattern_length == len(obj._ddims):
             obj = obj.iloc[..., 0, :] * 0 + 1
         # pattern supplied is longer than the triangle
         else:
             obj = obj.iloc[..., 0, :] * 0 + 1
-            extra = len(pattern_ddims) - len(obj.ddims)
+            extra = len(pattern_ddims) - len(obj._ddims)
             if extra > 0:
                 tail = xp.ones(obj.shape)[..., -1:]
                 tail = xp.repeat(tail, extra, -1)
                 obj.values = xp.concatenate((obj.values, tail), -1)
-                obj.ddims = np.array(pattern_ddims)
+                obj._ddims = np.array(pattern_ddims)
                 obj._set_slicers()
 
         if callable(self.patterns):
@@ -180,7 +180,7 @@ class DevelopmentConstant(DevelopmentBase):
                 ldf = (
                     pd
                     .concat(ldf.apply(pd.DataFrame, index=[0]).values, axis=0)
-                    .fillna(1)[obj.ddims]
+                    .fillna(1)[obj._ddims]
                     .values
                 )
                 ldf = xp.array(ldf[:, None, None, :])
@@ -189,14 +189,14 @@ class DevelopmentConstant(DevelopmentBase):
                 ldf = (
                     pd
                     .concat(ldf.apply(pd.DataFrame, index=[0]).values, axis=0)
-                    .fillna(1)[obj.ddims]
+                    .fillna(1)[obj._ddims]
                     .values
                 )
                 ldf = xp.array(ldf[None, :, None, :])
             else:
                 raise ValueError("callable axis needs to be 0 or 1")
         else:
-            ldf = xp.array([self.patterns.get(item, 1.0) for item in obj.ddims])
+            ldf = xp.array([self.patterns.get(item, 1.0) for item in obj._ddims])
             ldf = ldf[None, None, None, :]
 
         if self.style == "cdf":

--- a/chainladder/development/development.py
+++ b/chainladder/development/development.py
@@ -485,7 +485,7 @@ class Development(DevelopmentBase):
         obj = X[X.origin == X.origin.min()]
         xp = X.get_array_module()
         obj.values = xp.ones(obj.shape)[..., :-1] * params[..., idx : idx + 1, :]
-        obj.ddims = X.link_ratio.ddims
+        obj._ddims = X.link_ratio._ddims
         obj.valuation_date = pd.to_datetime(options.ULT_VAL)
         obj.is_pattern = True
         obj.is_cumulative = False

--- a/chainladder/development/incremental.py
+++ b/chainladder/development/incremental.py
@@ -209,7 +209,7 @@ class IncrementalAdditive(DevelopmentBase):
             Returns the instance itself.
         """
         # check dev lag
-        if not isinstance(X.ddims, np.ndarray):
+        if not isinstance(X._ddims, np.ndarray):
             raise ValueError("Triangle must be expressed with development lags")
         # convert to numpy
         if X.array_backend == "sparse":
@@ -261,7 +261,7 @@ class IncrementalAdditive(DevelopmentBase):
         self.zeta_ = self._param_property(x, self.params_.slope_[..., 0][..., None, :])
 
         # to consolidate under full_triangle_
-        y_ = xp.repeat(self.zeta_.values, len(x.odims), -2)
+        y_ = xp.repeat(self.zeta_.values, len(x._odims), -2)
         obj = x.copy()
         keeps = (
             1

--- a/chainladder/development/munich.py
+++ b/chainladder/development/munich.py
@@ -350,8 +350,8 @@ class MunichAdjustment(DevelopmentBase):
         """
         xp = X.get_array_module()
         obj = X.cdf_.copy()
-        obj.values = xp.repeat(obj.values, len(X.odims), 2)
-        obj.odims = X.odims
+        obj.values = xp.repeat(obj.values, len(X._odims), 2)
+        obj._odims = X._odims
         if type(self.paid_to_incurred) is tuple:
             p_to_i = [self.paid_to_incurred]
         else:
@@ -376,7 +376,7 @@ class MunichAdjustment(DevelopmentBase):
         ldf_tri = ldf_tri[..., :-1] / ldf_tri[..., 1:]
         obj = cdf.copy()
         obj.values = ldf_tri
-        obj.ddims = X.link_ratio.ddims
+        obj._ddims = X.link_ratio._ddims
         obj.is_pattern = True
         obj.is_cumulative = False
         obj._set_slicers()
@@ -396,8 +396,8 @@ class MunichAdjustment(DevelopmentBase):
     @property
     def lambda_(self):
         obj = self.ldf_.copy()
-        obj.odims = obj.odims[0:1]
-        obj.ddims = obj.ddims[0:1]
+        obj._odims = obj._odims[0:1]
+        obj._ddims = obj._ddims[0:1]
         obj.values = self._reshape("lambda_coef_")
         return obj.to_frame(origin_as_datetime=False)
 
@@ -417,13 +417,13 @@ class MunichAdjustment(DevelopmentBase):
     def resids_(self):
         obj = self.ldf_.copy()
         obj.values = self._reshape("residual_")
-        obj.odims = self.cdf_.odims[: obj.values.shape[2]]
+        obj._odims = self.cdf_._odims[: obj.values.shape[2]]
         return obj
 
     @property
     def q_(self):
         obj = self.rho_.copy()
-        obj.odims = self.cdf_.odims
+        obj._odims = self.cdf_._odims
         obj.values = self._reshape("q_f_")
         return obj
 
@@ -433,6 +433,6 @@ class MunichAdjustment(DevelopmentBase):
         obj.values = self._reshape("q_resid_")[
             ..., : self.residual_.shape[-2], : self.residual_.shape[-1]
         ]
-        obj.odims = obj.odims[: obj.values.shape[2]]
-        obj.ddims = obj.ddims[: obj.values.shape[3]]
+        obj._odims = obj._odims[: obj.values.shape[2]]
+        obj._ddims = obj._ddims[: obj.values.shape[3]]
         return obj

--- a/chainladder/development/outstanding.py
+++ b/chainladder/development/outstanding.py
@@ -11,7 +11,7 @@ import pandas as pd
 
 
 class CaseOutstanding(DevelopmentBase):
-    """ Deterministic development from prior-lag case reserves.
+    """Deterministic development from prior-lag case reserves.
 
     Estimates incremental paid amounts and case-reserve runoff as fractions of
     the prior lag's carried case reserve. Like
@@ -177,13 +177,13 @@ class CaseOutstanding(DevelopmentBase):
         xp = case_ldf_.get_array_module()
         # Broadcast triangle shape
         case_ldf_ = case_ldf_ * case_tri.latest_diagonal / case_tri.latest_diagonal
-        case_ldf_.odims = case_tri.odims
+        case_ldf_._odims = case_tri._odims
         case_ldf_.is_pattern = False
         case_ldf_.values = xp.concatenate(
             (xp.ones(list(case_ldf_.shape[:-1]) + [1]), case_ldf_.values), axis=-1
         )
 
-        case_ldf_.ddims = case_tri.ddims
+        case_ldf_._ddims = case_tri._ddims
         case_ldf_.valuation_date = case_ldf_.valuation.max()
         case_ldf_ = case_ldf_.dev_to_val().set_backend(self.case_ldf_.array_backend)
 
@@ -203,7 +203,7 @@ class CaseOutstanding(DevelopmentBase):
         case_tri = (
             (case_ldf_ * nans.values * case_tri.latest_diagonal.values)
             .val_to_dev()
-            .iloc[..., : len(case_tri.ddims)]
+            .iloc[..., : len(case_tri._ddims)]
         )
         ld = (
             case_tri[case_tri.valuation == X.valuation_date]
@@ -215,7 +215,7 @@ class CaseOutstanding(DevelopmentBase):
             self.paid_ldf_ * ld
         ).values
         paid = case_tri.iloc[..., :-1] * patterns
-        paid.ddims = case_tri.ddims[1:]
+        paid._ddims = case_tri._ddims[1:]
         paid.valuation_date = pd.Timestamp(options.ULT_VAL)
         # Create a full triangle of incurrds to support a multiplicative LDF
         paid = (paid_tri.cum_to_incr() + paid).incr_to_cum()
@@ -235,7 +235,7 @@ class CaseOutstanding(DevelopmentBase):
         # Convert the paid/incurred to multiplicative LDF
         dev = (dev.iloc[..., -1] / dev).iloc[..., :-1]
         dev.valuation_date = pd.Timestamp(options.ULT_VAL)
-        dev.ddims = X.link_ratio.ddims
+        dev._ddims = X.link_ratio._ddims
         dev.is_pattern = True
         dev.is_cumulative = True
 

--- a/chainladder/methods/base.py
+++ b/chainladder/methods/base.py
@@ -24,7 +24,7 @@ class MethodBase(BaseEstimator, EstimatorIO, Common):
         obj = X.copy()
         if "ldf_" not in obj:
             obj = Development().fit_transform(obj)
-        if len(obj.ddims) - len(obj.ldf_.ddims) == 1:
+        if len(obj._ddims) - len(obj.ldf_._ddims) == 1:
             obj = TailConstant().fit_transform(obj)
         return obj.val_to_dev()
 
@@ -39,7 +39,7 @@ class MethodBase(BaseEstimator, EstimatorIO, Common):
         xp = ultimate.get_array_module()
         if ultimate.array_backend != "sparse":
             ultimate.values[~xp.isfinite(ultimate.values)] = xp.nan
-        ultimate.ddims = pd.DatetimeIndex([options.ULT_VAL])
+        ultimate._ddims = pd.DatetimeIndex([options.ULT_VAL])
         ultimate.virtual_columns.columns = {}
         ultimate.is_cumulative = True
         ultimate._set_slicers()
@@ -100,7 +100,7 @@ class MethodBase(BaseEstimator, EstimatorIO, Common):
 
         """
         X_new = X.val_to_dev()
-        if sum(X_new.ddims > self.ldf_.ddims.max()) > 0:
+        if sum(X_new._ddims > self.ldf_._ddims.max()) > 0:
             raise ValueError("X has ages that exceed those available in model.")
         X_new = X_new + (self.X_.val_to_dev().iloc[0, 0].sum(2) * 0)
         self.validate_weight(X_new, sample_weight)

--- a/chainladder/methods/benktander.py
+++ b/chainladder/methods/benktander.py
@@ -297,5 +297,5 @@ class Benktander(MethodBase):
         b = cdf[-1, ...] * xp.nan_to_num(expectation.set_backend(backend).values)
         ultimate.values = num_to_nan(a + b)
         ultimate.array_backend = backend
-        ultimate.ddims = self.cdf_.ddims[: ultimate.shape[-1]]
+        ultimate._ddims = self.cdf_._ddims[: ultimate.shape[-1]]
         return self._set_ult_attr(ultimate)

--- a/chainladder/methods/mack.py
+++ b/chainladder/methods/mack.py
@@ -291,7 +291,7 @@ class MackChainladder(Chainladder):
         avg = {"regression": 0, "volume": 1, "simple": 2}
         avg = [avg.get(item, item) for item in X.average_]
         val = xp.broadcast_to(xp.array(avg + [avg[-1]]), X.shape)
-        weight = xp.sqrt(full.values[..., : len(X.ddims)] ** (2 - val))
+        weight = xp.sqrt(full.values[..., : len(X._ddims)] ** (2 - val))
         obj.values = X.sigma_.values / num_to_nan(weight)
         w = lxp.concatenate(
             (X.w_, lxp.ones((val.shape[0], val.shape[1], val.shape[2], 1))), 3
@@ -352,11 +352,11 @@ class MackChainladder(Chainladder):
             t1_t = xp.nan_to_num(
                 future_std_err.sum("origin").set_backend(backend).values
             )
-            obj.odims = obj.odims[0:1]
+            obj._odims = obj._odims[0:1]
         else:
             nans = xp.nan_to_num(X.nan_triangle[None, None])
             nans = 1 - xp.concatenate((nans, xp.zeros((1, 1, X.shape[2], 1))), 3)
-            full_tri = X._full_triangle_.values[..., : len(X.ddims)]
+            full_tri = X._full_triangle_.values[..., : len(X._ddims)]
             if est == "parameter_risk_":
                 # std_err_ is always numpy
                 t1_t = (
@@ -365,7 +365,7 @@ class MackChainladder(Chainladder):
             else:
                 t1_t = xp.nan_to_num(full_tri) * self._get_full_std_err_(X).values
         extend = X.ldf_.shape[-1] - X.shape[-1] + 1
-        ldf = X.ldf_.values[..., : len(X.ddims) - 1]
+        ldf = X.ldf_.values[..., : len(X._ddims) - 1]
         tail = X.cdf_.values[..., -extend : -extend + 1]
         ldf = xp.array(X.ldf_.get_array_module().concatenate((ldf, tail), -1))
         # Recursive Mack Formula
@@ -377,7 +377,7 @@ class MackChainladder(Chainladder):
                 t_tot = t_tot * nans[..., i + 1 : i + 2]
             risk_arr = xp.concatenate((risk_arr, xp.nan_to_num(t_tot)), 3)
         obj.values = risk_arr
-        obj.ddims = X._full_triangle_.ddims[list(range(X.shape[-1])) + [-1]]
+        obj._ddims = X._full_triangle_._ddims[list(range(X.shape[-1])) + [-1]]
         obj.valuation_date = X._full_triangle_.valuation_date
         obj._set_slicers()
         return obj
@@ -510,6 +510,6 @@ class MackChainladder(Chainladder):
             self.mack_std_err_.set_backend(backend).values[..., -1:],
         )
         obj.values = obj.get_array_module().concatenate(cols, 3)
-        obj.ddims = ["Latest", "IBNR", "Ultimate", "Mack Std Err"]
+        obj._ddims = ["Latest", "IBNR", "Ultimate", "Mack Std Err"]
         obj._set_slicers()
         return obj

--- a/chainladder/tails/base.py
+++ b/chainladder/tails/base.py
@@ -25,25 +25,25 @@ class TailBase(DevelopmentBase):
             "S": (2 * m, 6),
         }[obj.development_grain]
         t_ddims = [
-            (item + 1) * self._ave_period[1] + obj.ldf_.ddims[-1]
+            (item + 1) * self._ave_period[1] + obj.ldf_._ddims[-1]
             for item in range(self._ave_period[0] + 1)
         ]
         ddims = np.concatenate(
-            (obj.ldf_.ddims, t_ddims),
+            (obj.ldf_._ddims, t_ddims),
             0,
         )
         self.ldf_ = obj.ldf_.copy()
         tail = xp.ones(self.ldf_.shape)[..., -1:]
         tail = xp.repeat(tail, self._ave_period[0] + 1, -1)
         self.ldf_.values = xp.concatenate((self.ldf_.values, tail), -1)
-        self.ldf_.ddims = ddims
+        self.ldf_._ddims = ddims
         if hasattr(obj, "sigma_"):
             zeros = (obj.sigma_.iloc[..., -1:] * 0).values
             self.sigma_ = getattr(obj, "sigma_").copy()
             self.sigma_.values = xp.concatenate((self.sigma_.values, zeros), -1)
             self.std_err_ = getattr(obj, "std_err_").copy()
             self.std_err_.values = xp.concatenate((self.std_err_.values, zeros), -1)
-            self.sigma_.ddims = self.std_err_.ddims = self.ldf_.ddims[: obj.shape[2]]
+            self.sigma_._ddims = self.std_err_._ddims = self.ldf_._ddims[: obj.shape[2]]
             self.sigma_._set_slicers()
             self.std_err_._set_slicers()
         if hasattr(obj, "average_"):

--- a/chainladder/tails/bondy.py
+++ b/chainladder/tails/bondy.py
@@ -146,19 +146,19 @@ class TailBondy(TailBase):
         super().fit(X, y, sample_weight)
 
         if self.earliest_age is None:
-            earliest_age = X.ddims[-2]
+            earliest_age = X._ddims[-2]
         else:
-            earliest_age = X.ddims[
+            earliest_age = X._ddims[
                 int(
                     self.earliest_age
                     / ({"Y": 12, "S": 6, "Q": 3, "M": 1}[X.development_grain])
                 )
                 - 1
             ]
-        attachment_age = self.attachment_age if self.attachment_age else X.ddims[-2]
+        attachment_age = self.attachment_age if self.attachment_age else X._ddims[-2]
         obj = Development().fit_transform(X) if "ldf_" not in X else X
         b_optimized = []
-        initial = xp.where(obj.ddims == earliest_age)[0][0] if earliest_age else 0
+        initial = xp.where(obj._ddims == earliest_age)[0][0] if earliest_age else 0
         for num in range(len(obj.columns)):
             b0 = (xp.ones(obj.shape[0]) * 0.5)[:, None]
             data = xp.log(obj.ldf_.values[:, num, 0, initial:])
@@ -176,14 +176,14 @@ class TailBondy(TailBase):
                 [item.reshape(-1, 2)[:, 1:2] for item in b_optimized], axis=1
             )[..., None, None]
         )
-        if sum(X.ddims > earliest_age) > 1:
-            tail = xp.exp(self.earliest_ldf_ * self.b_ ** (len(obj.ldf_.ddims) - 1))
+        if sum(X._ddims > earliest_age) > 1:
+            tail = xp.exp(self.earliest_ldf_ * self.b_ ** (len(obj.ldf_._ddims) - 1))
         else:
             tail = self.ldf_.values[..., 0, initial]
         tail = tail ** (self.b_ / (1 - self.b_))
         f0 = self.ldf_.values[..., 0:1, initial : initial + 1]
         fitted = f0 ** (
-            self.b_ ** (np.arange(sum(X.ddims >= earliest_age))[None, None, None, :])
+            self.b_ ** (np.arange(sum(X._ddims >= earliest_age))[None, None, None, :])
         )
         fitted = xp.concatenate(
             (fitted, fitted[..., -1:] ** (self.b_ / (1 - self.b_))), axis=-1
@@ -196,8 +196,8 @@ class TailBondy(TailBase):
         )
         self.ldf_.values = xp.concatenate(
             (
-                self.ldf_.values[..., : sum(X.ddims <= attachment_age)],
-                fitted[..., -sum(X.ddims >= attachment_age) :],
+                self.ldf_.values[..., : sum(X._ddims <= attachment_age)],
+                fitted[..., -sum(X._ddims >= attachment_age) :],
             ),
             axis=-1,
         )

--- a/chainladder/tails/clark.py
+++ b/chainladder/tails/clark.py
@@ -112,8 +112,13 @@ class TailClark(TailBase):
 
     """
 
-    def __init__(self, growth="loglogistic", truncation_age=None,
-                 attachment_age=None, projection_period=12):
+    def __init__(
+        self,
+        growth="loglogistic",
+        truncation_age=None,
+        attachment_age=None,
+        projection_period=12,
+    ):
         self.growth = growth
         self.truncation_age = truncation_age
         self.attachment_age = attachment_age
@@ -145,7 +150,7 @@ class TailClark(TailBase):
         model = ClarkLDF(growth=self.growth).fit(X, sample_weight=sample_weight)
         xp = X.get_array_module()
         age_offset = {"Y": 6.0, "S": 3, "Q": 1.5, "M": 0.5}[X.development_grain]
-        fitted = 1 / model.G_(self.ldf_.ddims - age_offset)
+        fitted = 1 / model.G_(self.ldf_._ddims - age_offset)
         fitted = xp.concatenate(
             (
                 fitted.values[..., :-1] / fitted.values[..., 1:],
@@ -154,11 +159,14 @@ class TailClark(TailBase):
             -1,
         )
         fitted = xp.repeat(fitted, self.ldf_.values.shape[2], 2)
-        attachment_age = self.attachment_age if self.attachment_age else X.ddims[-2]
-        self.ldf_.values = xp.concatenate((
-            self.ldf_.values[..., : sum(self.ldf_.ddims < attachment_age)],
-            fitted[..., -sum(self.ldf_.ddims >= attachment_age) :],),
-            axis=-1,)
+        attachment_age = self.attachment_age if self.attachment_age else X._ddims[-2]
+        self.ldf_.values = xp.concatenate(
+            (
+                self.ldf_.values[..., : sum(self.ldf_._ddims < attachment_age)],
+                fitted[..., -sum(self.ldf_._ddims >= attachment_age) :],
+            ),
+            axis=-1,
+        )
         self.omega_ = model.omega_
         self.theta_ = model.theta_
         self.G_ = model.G_
@@ -169,7 +177,9 @@ class TailClark(TailBase):
             self.elr_ = model.elr_
         self.norm_resid_ = model.norm_resid_
         if self.truncation_age:
-            self.ldf_.values[..., -1:] = self.ldf_.values[..., -1:] * self.G_(self.truncation_age).values
+            self.ldf_.values[..., -1:] = (
+                self.ldf_.values[..., -1:] * self.G_(self.truncation_age).values
+            )
         # self._get_tail_stats(self)
         if backend == "cupy":
             self = self.set_backend("cupy", inplace=True)

--- a/chainladder/tails/constant.py
+++ b/chainladder/tails/constant.py
@@ -147,9 +147,9 @@ class TailConstant(TailBase):
         xp = self.ldf_.get_array_module()
         tail = self.tail
         if self.attachment_age:
-            attach_idx = xp.min(xp.where(X.ddims >= self.attachment_age))
+            attach_idx = xp.min(xp.where(X._ddims >= self.attachment_age))
         else:
-            attach_idx = len(X.ddims) - 1
+            attach_idx = len(X._ddims) - 1
         self = self._apply_decay(X, tail, attach_idx)
         obj = Development().fit_transform(X) if "ldf_" not in X else X
         self._get_tail_stats(obj)

--- a/chainladder/tails/curve.py
+++ b/chainladder/tails/curve.py
@@ -250,9 +250,9 @@ class TailCurve(TailBase):
         )
         tail = self._predict_tail(extrapolate)
         if self.attachment_age:
-            attach_idx = xp.min(xp.where(X.ddims >= self.attachment_age))
+            attach_idx = xp.min(xp.where(X._ddims >= self.attachment_age))
         else:
-            attach_idx = len(X.ddims) - 1
+            attach_idx = len(X._ddims) - 1
         self.ldf_.values = xp.concatenate(
             (self.ldf_.values[..., :attach_idx], tail[..., attach_idx:]), -1
         )

--- a/chainladder/tails/tests/rtest_exponential.py
+++ b/chainladder/tails/tests/rtest_exponential.py
@@ -1,3 +1,4 @@
+import numpy as np
 import pytest
 import chainladder as cl
 

--- a/chainladder/tails/tests/rtest_exponential.py
+++ b/chainladder/tails/tests/rtest_exponential.py
@@ -1,4 +1,3 @@
-import numpy as np
 import pytest
 import chainladder as cl
 
@@ -7,7 +6,7 @@ try:
     from rpy2.robjects import r
 
     CL = importr("ChainLadder")
-except ImportError:
+except Exception:
     pass
 
 

--- a/chainladder/tails/tests/rtest_exponential.py
+++ b/chainladder/tails/tests/rtest_exponential.py
@@ -102,7 +102,7 @@ def test_tail_doesnt_mutate_ldf_(data, averages, est_sigma):
     xp = p.get_array_module()
     p_no_tail = mack_p_no_tail(data, averages[0], est_sigma[0]).ldf_.values
     xp.testing.assert_array_equal(
-        p_no_tail, p.values[..., : len(cl.load_sample(data).ddims) - 1]
+        p_no_tail, p.values[..., : len(cl.load_sample(data).development) - 1]
     )
 
 

--- a/chainladder/tails/tests/test_exponential.py
+++ b/chainladder/tails/tests/test_exponential.py
@@ -7,7 +7,8 @@ def test_fit_period():
     dev = cl.Development(average="simple").fit_transform(tri)
     assert (
         round(
-            cl.TailCurve(fit_period=(tri.ddims[-7], None), extrap_periods=10)
+            cl
+            .TailCurve(fit_period=(tri.development.iloc[-7], None), extrap_periods=10)
             .fit(dev)
             .cdf_["paid"]
             .set_backend("numpy", inplace=True)
@@ -24,10 +25,8 @@ def test_curve_validation():
     """
 
     with pytest.raises(ValueError):
-        tri = cl.load_sample('tail_sample')
-        cl.TailCurve(
-            curve='Exponential'
-        ).fit_transform(tri)
+        tri = cl.load_sample("tail_sample")
+        cl.TailCurve(curve="Exponential").fit_transform(tri)
 
 
 def test_errors_validation():
@@ -35,7 +34,5 @@ def test_errors_validation():
     Test validation of the errors parameter. Should raise a value error if an incorrect argument is supplied.
     """
     with pytest.raises(ValueError):
-        tri = cl.load_sample('tail_sample')
-        cl.TailCurve(
-            errors='Ignore'
-        ).fit_transform(tri)
+        tri = cl.load_sample("tail_sample")
+        cl.TailCurve(errors="Ignore").fit_transform(tri)

--- a/chainladder/utils/tests/test_utilities.py
+++ b/chainladder/utils/tests/test_utilities.py
@@ -61,8 +61,8 @@ def test_triangle_json_io(clrd):
     assert clrd == clrd2
     assert clrd.index.equals(clrd2.index)
     assert np.all(clrd.columns == clrd2.columns)
-    assert np.all(clrd.odims == clrd2.odims)
-    assert np.all(clrd.ddims == clrd2.ddims)
+    assert np.all(clrd.origin == clrd2.origin)
+    assert np.all(clrd.development == clrd2.development)
     assert np.all(clrd.valuation == clrd2.valuation)
 
 

--- a/chainladder/utils/utility_functions.py
+++ b/chainladder/utils/utility_functions.py
@@ -689,10 +689,10 @@ def concat(
         for obj in objs[1:]:
             assert obj.index.equals(objs[0].index)
     if axis != 2:
-        a = np.array([obj.odims for obj in objs])
+        a = np.array([obj._odims for obj in objs])
         assert np.all(a == a[0])
     if axis != 3:
-        a = np.array([obj.ddims for obj in objs])
+        a = np.array([obj._ddims for obj in objs])
         assert np.all(a == a[0])
 
     out = copy.deepcopy(objs[0])
@@ -721,20 +721,20 @@ def concat(
         out._columns = new_axis
     elif axis == 2:
         if ignore_index:
-            new_axis = np.arange(sum([len(obj.odims) for obj in objs]))
+            new_axis = np.arange(sum([len(obj._odims) for obj in objs]))
         else:
-            new_axis = np.concatenate([obj.odims for obj in objs])
+            new_axis = np.concatenate([obj._odims for obj in objs])
             assert len(new_axis) == len(set(new_axis))
-        out.odims = new_axis
+        out._odims = new_axis
     elif axis == 3:
         if ignore_index:
-            new_axis = np.arange(sum([len(obj.ddims) for obj in objs]))
+            new_axis = np.arange(sum([len(obj._ddims) for obj in objs]))
         else:
-            new_axis = np.concatenate([obj.ddims for obj in objs])
+            new_axis = np.concatenate([obj._ddims for obj in objs])
             assert len(new_axis) == len(set(new_axis))
-        out.ddims = new_axis
-        if out.ddims.dtype == __dt64_dtype__ and type(out.ddims) is np.ndarray:
-            out.ddims = pd.DatetimeIndex(out.ddims)
+        out._ddims = new_axis
+        if out._ddims.dtype == __dt64_dtype__ and type(out._ddims) is np.ndarray:
+            out._ddims = pd.DatetimeIndex(out._ddims)
 
     out.valuation_date = pd.Series([obj.valuation_date for obj in objs]).max()
     out._set_slicers()


### PR DESCRIPTION
## Summary of Changes  
- Deprecate odims (#1012) and ddims (#1013) on Triangle with FutureWarnings pointing to origin and development
- Update internal usage across core modules, estimators, adjustments, and tails to prevent internal warnings
- Preserve legacy pickle compatibility in Triangle.__setstate__ so older saved instances unpickle cleanly
- Add test coverage verifying deprecation warnings when reading or setting both attributes and unpickling legacy objects
- Address ruff lint and formatting on touched files

## Related GitHub Issue(s)  
Closes #1012, closes #1013, refs #601, refs #1216

## Additional Context for Reviewers  
- Existing code reading or setting odims and ddims continues to work as expected for backward compatibility.
- Per discussion on #1013, _ddims is encapsulated as an array/index without introducing a DevelopmentIndex redesign, keeping public access on Triangle.development.
- This PR is stacked on feature/deprecate-dims (#1303).



<!-- Do not edit anything below this. -->

## Checklist
- [ ] I passed tests locally for both code (`uv run pytest`) and documentation changes (`uv run --directory docs jb build . --builder=custom --custom-builder=doctest`)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Wide changes to how origin/development axes are stored and mutated across reserving and triangle arithmetic, though behavior is intended to stay backward compatible via deprecated accessors and pickle migration.
> 
> **Overview**
> **Deprecates** public `Triangle.odims` and `Triangle.ddims`, moving internal axis storage to private `_odims` and `_ddims` while steering callers toward **`origin`** and **`development`**.
> 
> Read/write access to the old names still works but emits **`FutureWarning`**. Library code across core, development, methods, tails, adjustments, and utilities is updated to use the private fields so internals no longer trigger deprecation noise. Slicing helpers accept both legacy and private axis names for compatibility.
> 
> **Pickle migration** in `Triangle.__setstate__` maps serialized `odims`/`ddims` into `_odims`/`_ddims`, with expanded tests for warnings, legacy unpickling, and JSON checks using `origin`/`development`. A few unrelated test fixes (R import guard, `TailCurve` fit period) ride along.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a2ce5cdbccdd2fb2fbc9f4f250906633729adcb4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->