### PR TITLE
[FIX] raise when the fitted pattern cannot be applied to the triangle passed in

### DIFF
--- a/chainladder/methods/base.py
+++ b/chainladder/methods/base.py
@@ -102,6 +102,9 @@ class MethodBase(BaseEstimator, EstimatorIO, Common):
         X_new = X.val_to_dev()
         if sum(X_new.ddims > self.ldf_.ddims.max()) > 0:
             raise ValueError("X has ages that exceed those available in model.")
+        # Before the line below, which borrows self.X_'s index when both sides
+        # are a single row and so would erase what the caller actually passed.
+        self.validate_ldf(X_new, self.ldf_)
         X_new = X_new + (self.X_.val_to_dev().iloc[0, 0].sum(2) * 0)
         self.validate_weight(X_new, sample_weight)
         if sample_weight:
@@ -154,6 +157,45 @@ class MethodBase(BaseEstimator, EstimatorIO, Common):
         else:
             process_var = None
         return process_var
+
+    @staticmethod
+    def validate_ldf(X: Triangle, ldf: Triangle) -> None:
+        """
+        Checks that a fitted pattern can be applied to X as it was passed in.
+        The index and the columns of the two have to line up: values or columns
+        X carries that the pattern does not cannot be predicted, and index
+        levels the pattern carries that X does not cannot be applied.
+        """
+        # A pattern whose index is entirely the "(All)" sentinel that Triangle.sum
+        # sets carries no group identity, so nothing about it constrains what it
+        # may be applied to. Note the limit of that: sum() stamps "(All)" on
+        # whatever subset it was called on, so a pattern summed from one line of
+        # business is exempt here just as a pattern summed from everything is.
+        # Telling those apart needs aggregation provenance on the Triangle.
+        if len(ldf) == 1 and set(ldf.index.values.flatten()) == {"(All)"}:
+            return
+        shared = sorted(set(X.key_labels) & set(ldf.key_labels))
+        if shared:
+            missing = sorted(
+                set(X.index.set_index(shared).index)
+                - set(ldf.index.set_index(shared).index)
+            )
+            if missing:
+                raise ValueError(
+                    "X has index values the model was not fit on: "
+                    + str(missing[:5])
+                    + (", and others" if len(missing) > 5 else "")
+                )
+        columns = sorted(set(X.columns) - set(ldf.columns))
+        if columns:
+            raise ValueError("X has columns the model was not fit on: " + str(columns))
+        finer = sorted(set(ldf.key_labels) - set(X.key_labels))
+        if finer:
+            raise ValueError(
+                "The fitted pattern has index levels that X does not: "
+                + str(finer)
+                + ". It cannot be applied to a triangle that does not carry them."
+            )
 
     @staticmethod
     def validate_weight(

--- a/chainladder/methods/capecod.py
+++ b/chainladder/methods/capecod.py
@@ -319,6 +319,7 @@ class CapeCod(Benktander):
         if sample_weight is None:
             raise ValueError("sample_weight is required.")
         X_new = X.copy()
+        self.validate_ldf(X_new, self.ldf_)
         _, X_new.ldf_ = self.intersection(X_new, self.ldf_)
         # If model was fit at a higher grain, then need to aggregate predicted aprioris too
         if len(set(sample_weight.key_labels) - set(self.apriori_.key_labels)) > 0:

--- a/chainladder/methods/tests/test_predict.py
+++ b/chainladder/methods/tests/test_predict.py
@@ -190,6 +190,168 @@ def test_misaligned_index2(clrd):
     assert abs(a - b) < 1e-5
 
 
+def test_predict_rejects_index_values_the_model_never_saw(clrd):
+    """github issue #1288
+
+    intersection() narrows both operands to their shared index, so a group the
+    model was never fit on used to be dropped from the result instead of
+    predicted, silently on Chainladder and as a numpy shape error on the others.
+    """
+    tri = clrd["CumPaidLoss"]
+    sample_weight = clrd["EarnedPremDIR"].latest_diagonal
+    seen = tri.index["LOB"] != "wkcomp"
+    train = tri[seen].groupby("LOB").sum()
+    train_weight = sample_weight[seen].groupby("LOB").sum()
+
+    models = [
+        cl.Chainladder().fit(cl.Development().fit_transform(train)),
+        cl.BornhuetterFerguson(apriori=0.7).fit(train, sample_weight=train_weight),
+        cl.CapeCod().fit(train, sample_weight=train_weight),
+    ]
+    for model in models:
+        with pytest.raises(ValueError, match="index values the model was not fit on"):
+            if isinstance(model, cl.Chainladder):
+                model.predict(tri)
+            else:
+                model.predict(tri, sample_weight=sample_weight)
+
+
+def test_predict_rejects_a_different_single_group(clrd):
+    """github issue #1288
+
+    Both sides being one row is the case intersection() short circuits on, so
+    the pattern from one group used to be applied to another silently, with the
+    result labelled as the group that was predicted on.
+    """
+    lob = clrd["CumPaidLoss"].groupby("LOB").sum()
+    fitted_on = lob[lob.index["LOB"] == "comauto"]
+    predicted_on = lob[lob.index["LOB"] == "othliab"]
+    assert len(fitted_on) == len(predicted_on) == 1
+
+    weight = clrd["EarnedPremDIR"].latest_diagonal.groupby("LOB").sum()
+    fitted_weight = weight[weight.index["LOB"] == "comauto"]
+    predicted_weight = weight[weight.index["LOB"] == "othliab"]
+
+    model = cl.Chainladder().fit(cl.Development().fit_transform(fitted_on))
+    with pytest.raises(ValueError, match="index values the model was not fit on"):
+        model.predict(predicted_on)
+    # the same single group is still fine
+    assert model.predict(fitted_on).ultimate_.shape[0] == 1
+
+    for cls in (cl.BornhuetterFerguson, cl.CapeCod):
+        exposure_model = cls().fit(fitted_on, sample_weight=fitted_weight)
+        with pytest.raises(ValueError, match="index values the model was not fit on"):
+            exposure_model.predict(predicted_on, sample_weight=predicted_weight)
+
+
+def test_predict_rejects_a_pattern_finer_than_the_triangle(clrd):
+    """github issue #1288
+
+    The reverse direction: a pattern fit per company cannot be applied to a
+    triangle that has aggregated companies away. intersection() leaves the ldf_
+    at the fitted grain, which used to surface as a 775 row ultimate_ from a
+    6 row input.
+    """
+    tri = clrd["CumPaidLoss"]
+    sample_weight = clrd["EarnedPremDIR"].latest_diagonal
+    coarse = tri.groupby("LOB").sum()
+    coarse_weight = sample_weight.groupby("LOB").sum()
+
+    models = [
+        cl.Chainladder().fit(cl.Development().fit_transform(tri)),
+        cl.BornhuetterFerguson(apriori=0.7).fit(tri, sample_weight=sample_weight),
+        cl.CapeCod().fit(tri, sample_weight=sample_weight),
+    ]
+    for model in models:
+        with pytest.raises(ValueError, match="has index levels that X does not"):
+            if isinstance(model, cl.Chainladder):
+                model.predict(coarse)
+            else:
+                model.predict(coarse, sample_weight=coarse_weight)
+
+
+def test_predict_rejects_columns_the_model_was_not_fit_on(clrd):
+    """github issue #1288
+
+    The same mismatch on the columns axis. A paid pattern applied to an incurred
+    triangle used to come back labelled incurred, overstating the ultimate by
+    about half on clrd.
+    """
+    paid = clrd["CumPaidLoss"].groupby("LOB").sum()
+    incurred = clrd["IncurLoss"].groupby("LOB").sum()
+    both = clrd[["CumPaidLoss", "IncurLoss"]].groupby("LOB").sum()
+
+    model = cl.Chainladder().fit(cl.Development().fit_transform(paid))
+    with pytest.raises(ValueError, match="columns the model was not fit on"):
+        model.predict(incurred)
+    with pytest.raises(ValueError, match="columns the model was not fit on"):
+        model.predict(both)
+
+    # the column it was fit on is still fine
+    assert model.predict(paid).ultimate_.shape[0] == paid.shape[0]
+
+
+def test_predict_still_allows_an_aggregate_pattern(clrd):
+    """github issue #1288
+
+    A pattern fit on a fully aggregated triangle carries the "(All)" sentinel
+    rather than any group identity, so it may be broadcast to any grain. Both
+    directions matter: test_different_backends relies on the first.
+    """
+    tri = clrd["CumPaidLoss"]
+    sample_weight = clrd["EarnedPremDIR"].latest_diagonal
+    model = cl.BornhuetterFerguson().fit(tri.sum(), sample_weight=sample_weight.sum())
+
+    per_company = model.predict(tri, sample_weight=sample_weight)
+    assert per_company.ultimate_.shape[0] == tri.shape[0]
+
+    by_lob = model.predict(
+        tri.groupby("LOB").sum(), sample_weight=sample_weight.groupby("LOB").sum()
+    )
+    assert by_lob.ultimate_.shape[0] == tri.groupby("LOB").sum().shape[0]
+
+
+def test_predict_checks_before_the_index_is_borrowed(clrd):
+    """github issue #1288
+
+    MethodBase.predict adds a zeroed slice of self.X_ to X, and for single row
+    operands whose key_labels differ that addition takes the model's index. The
+    check has to run before it, or by the time it looks the caller's identity is
+    already the model's and the two agree.
+    """
+    tri = clrd["CumPaidLoss"]
+    by_company = tri.groupby("GRNAME").sum()
+    by_lob = tri.groupby("LOB").sum()
+    fitted_on = by_company[by_company.index["GRNAME"] == "Aegis Grp"]
+    predicted_on = by_lob[by_lob.index["LOB"] == "othliab"]
+    assert fitted_on.key_labels != predicted_on.key_labels
+
+    model = cl.Chainladder().fit(cl.Development().fit_transform(fitted_on))
+    with pytest.raises(ValueError):
+        model.predict(predicted_on)
+
+
+def test_predict_still_allows_a_pattern_coarser_than_the_triangle(clrd):
+    """github issue #1288
+
+    The #400 flow must keep working: a pattern fit at a coarser grain broadcasts
+    down to the triangle, so validate_ldf has to stay quiet here.
+    """
+    tri = clrd["CumPaidLoss"]
+    sample_weight = clrd["EarnedPremDIR"].latest_diagonal
+    train = tri.groupby("LOB").sum()
+    train_weight = sample_weight.groupby("LOB").sum()
+
+    bcl = cl.Chainladder().fit(cl.Development().fit_transform(train)).predict(tri)
+    assert bcl.ultimate_.shape[0] == tri.shape[0]
+
+    bcc = cl.CapeCod().fit(train, sample_weight=train_weight)
+    assert (
+        bcc.predict(tri, sample_weight=sample_weight).apriori_.shape[0]
+        == train.shape[0]
+    )
+
+
 def test_align_cdfs(raa):
     ld = raa.latest_diagonal * 0 + 40000
     model = cl.BornhuetterFerguson().fit(raa, sample_weight=ld)


### PR DESCRIPTION
## Summary of Changes

`intersection()` narrows two triangles to their shared index. That is the right thing for the grain broadcast #400 asked for, and the wrong thing for a mismatch, and it cannot tell the two apart. Three mismatches were resolving quietly:

- **`X` carries a group the model was never fit on.** `intersection` drops those rows, so `Chainladder` returned 643 of the 775 rows it was handed with no warning, while `BornhuetterFerguson` and `CapeCod` raised `operands could not be broadcast together with shapes (775,1,10,1) (643,1,10,1)`, which names no index value.
- **`ldf_` is at a finer grain than `X`.** `intersection` narrows neither side, so `predict` returns an object whose triangle sits at the caller's grain and whose `ldf_` sits at the model's, and `Chainladder` built a 775 row `ultimate_` from a 6 row input.
- **Both sides are a single row.** `intersection` short circuits on that at its first line, so a pattern fit on one group was applied to another with no warning. Fitting on `State Farm Mut Grp` comauto and predicting on `State Farm Mut Grp` othliab returns an ultimate of 1,638,150.65 carrying `[['State Farm Mut Grp', 'othliab']]` as its index, where othliab's own pattern gives 2,640,829.49. Which side's index the result carries depends on whether the two triangles share key labels: where they share at least one it is the group predicted on, and where they share none the addition below takes the fitted triangle's labels instead.

`validate_ldf` checks all three, in the shape `validate_weight` already uses.

Two things about it are worth flagging, because neither is obvious from the diff.

**Where the call sits.** It runs before `X_new = X_new + (self.X_.val_to_dev().iloc[0,0].sum(2) * 0)`, not next to `intersection`. That addition goes through `_prep_index`, which borrows `self.X_`'s index when both sides are a single row, so by the time control reaches `intersection` the caller's identity is already gone and the check sees two triangles that agree. Placing the call after that line looks natural and silently does nothing for the single-row case.

**The `"(All)"` exemption.** A pattern whose index is entirely the `"(All)"` sentinel came from `Triangle.sum` and carries no group identity, so neither its index values nor its key labels constrain what it may be applied to, and it is exempt from both checks. Without that, this rejects `test_different_backends`, which fits on `clrd.sum()` and predicts on 132 companies. Row count cannot separate that from the single-group mistake above: both are one row sharing no index value with the target. The limit of that exemption is worth stating plainly, because it is wider than it first looks. `Triangle.sum` stamps `"(All)"` on whatever subset it was called on, so a pattern summed from a single line of business is exempt exactly as a pattern summed from the whole book is. Fitting on `tri[tri.index["LOB"] == "wkcomp"].sum()` and predicting on comauto is allowed and returns 157 rows, which is the third case above reached with one extra `.sum()`. Closing that means recording aggregation provenance on the Triangle, which is a larger change than this and your call rather than mine. What this PR does is remove the cases where nothing was summed at all.

A pattern coarser than `X` stays allowed, which is the #400 flow.

**Columns, added after review.** The same mismatch on the columns axis: fitting on `CumPaidLoss` and predicting on `IncurLoss` returned an ultimate of 228,088,946 labelled `IncurLoss`, where fitting on the incurred triangle gives 150,105,776. `paid -> [paid, incurred]` was allowed too. The check is one direction, `set(X.columns) - set(ldf.columns)`; the reverse is noted on the thread.

## Related GitHub Issue(s)

Fixes #1288. `intersection` itself is untouched, per your point on that thread about #1037.

Note for merge order: #1306 touches the adjacent lines in `CapeCod.predict`, so whichever lands second will want a rebase.

## Additional Context for Reviewers

- Seven tests, placed next to `test_misaligned_index2`. Those two cover predicting on a strict subset of the fitted data, which is the case this check is most likely to reject by mistake, so the boundary sits in one place. Removing `validate_ldf` from both call sites fails exactly the five rejection tests; the two that assert a flow still works pass either way, which is what they are for. `test_predict_checks_before_the_index_is_borrowed` fails on its own if the call is moved back after the addition, so the ordering above is held by a test rather than by a comment.
- `pytest chainladder` passes: 1156 passed, 7 skipped, against 1142 and 7 on `main`. The fourteen are the seven new tests across both backend parametrisations; no existing test changes behaviour.
- `ruff check --force-exclude --config lint.per-file-ignores={}` reports the same 15 findings on these three files before and after, and `ruff format --check` reports the same hunks line for line.
- `CapeCod` calls `validate_ldf` as well. For the finer-`ldf_` case that call is the only thing between the caller and a raw numpy error inside `_get_capecod_aprioris`, which runs before `MethodBase.predict` is reached. For the unseen-group case `MethodBase.predict` would catch it anyway through `super().predict`, just after CapeCod has done work it did not need to.
- One deliberate deviation: `validate_weight` next door uses a multi-line signature and `'''` docstrings, and `ruff format` wants neither. I wrote `validate_ldf` the way the formatter wants so it adds nothing to the format diff, rather than matching its neighbour.

## Declarations

I am adhering to the standards in the Governing Doc. I am a human contributor, not a bot, and I opened this because @henrydingliu asked for it on #1288.

AI disclosure, per the AI Usage Policy: I used Claude Code on this. It ran the reproductions across the estimators and all three directions, and found both the single-row case and the call-site ordering by running the suite against earlier attempts that were wrong in each of those ways. I reviewed the diff and the tests myself, and the suite was run locally on my machine.

