### PR TITLE
[FEAT] Add deprecation tools

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -10,7 +10,8 @@ chainladder-python/
 │   │
 │   ├── _config/                    # Package-wide configuration
 │   │   ├── options.py              # Datetime constants, package options
-│   │   └── deprecation.py          # Deprecation utilities
+│   │   ├── deprecation.py          # Deprecation utilities
+│   │   └── tests/
 │   │
 │   ├── core/                       # Triangle data structure
 │   │   ├── triangle.py             # Triangle (the public-facing class)

--- a/chainladder/__init__.py
+++ b/chainladder/__init__.py
@@ -32,6 +32,9 @@ from chainladder._config import (  # noqa (API import)
     _deprecated_backend_message,
     _dask_parallel_state,
     _warn_dask_parallel_deprecated,
+    deprecated_rename,
+    deprecated_rename_argument,
+    deprecated_drop_argument,
 )
 from chainladder.utils import (  # noqa (API import)
     WeightedRegression,

--- a/chainladder/__init__.py
+++ b/chainladder/__init__.py
@@ -32,9 +32,9 @@ from chainladder._config import (  # noqa (API import)
     _deprecated_backend_message,
     _dask_parallel_state,
     _warn_dask_parallel_deprecated,
-    deprecated_rename,
-    deprecated_rename_argument,
-    deprecated_drop_argument,
+    _deprecated_rename,
+    _deprecated_rename_argument,
+    _deprecated_drop_argument,
 )
 from chainladder.utils import (  # noqa (API import)
     WeightedRegression,

--- a/chainladder/_config/__init__.py
+++ b/chainladder/_config/__init__.py
@@ -6,7 +6,10 @@ from chainladder._config.deprecation import (
     _DEPRECATED_BACKENDS,
     _deprecated_backend_message,
     _dask_parallel_state,
-    _warn_dask_parallel_deprecated,  # noqa (API import)
+    _warn_dask_parallel_deprecated,
+    deprecated_rename,
+    deprecated_rename_argument,
+    deprecated_drop_argument,  # noqa (API import)
 )
 from chainladder._config.options import (
     __dt64_dtype__,
@@ -24,4 +27,7 @@ __all__: list[str] = [
     "_deprecated_backend_message",
     "_dask_parallel_state",
     "_warn_dask_parallel_deprecated",
+    "deprecated_rename",
+    "deprecated_rename_argument",
+    "deprecated_drop_argument",
 ]

--- a/chainladder/_config/__init__.py
+++ b/chainladder/_config/__init__.py
@@ -7,9 +7,9 @@ from chainladder._config.deprecation import (
     _deprecated_backend_message,
     _dask_parallel_state,
     _warn_dask_parallel_deprecated,
-    deprecated_rename,
-    deprecated_rename_argument,
-    deprecated_drop_argument,  # noqa (API import)
+    _deprecated_rename,
+    _deprecated_rename_argument,
+    _deprecated_drop_argument,  # noqa (API import)
 )
 from chainladder._config.options import (
     __dt64_dtype__,
@@ -27,7 +27,7 @@ __all__: list[str] = [
     "_deprecated_backend_message",
     "_dask_parallel_state",
     "_warn_dask_parallel_deprecated",
-    "deprecated_rename",
-    "deprecated_rename_argument",
-    "deprecated_drop_argument",
+    "_deprecated_rename",
+    "_deprecated_rename_argument",
+    "_deprecated_drop_argument",
 ]

--- a/chainladder/_config/deprecation.py
+++ b/chainladder/_config/deprecation.py
@@ -154,7 +154,7 @@ def _resolve_pat(
 _F = TypeVar("_F", bound="Callable[..., object]")
 
 
-def deprecated_rename(
+def _deprecated_rename(
     new_name: str,
     *,
     version: str | None = None,
@@ -187,9 +187,9 @@ def deprecated_rename(
     .. testcode::
         :options: +SKIP
 
-        from chainladder._config.deprecation import deprecated_rename
+        from chainladder._config.deprecation import _deprecated_rename
 
-        @deprecated_rename("new_func", version="0.11.0")
+        @_deprecated_rename("new_func", version="0.11.0")
         def old_func(x):
             return x + 1
 
@@ -219,7 +219,7 @@ def deprecated_rename(
     return decorator
 
 
-def deprecated_rename_argument(
+def _deprecated_rename_argument(
     old_name: str,
     new_name: str,
     *,
@@ -261,9 +261,9 @@ def deprecated_rename_argument(
     .. testcode::
         :options: +SKIP
 
-        from chainladder._config.deprecation import deprecated_rename_argument
+        from chainladder._config.deprecation import _deprecated_rename_argument
 
-        @deprecated_rename_argument("old_arg", "new_arg", version="0.11.0")
+        @_deprecated_rename_argument("old_arg", "new_arg", version="0.11.0")
         def func(new_arg):
             return new_arg + 1
 
@@ -298,7 +298,7 @@ def deprecated_rename_argument(
     return decorator
 
 
-def deprecated_drop_argument(
+def _deprecated_drop_argument(
     name: str,
     *,
     version: str | None = None,
@@ -330,9 +330,9 @@ def deprecated_drop_argument(
     .. testcode::
         :options: +SKIP
 
-        from chainladder._config.deprecation import deprecated_drop_argument
+        from chainladder._config.deprecation import _deprecated_drop_argument
 
-        @deprecated_drop_argument("verbose", version="0.11.0")
+        @_deprecated_drop_argument("verbose", version="0.11.0")
         def func(x, verbose=False):
             return x + 1
 

--- a/chainladder/_config/deprecation.py
+++ b/chainladder/_config/deprecation.py
@@ -7,14 +7,15 @@ Utilities for deprecating chainladder features.
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 from __future__ import annotations
 
+import functools
 import inspect
 import warnings
 
-from typing import overload, TYPE_CHECKING
+from typing import overload, TYPE_CHECKING, TypeVar
 
 if TYPE_CHECKING:
     from types import FrameType
-    from typing import Literal
+    from typing import Callable, Literal
 del TYPE_CHECKING
 del annotations
 
@@ -147,3 +148,213 @@ def _resolve_pat(
             caller: str = f_back.f_code.co_name
         raise TypeError(f"{caller}() missing required argument: 'pat'.")
     return pat
+
+
+# Type variable ensures that decorated functions maintain their signatures.
+_F = TypeVar("_F", bound="Callable[..., object]")
+
+
+def deprecated_rename(
+    new_name: str,
+    *,
+    version: str | None = None,
+    category: type[Warning] = FutureWarning,
+) -> Callable[[_F], _F]:
+    """
+    Decorator factory that marks a function as scheduled to be renamed.
+
+    Calling the decorated function will emit a warning that the function will be renamed in a future release.
+
+    Parameters
+    ----------
+    new_name: str
+        The name this function will be renamed to.
+    version: str | None
+        The release the rename is expected to land in, e.g. "0.11.0".
+        Included in the warning message when given. Optional.
+    category: type[Warning]
+        The warning category to emit. Defaults to FutureWarning.
+
+    Returns
+    -------
+    Callable
+        A decorator that wraps a function, preserving its name, docstring,
+        and signature.
+
+    Examples
+    --------
+
+    .. testcode::
+        :options: +SKIP
+
+        from chainladder._config.deprecation import deprecated_rename
+
+        @deprecated_rename("new_func", version="0.11.0")
+        def old_func(x):
+            return x + 1
+
+        old_func(1)
+
+    .. testoutput::
+
+        example.py:8: FutureWarning: 'old_func' is deprecated and will be renamed to 'new_func' in 0.11.0. Update your code to use 'new_func' instead.
+          old_func(1)
+
+    """
+
+    def decorator(func: _F) -> _F:
+        old_name = func.__name__
+        message = f"'{old_name}' is deprecated and will be renamed to '{new_name}'"
+        if version:
+            message += f" in {version}"
+        message += f". Update your code to use '{new_name}' instead."
+
+        @functools.wraps(func)
+        def wrapper(*args, **kwargs):
+            warnings.warn(message, category, stacklevel=2)  # noqa
+            return func(*args, **kwargs)
+
+        return wrapper  # type: ignore[return-value]
+
+    return decorator
+
+
+def deprecated_rename_argument(
+    old_name: str,
+    new_name: str,
+    *,
+    version: str | None = None,
+    category: type[Warning] = FutureWarning,
+) -> Callable[[_F], _F]:
+    """
+    Decorator factory that marks a keyword argument as scheduled to be
+    renamed.
+
+    Apply this to a function while it still accepts the argument under its
+    *current* name, to warn callers ahead of the actual rename.
+
+    This decorator allows you to replace the old argument with the new argument
+    in the function signature. Once you are ready to deprecate, simply remove the
+    decorator.
+
+    Parameters
+    ----------
+    old_name: str
+        The keyword argument name the function currently accepts.
+    new_name: str
+        The keyword argument name it will be renamed to.
+    version: str | None
+        The release the rename is expected to land in, e.g. "0.11.0".
+        Included in the warning message when given. Optional.
+    category: type[Warning]
+        The warning category to emit. Defaults to FutureWarning.
+
+    Returns
+    -------
+    Callable
+        A decorator that wraps a function, preserving its name, docstring,
+        and signature via functools.wraps.
+
+    Examples
+    --------
+
+    .. testcode::
+        :options: +SKIP
+
+        from chainladder._config.deprecation import deprecated_rename_argument
+
+        @deprecated_rename_argument("old_arg", "new_arg", version="0.11.0")
+        def func(new_arg):
+            return new_arg + 1
+
+        print(func(old_arg=1))
+
+    .. testoutput::
+
+        example.py:8: FutureWarning: 'old_arg' is deprecated and will be renamed to 'new_arg' in 0.11.0. Use 'new_arg' instead.
+          func(old_arg=1)
+
+    """
+
+    def decorator(func: _F) -> _F:
+        message = f"'{old_name}' is deprecated and will be renamed to '{new_name}'"
+        if version:
+            message += f" in {version}"
+        message += f". Use '{new_name}' instead."
+
+        @functools.wraps(func)
+        def wrapper(*args, **kwargs):
+            if old_name in kwargs:
+                if new_name in kwargs:
+                    raise TypeError(
+                        f"Cannot specify both '{old_name}' and '{new_name}'."
+                    )
+                warnings.warn(message, category, stacklevel=2)  # noqa
+                kwargs[new_name] = kwargs.pop(old_name)
+            return func(*args, **kwargs)
+
+        return wrapper  # type: ignore[return-value]
+
+    return decorator
+
+
+def deprecated_drop_argument(
+    name: str,
+    *,
+    version: str | None = None,
+    category: type[Warning] = FutureWarning,
+) -> Callable[[_F], _F]:
+    """
+    Decorator factory that marks a keyword argument as scheduled for removal,
+    with no replacement.
+
+    Parameters
+    ----------
+    name: str
+        The keyword argument scheduled for removal.
+    version: str | None
+        The release the removal is expected to land in, e.g. "0.11.0".
+        Included in the warning message when given. Optional.
+    category: type[Warning]
+        The warning category to emit. Defaults to FutureWarning.
+
+    Returns
+    -------
+    Callable
+        A decorator that wraps a function, preserving its name, docstring,
+        and signature via functools.wraps.
+
+    Examples
+    --------
+
+    .. testcode::
+        :options: +SKIP
+
+        from chainladder._config.deprecation import deprecated_drop_argument
+
+        @deprecated_drop_argument("verbose", version="0.11.0")
+        def func(x, verbose=False):
+            return x + 1
+
+        print(func(1, verbose=True))
+
+    .. testoutput::
+
+        example.py:8: FutureWarning: 'verbose' is deprecated and will be removed in 0.11.0.
+          func(1, verbose=True)
+
+    """
+
+    def decorator(func: _F) -> _F:
+        message = f"'{name}' is deprecated and will be removed"
+        message += f" in {version}." if version else " in a future release."
+
+        @functools.wraps(func)
+        def wrapper(*args, **kwargs):
+            if name in kwargs:
+                warnings.warn(message, category, stacklevel=2)  # noqa
+            return func(*args, **kwargs)
+
+        return wrapper  # type: ignore[return-value]
+
+    return decorator

--- a/chainladder/_config/tests/test_deprecation.py
+++ b/chainladder/_config/tests/test_deprecation.py
@@ -1,6 +1,7 @@
 """
 Test the deprecation tools.
 """
+
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
@@ -11,9 +12,9 @@ import warnings
 import pytest
 
 from chainladder._config.deprecation import (
-    deprecated_drop_argument,
-    deprecated_rename,
-    deprecated_rename_argument,
+    _deprecated_drop_argument,
+    _deprecated_rename,
+    _deprecated_rename_argument,
 )
 
 
@@ -29,12 +30,12 @@ def _warn_once(func, *args, **kwargs) -> tuple[object, warnings.WarningMessage]:
 
 
 class TestDeprecatedRename:
-    """Test the deprecated_rename decorator."""
+    """Test the _deprecated_rename decorator."""
 
     def test_warns_default_category(self) -> None:
         """Check that the default warning category is FutureWarning."""
 
-        @deprecated_rename("new_func")
+        @_deprecated_rename("new_func")
         def old_func(x):
             return x + 1
 
@@ -45,7 +46,7 @@ class TestDeprecatedRename:
     def test_message_with_version(self) -> None:
         """Check the warning message when a version is given."""
 
-        @deprecated_rename("new_func", version="0.11.0")
+        @_deprecated_rename("new_func", version="0.11.0")
         def old_func():
             pass
 
@@ -58,7 +59,7 @@ class TestDeprecatedRename:
     def test_message_without_version(self) -> None:
         """Check the warning message when no version is given."""
 
-        @deprecated_rename("new_func")
+        @_deprecated_rename("new_func")
         def old_func():
             pass
 
@@ -71,7 +72,7 @@ class TestDeprecatedRename:
     def test_custom_category(self) -> None:
         """Check that a custom warning category is honored."""
 
-        @deprecated_rename("new_func", category=DeprecationWarning)
+        @_deprecated_rename("new_func", category=DeprecationWarning)
         def old_func():
             pass
 
@@ -81,7 +82,7 @@ class TestDeprecatedRename:
     def test_forwards_args_and_kwargs(self) -> None:
         """Check that positional and keyword arguments reach the wrapped function unchanged."""
 
-        @deprecated_rename("new_func")
+        @_deprecated_rename("new_func")
         def old_func(a, b, *, c):
             return a, b, c
 
@@ -92,7 +93,7 @@ class TestDeprecatedRename:
     def test_preserves_metadata(self) -> None:
         """Check that functools.wraps preserves the function's name and docstring."""
 
-        @deprecated_rename("new_func")
+        @_deprecated_rename("new_func")
         def old_func():
             """Original docstring."""
 
@@ -102,7 +103,7 @@ class TestDeprecatedRename:
     def test_warns_every_call(self) -> None:
         """Check that the warning fires on every call, not just the first."""
 
-        @deprecated_rename("new_func")
+        @_deprecated_rename("new_func")
         def old_func():
             pass
 
@@ -115,12 +116,12 @@ class TestDeprecatedRename:
 
 
 class TestDeprecatedRenameArgument:
-    """Tests for the deprecated_rename_argument decorator."""
+    """Tests for the _deprecated_rename_argument decorator."""
 
     def test_old_name_translates_and_warns(self) -> None:
         """Check that the old argument name is translated to the new one and warns."""
 
-        @deprecated_rename_argument("old_arg", "new_arg")
+        @_deprecated_rename_argument("old_arg", "new_arg")
         def func(new_arg):
             return new_arg
 
@@ -131,7 +132,7 @@ class TestDeprecatedRenameArgument:
     def test_new_name_no_warning(self) -> None:
         """Check that calling with the new argument name alone doesn't warn."""
 
-        @deprecated_rename_argument("old_arg", "new_arg")
+        @_deprecated_rename_argument("old_arg", "new_arg")
         def func(new_arg):
             return new_arg
 
@@ -145,7 +146,7 @@ class TestDeprecatedRenameArgument:
     def test_neither_name_uses_default_no_warning(self) -> None:
         """Check that omitting both names falls back to the default without warning."""
 
-        @deprecated_rename_argument("old_arg", "new_arg")
+        @_deprecated_rename_argument("old_arg", "new_arg")
         def func(new_arg="default"):
             return new_arg
 
@@ -159,7 +160,7 @@ class TestDeprecatedRenameArgument:
     def test_both_names_raises_type_error(self) -> None:
         """Check that passing both the old and new names raises a TypeError."""
 
-        @deprecated_rename_argument("old_arg", "new_arg")
+        @_deprecated_rename_argument("old_arg", "new_arg")
         def func(new_arg=None):
             return new_arg
 
@@ -172,7 +173,7 @@ class TestDeprecatedRenameArgument:
     def test_message_with_version(self) -> None:
         """Check the warning message when a version is given."""
 
-        @deprecated_rename_argument("old_arg", "new_arg", version="0.11.0")
+        @_deprecated_rename_argument("old_arg", "new_arg", version="0.11.0")
         def func(new_arg=None):
             return new_arg
 
@@ -185,7 +186,7 @@ class TestDeprecatedRenameArgument:
     def test_message_without_version(self) -> None:
         """Check the warning message when no version is given."""
 
-        @deprecated_rename_argument("old_arg", "new_arg")
+        @_deprecated_rename_argument("old_arg", "new_arg")
         def func(new_arg=None):
             return new_arg
 
@@ -198,7 +199,7 @@ class TestDeprecatedRenameArgument:
     def test_custom_category(self) -> None:
         """Check that a custom warning category is honored."""
 
-        @deprecated_rename_argument("old_arg", "new_arg", category=DeprecationWarning)
+        @_deprecated_rename_argument("old_arg", "new_arg", category=DeprecationWarning)
         def func(new_arg=None):
             return new_arg
 
@@ -209,7 +210,7 @@ class TestDeprecatedRenameArgument:
     def test_positional_args_unaffected(self) -> None:
         """Check that positional arguments pass through unaffected."""
 
-        @deprecated_rename_argument("old_arg", "new_arg")
+        @_deprecated_rename_argument("old_arg", "new_arg")
         def func(a, b, new_arg=None):
             return a, b, new_arg
 
@@ -224,7 +225,7 @@ class TestDeprecatedRenameArgument:
     def test_preserves_metadata(self) -> None:
         """Check that functools.wraps preserves the function's name and docstring."""
 
-        @deprecated_rename_argument("old_arg", "new_arg")
+        @_deprecated_rename_argument("old_arg", "new_arg")
         def func(new_arg=None):  # noqa
             """Original docstring."""
 
@@ -234,7 +235,7 @@ class TestDeprecatedRenameArgument:
     def test_warns_every_call(self) -> None:
         """Check that the warning fires on every call, not just the first."""
 
-        @deprecated_rename_argument("old_arg", "new_arg")
+        @_deprecated_rename_argument("old_arg", "new_arg")
         def func(new_arg=None):
             return new_arg
 
@@ -249,12 +250,12 @@ class TestDeprecatedRenameArgument:
 
 
 class TestDeprecatedDropArgument:
-    """Tests for the deprecated_drop_argument decorator."""
+    """Tests for the _deprecated_drop_argument decorator."""
 
     def test_warns_and_forwards_value_unchanged(self) -> None:
         """Check that the deprecated argument still reaches the function unchanged."""
 
-        @deprecated_drop_argument("verbose")
+        @_deprecated_drop_argument("verbose")
         def func(x, verbose: bool = False):
             return x, verbose
 
@@ -265,7 +266,7 @@ class TestDeprecatedDropArgument:
     def test_not_passed_no_warning(self) -> None:
         """Check that omitting the deprecated argument doesn't warn."""
 
-        @deprecated_drop_argument("verbose")
+        @_deprecated_drop_argument("verbose")
         def func(x, verbose: bool = False):
             return x, verbose
 
@@ -279,7 +280,7 @@ class TestDeprecatedDropArgument:
     def test_message_with_version(self) -> None:
         """Check the warning message when a version is given."""
 
-        @deprecated_drop_argument("verbose", version="0.11.0")
+        @_deprecated_drop_argument("verbose", version="0.11.0")
         def func(verbose: bool = False):  # noqa
             pass
 
@@ -291,8 +292,8 @@ class TestDeprecatedDropArgument:
     def test_message_without_version(self) -> None:
         """Check the warning message when no version is given."""
 
-        @deprecated_drop_argument("verbose")
-        def func(verbose: bool = False): # noqa
+        @_deprecated_drop_argument("verbose")
+        def func(verbose: bool = False):  # noqa
             pass
 
         _, warning = _warn_once(func, verbose=True)
@@ -303,8 +304,8 @@ class TestDeprecatedDropArgument:
     def test_custom_category(self) -> None:
         """Check that a custom warning category is honored."""
 
-        @deprecated_drop_argument("verbose", category=DeprecationWarning)
-        def func(verbose: bool = False): # noqa
+        @_deprecated_drop_argument("verbose", category=DeprecationWarning)
+        def func(verbose: bool = False):  # noqa
             pass
 
         with pytest.warns(DeprecationWarning):
@@ -313,7 +314,7 @@ class TestDeprecatedDropArgument:
     def test_positional_args_unaffected(self) -> None:
         """Check that positional arguments pass through unaffected."""
 
-        @deprecated_drop_argument("verbose")
+        @_deprecated_drop_argument("verbose")
         def func(a, b, verbose: bool = False):
             return a, b, verbose
 
@@ -327,7 +328,7 @@ class TestDeprecatedDropArgument:
     def test_preserves_metadata(self) -> None:
         """Check that functools.wraps preserves the function's name and docstring."""
 
-        @deprecated_drop_argument("verbose")
+        @_deprecated_drop_argument("verbose")
         def func(verbose: bool = False):  # noqa
             """Original docstring."""
 
@@ -337,7 +338,7 @@ class TestDeprecatedDropArgument:
     def test_warns_every_call(self) -> None:
         """Check that the warning fires on every call, not just the first."""
 
-        @deprecated_drop_argument("verbose")
+        @_deprecated_drop_argument("verbose")
         def func(verbose: bool = False):  # noqa
             pass
 

--- a/chainladder/_config/tests/test_deprecation.py
+++ b/chainladder/_config/tests/test_deprecation.py
@@ -1,0 +1,349 @@
+"""
+Test the deprecation tools.
+"""
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+from __future__ import annotations
+
+import warnings
+
+import pytest
+
+from chainladder._config.deprecation import (
+    deprecated_drop_argument,
+    deprecated_rename,
+    deprecated_rename_argument,
+)
+
+
+def _warn_once(func, *args, **kwargs) -> tuple[object, warnings.WarningMessage]:
+    """Calls func and returns (result, the single warning recorded)."""
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        result = func(*args, **kwargs)
+    assert caught is not None
+    # Check that the warning was triggered.
+    assert len(caught) == 1
+    return result, caught[0]
+
+
+class TestDeprecatedRename:
+    """Test the deprecated_rename decorator."""
+
+    def test_warns_default_category(self) -> None:
+        """Check that the default warning category is FutureWarning."""
+
+        @deprecated_rename("new_func")
+        def old_func(x):
+            return x + 1
+
+        result, warning = _warn_once(old_func, 1)
+        assert result == 2
+        assert warning.category is FutureWarning
+
+    def test_message_with_version(self) -> None:
+        """Check the warning message when a version is given."""
+
+        @deprecated_rename("new_func", version="0.11.0")
+        def old_func():
+            pass
+
+        _, warning = _warn_once(old_func)
+        assert str(warning.message) == (
+            "'old_func' is deprecated and will be renamed to 'new_func' in "
+            "0.11.0. Update your code to use 'new_func' instead."
+        )
+
+    def test_message_without_version(self) -> None:
+        """Check the warning message when no version is given."""
+
+        @deprecated_rename("new_func")
+        def old_func():
+            pass
+
+        _, warning = _warn_once(old_func)
+        assert str(warning.message) == (
+            "'old_func' is deprecated and will be renamed to 'new_func'. "
+            "Update your code to use 'new_func' instead."
+        )
+
+    def test_custom_category(self) -> None:
+        """Check that a custom warning category is honored."""
+
+        @deprecated_rename("new_func", category=DeprecationWarning)
+        def old_func():
+            pass
+
+        with pytest.warns(DeprecationWarning):
+            old_func()
+
+    def test_forwards_args_and_kwargs(self) -> None:
+        """Check that positional and keyword arguments reach the wrapped function unchanged."""
+
+        @deprecated_rename("new_func")
+        def old_func(a, b, *, c):
+            return a, b, c
+
+        with warnings.catch_warnings():  # noqa
+            warnings.simplefilter("ignore")
+            assert old_func(1, 2, c=3) == (1, 2, 3)
+
+    def test_preserves_metadata(self) -> None:
+        """Check that functools.wraps preserves the function's name and docstring."""
+
+        @deprecated_rename("new_func")
+        def old_func():
+            """Original docstring."""
+
+        assert old_func.__name__ == "old_func"
+        assert old_func.__doc__ == "Original docstring."
+
+    def test_warns_every_call(self) -> None:
+        """Check that the warning fires on every call, not just the first."""
+
+        @deprecated_rename("new_func")
+        def old_func():
+            pass
+
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            old_func()
+            old_func()
+        assert caught is not None
+        assert len(caught) == 2
+
+
+class TestDeprecatedRenameArgument:
+    """Tests for the deprecated_rename_argument decorator."""
+
+    def test_old_name_translates_and_warns(self) -> None:
+        """Check that the old argument name is translated to the new one and warns."""
+
+        @deprecated_rename_argument("old_arg", "new_arg")
+        def func(new_arg):
+            return new_arg
+
+        result, warning = _warn_once(func, old_arg=1)
+        assert result == 1
+        assert warning.category is FutureWarning
+
+    def test_new_name_no_warning(self) -> None:
+        """Check that calling with the new argument name alone doesn't warn."""
+
+        @deprecated_rename_argument("old_arg", "new_arg")
+        def func(new_arg):
+            return new_arg
+
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            result = func(new_arg=1)
+        assert result == 1
+        assert caught is not None
+        assert len(caught) == 0
+
+    def test_neither_name_uses_default_no_warning(self) -> None:
+        """Check that omitting both names falls back to the default without warning."""
+
+        @deprecated_rename_argument("old_arg", "new_arg")
+        def func(new_arg="default"):
+            return new_arg
+
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            result = func()
+        assert result == "default"
+        assert caught is not None
+        assert len(caught) == 0
+
+    def test_both_names_raises_type_error(self) -> None:
+        """Check that passing both the old and new names raises a TypeError."""
+
+        @deprecated_rename_argument("old_arg", "new_arg")
+        def func(new_arg=None):
+            return new_arg
+
+        with pytest.raises(
+            TypeError, match="Cannot specify both 'old_arg' and 'new_arg'"
+        ):
+            # noinspection PyArgumentList
+            func(old_arg=1, new_arg=2)  # pyright: ignore[reportCallIssue]
+
+    def test_message_with_version(self) -> None:
+        """Check the warning message when a version is given."""
+
+        @deprecated_rename_argument("old_arg", "new_arg", version="0.11.0")
+        def func(new_arg=None):
+            return new_arg
+
+        _, warning = _warn_once(func, old_arg=1)
+        assert str(warning.message) == (
+            "'old_arg' is deprecated and will be renamed to 'new_arg' in "
+            "0.11.0. Use 'new_arg' instead."
+        )
+
+    def test_message_without_version(self) -> None:
+        """Check the warning message when no version is given."""
+
+        @deprecated_rename_argument("old_arg", "new_arg")
+        def func(new_arg=None):
+            return new_arg
+
+        _, warning = _warn_once(func, old_arg=1)
+        assert str(warning.message) == (
+            "'old_arg' is deprecated and will be renamed to 'new_arg'. "
+            "Use 'new_arg' instead."
+        )
+
+    def test_custom_category(self) -> None:
+        """Check that a custom warning category is honored."""
+
+        @deprecated_rename_argument("old_arg", "new_arg", category=DeprecationWarning)
+        def func(new_arg=None):
+            return new_arg
+
+        with pytest.warns(DeprecationWarning):
+            # noinspection PyArgumentList
+            func(old_arg=1)  # pyright: ignore[reportCallIssue]
+
+    def test_positional_args_unaffected(self) -> None:
+        """Check that positional arguments pass through unaffected."""
+
+        @deprecated_rename_argument("old_arg", "new_arg")
+        def func(a, b, new_arg=None):
+            return a, b, new_arg
+
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            # noinspection PyArgumentList
+            result = func(1, 2, old_arg=3)  # pyright: ignore[reportCallIssue]
+        assert result == (1, 2, 3)
+        assert caught is not None
+        assert len(caught) == 1
+
+    def test_preserves_metadata(self) -> None:
+        """Check that functools.wraps preserves the function's name and docstring."""
+
+        @deprecated_rename_argument("old_arg", "new_arg")
+        def func(new_arg=None):  # noqa
+            """Original docstring."""
+
+        assert func.__name__ == "func"
+        assert func.__doc__ == "Original docstring."
+
+    def test_warns_every_call(self) -> None:
+        """Check that the warning fires on every call, not just the first."""
+
+        @deprecated_rename_argument("old_arg", "new_arg")
+        def func(new_arg=None):
+            return new_arg
+
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            # noinspection PyArgumentList
+            func(old_arg=1)  # pyright: ignore[reportCallIssue]
+            # noinspection PyArgumentList
+            func(old_arg=2)  # pyright: ignore[reportCallIssue]
+        assert caught is not None
+        assert len(caught) == 2
+
+
+class TestDeprecatedDropArgument:
+    """Tests for the deprecated_drop_argument decorator."""
+
+    def test_warns_and_forwards_value_unchanged(self) -> None:
+        """Check that the deprecated argument still reaches the function unchanged."""
+
+        @deprecated_drop_argument("verbose")
+        def func(x, verbose: bool = False):
+            return x, verbose
+
+        result, warning = _warn_once(func, 1, verbose=True)
+        assert result == (1, True)
+        assert warning.category is FutureWarning
+
+    def test_not_passed_no_warning(self) -> None:
+        """Check that omitting the deprecated argument doesn't warn."""
+
+        @deprecated_drop_argument("verbose")
+        def func(x, verbose: bool = False):
+            return x, verbose
+
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            result = func(1)
+        assert result == (1, False)
+        assert caught is not None
+        assert len(caught) == 0
+
+    def test_message_with_version(self) -> None:
+        """Check the warning message when a version is given."""
+
+        @deprecated_drop_argument("verbose", version="0.11.0")
+        def func(verbose: bool = False):  # noqa
+            pass
+
+        _, warning = _warn_once(func, verbose=True)
+        assert str(warning.message) == (
+            "'verbose' is deprecated and will be removed in 0.11.0."
+        )
+
+    def test_message_without_version(self) -> None:
+        """Check the warning message when no version is given."""
+
+        @deprecated_drop_argument("verbose")
+        def func(verbose: bool = False): # noqa
+            pass
+
+        _, warning = _warn_once(func, verbose=True)
+        assert str(warning.message) == (
+            "'verbose' is deprecated and will be removed in a future release."
+        )
+
+    def test_custom_category(self) -> None:
+        """Check that a custom warning category is honored."""
+
+        @deprecated_drop_argument("verbose", category=DeprecationWarning)
+        def func(verbose: bool = False): # noqa
+            pass
+
+        with pytest.warns(DeprecationWarning):
+            func(verbose=True)
+
+    def test_positional_args_unaffected(self) -> None:
+        """Check that positional arguments pass through unaffected."""
+
+        @deprecated_drop_argument("verbose")
+        def func(a, b, verbose: bool = False):
+            return a, b, verbose
+
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            result = func(1, 2, verbose=True)
+        assert result == (1, 2, True)
+        assert caught is not None
+        assert len(caught) == 1
+
+    def test_preserves_metadata(self) -> None:
+        """Check that functools.wraps preserves the function's name and docstring."""
+
+        @deprecated_drop_argument("verbose")
+        def func(verbose: bool = False):  # noqa
+            """Original docstring."""
+
+        assert func.__name__ == "func"
+        assert func.__doc__ == "Original docstring."
+
+    def test_warns_every_call(self) -> None:
+        """Check that the warning fires on every call, not just the first."""
+
+        @deprecated_drop_argument("verbose")
+        def func(verbose: bool = False):  # noqa
+            pass
+
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            func(verbose=True)
+            func(verbose=True)
+        assert caught is not None
+        assert len(caught) == 2


### PR DESCRIPTION
## Summary of Changes  

Needed to close #1316.

Adds three generalized deprecation tools:

- Rename a function
- Rename a function argument
- Drop an argument

This simplifies the deprecation process by allowing contributors to simply mark a feature with a decorator.

This enables a standardized way of marking features for deprecation, and enables us to run checks prior to releasing new versions that we actually deprecated the things we said we would.

## Related GitHub Issue(s)  

#1320 
#1321 
#1322 

## Additional Context for Reviewers  




<!-- Do not edit anything below this. -->

## Checklist
- [x] I passed tests locally for both code (`uv run pytest`) and documentation changes (`uv run --directory docs jb build . --builder=custom --custom-builder=doctest`)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds internal deprecation helpers and tests only; runtime behavior of the library is unchanged until decorators are applied to specific APIs.
> 
> **Overview**
> Introduces **three decorator factories** in `chainladder/_config/deprecation.py` for a consistent deprecation workflow: `_deprecated_rename` (warn when an old function name is called), `_deprecated_rename_argument` (map old kwargs to new names with a warning, reject both), and `_deprecated_drop_argument` (warn when a kwarg slated for removal is used). Each supports optional target version and warning category, uses `functools.wraps`, and emits `FutureWarning` by default.
> 
> The helpers are **re-exported** from `chainladder._config` and the top-level `chainladder` package alongside existing deprecation utilities. **ARCHITECTURE.md** now documents `chainladder/_config/tests/`. A new **`test_deprecation.py`** suite covers warning text, categories, argument forwarding, metadata preservation, and repeat-call behavior.
> 
> No existing public APIs are wired to these decorators in this PR; this is foundational tooling for upcoming deprecations (e.g. issues #1320–#1322).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a4e1e3235324c825a7b488918f1c8c83cda306e6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->