### PR TITLE
[CHORE] Ruff fix for test_display

### DIFF
--- a/chainladder/core/tests/test_display.py
+++ b/chainladder/core/tests/test_display.py
@@ -379,7 +379,7 @@ def test_heatmap_render(raa):
     try:
         raa.heatmap()
 
-    except:
+    except Exception:
         assert False
 
 
@@ -392,7 +392,7 @@ def test_to_frame(raa):
         cl.Chainladder().fit(raa).ultimate_.to_frame(origin_as_datetime=False)
         cl.Chainladder().fit(raa).ultimate_.to_frame(origin_as_datetime=True)
 
-    except:
+    except Exception:
         assert False
 
 

--- a/chainladder/core/tests/test_display.py
+++ b/chainladder/core/tests/test_display.py
@@ -371,24 +371,16 @@ def test_display_import_fallback_when_ipython_missing() -> None:
 
 def test_heatmap_render(raa):
     """The heatmap method should render correctly given the sample."""
-    try:
-        raa.heatmap()
-
-    except Exception:
-        assert False
+    raa.heatmap()
 
 
 def test_to_frame(raa):
-    try:
-        cl.Chainladder().fit(raa).cdf_.to_frame()
-        cl.Chainladder().fit(raa).cdf_.to_frame(origin_as_datetime=False)
-        cl.Chainladder().fit(raa).cdf_.to_frame(origin_as_datetime=True)
-        cl.Chainladder().fit(raa).ultimate_.to_frame()
-        cl.Chainladder().fit(raa).ultimate_.to_frame(origin_as_datetime=False)
-        cl.Chainladder().fit(raa).ultimate_.to_frame(origin_as_datetime=True)
-
-    except Exception:
-        assert False
+    cl.Chainladder().fit(raa).cdf_.to_frame()
+    cl.Chainladder().fit(raa).cdf_.to_frame(origin_as_datetime=False)
+    cl.Chainladder().fit(raa).cdf_.to_frame(origin_as_datetime=True)
+    cl.Chainladder().fit(raa).ultimate_.to_frame()
+    cl.Chainladder().fit(raa).ultimate_.to_frame(origin_as_datetime=False)
+    cl.Chainladder().fit(raa).ultimate_.to_frame(origin_as_datetime=True)
 
 
 def test_labels(xyz):

--- a/chainladder/core/tests/test_display.py
+++ b/chainladder/core/tests/test_display.py
@@ -39,6 +39,7 @@ def check_html(html: str) -> None:
     # Raise assertion error if one is detected. If so, print the error log as a list.
     assert len(parser.error_log) == 0, list(parser.error_log)
 
+
 def test_check_html() -> None:
     """
     Make sure check_html does its job on a malformed string.
@@ -182,6 +183,7 @@ def test_repr_html_single(raa):
     assert "<table" in html_str
     check_html(html=html_str)
 
+
 def test_repr_html_multi(clrd: Triangle) -> None:
     """
     Inspect the HTML representation of a multidimensional triangle.
@@ -200,6 +202,7 @@ def test_repr_html_multi(clrd: Triangle) -> None:
     assert "Triangle Summary" in html_str
     assert "<table" in html_str
     check_html(html=html_str)
+
 
 def test_get_format_str_all_nan() -> None:
     """
@@ -337,11 +340,7 @@ def test_heatmap_no_ipython(raa: Triangle) -> None:
     """
     import chainladder.core.display as display_mod
 
-    blocked = {
-        "IPython": None,
-        "IPython.core": None,
-        "IPython.core.display": None
-    }
+    blocked = {"IPython": None, "IPython.core": None, "IPython.core.display": None}
     with mock.patch.dict(sys.modules, blocked):
         importlib.reload(display_mod)
         with pytest.raises(ImportError, match=r"heatmap\(\) requires IPython\."):
@@ -361,11 +360,7 @@ def test_display_import_fallback_when_ipython_missing() -> None:
     """
     import chainladder.core.display as display_mod
 
-    blocked = {
-        "IPython": None,
-        "IPython.core": None,
-        "IPython.core.display": None
-    }
+    blocked = {"IPython": None, "IPython.core": None, "IPython.core.display": None}
     with mock.patch.dict(sys.modules, blocked):
         importlib.reload(display_mod)
         assert display_mod.HTML is None

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -113,10 +113,8 @@ select = ["E2", "E4", "E7", "E9", "F", "B018", "UP034", "N802"]
 # check can be required without blocking unrelated PRs. Remove entries as
 # files are cleaned up.
 [tool.ruff.lint.per-file-ignores]
-"chainladder/core/tests/test_display.py" = ["E722"]
 "docs/friedland/chapter_10.ipynb" = ["E731", "F841"]
 "docs/friedland/chapter_7_part_2.ipynb" = ["N802"]
-"docs/friedland/chapter_9.ipynb" = ["E731"]
 
 [tool.ruff.format]
 docstring-code-format = true


### PR DESCRIPTION
## Summary of Changes  


## Related GitHub Issue(s)  
#1216

## Additional Context for Reviewers  




<!-- Do not edit anything below this. -->

## Checklist
- [ ] I passed tests locally for both code (`uv run pytest`) and documentation changes (`uv run --directory docs jb build . --builder=custom --custom-builder=doctest`)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only and lint-config changes with no production behavior impact.
> 
> **Overview**
> Brings **`chainladder/core/tests/test_display.py`** in line with Ruff by removing bare `except:` blocks in `test_heatmap_render` and `test_to_frame` so failures surface as normal test exceptions instead of a generic `assert False`.
> 
> Minor formatting tweaks (blank lines, one-line `blocked` dicts) accompany that cleanup.
> 
> **`pyproject.toml`** drops the grandfathered Ruff per-file ignores for `test_display.py` (`E722`) and `docs/friedland/chapter_9.ipynb` (`E731`) now that the display tests no longer need the exemption.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 06b2d6a13b5766df0bc6ab3c9900f8991a2feb6b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->