### PR TITLE
[CHORE] Ruff fix for test_learning

### DIFF
--- a/chainladder/development/tests/test_learning.py
+++ b/chainladder/development/tests/test_learning.py
@@ -4,71 +4,72 @@ from sklearn.pipeline import Pipeline
 from chainladder.utils.utility_functions import PatsyFormula
 import pandas as pd
 
+
 def test_incremental(genins):
     response = [genins.columns[0]]
     model = cl.DevelopmentML(
         Pipeline(
             steps=[
-                ('design_matrix', PatsyFormula('C(development)')),
-                ('model', LinearRegression(fit_intercept=False))
+                ("design_matrix", PatsyFormula("C(development)")),
+                ("model", LinearRegression(fit_intercept=False)),
             ]
         ),
         y_ml=response,
         fit_incrementals=False,
     ).fit(genins)
-    assert abs(model.triangle_ml_.loc[:, :, '2010', :] - genins.mean()).max() < 1e2
+    assert abs(model.triangle_ml_.loc[:, :, "2010", :] - genins.mean()).max() < 1e2
 
 
 def test_misc(genins):
     model = cl.DevelopmentML(
         Pipeline(
             steps=[
-                ('design_matrix', PatsyFormula('C(development)')),
-                ('model', LinearRegression(fit_intercept=False))
+                ("design_matrix", PatsyFormula("C(development)")),
+                ("model", LinearRegression(fit_intercept=False)),
             ]
         ),
-        weighted_step=['model'],
+        weighted_step=["model"],
         fit_incrementals=False,
     ).fit(genins, sample_weight=genins / genins)
-    assert abs(model.triangle_ml_.loc[:, :, '2010', :] - genins.mean()).max() < 1e2
+    assert abs(model.triangle_ml_.loc[:, :, "2010", :] - genins.mean()).max() < 1e2
 
 
 def test_grain():   
-    grains={'Y': 2, '2Q': 4, 'Q': 8, 'M': 24}
+    grains = {"Y": 2, "2Q": 4, "Q": 8, "M": 24}
     for period in grains.keys():
         tframe = pd.DataFrame()
-        devdates=pd.date_range(
-            start='2000-01-01', end='2002-01-01', freq=period + 'S', inclusive='left'
+        devdates = pd.date_range(
+            start="2000-01-01", end="2002-01-01", freq=period + "S", inclusive="left"
         )
         for ind, sdate in enumerate(devdates):
-            tframe=pd.concat([
+            tframe = pd.concat([
                 tframe,
                 pd.DataFrame({
-                    'origin': [sdate] * (len(devdates) - ind),
-                    'development': pd.date_range(
+                    "origin": [sdate] * (len(devdates) - ind),
+                    "development": pd.date_range(
                         start=sdate,
-                        end='2002-01-01',
-                        freq=period + 'S',
-                        inclusive='left',
+                        end="2002-01-01",
+                        freq=period + "S",
+                        inclusive="left",
                     ),
-                    'loss': [100] * (len(devdates) - ind),
+                    "loss": [100] * (len(devdates) - ind),
                 })
             ])
         tri = cl.Triangle(
             tframe,
-            origin='origin',
-            development='development',
-            columns='loss',
+            origin="origin",
+            development="development",
+            columns="loss",
             cumulative=False,
         )
         model = cl.DevelopmentML(
             Pipeline(
                 steps=[
-                    ('design_matrix', PatsyFormula('C(development)')),
-                    ('model', LinearRegression(fit_intercept=False)),
+                    ("design_matrix", PatsyFormula("C(development)")),
+                    ("model", LinearRegression(fit_intercept=False)),
                 ]
             ),
-            weighted_step = ['model'],
+            weighted_step=["model"],
             fit_incrementals=False,
         ).fit(tri)
         assert grains[period] == len(model.triangle_ml_.development)

--- a/chainladder/development/tests/test_learning.py
+++ b/chainladder/development/tests/test_learning.py
@@ -34,7 +34,7 @@ def test_misc(genins):
     assert abs(model.triangle_ml_.loc[:, :, "2010", :] - genins.mean()).max() < 1e2
 
 
-def test_grain():   
+def test_grain():
     grains = {"Y": 2, "2Q": 4, "Q": 8, "M": 24}
     for period in grains.keys():
         tframe = pd.DataFrame()
@@ -53,7 +53,7 @@ def test_grain():
                         inclusive="left",
                     ),
                     "loss": [100] * (len(devdates) - ind),
-                })
+                }),
             ])
         tri = cl.Triangle(
             tframe,

--- a/chainladder/development/tests/test_learning.py
+++ b/chainladder/development/tests/test_learning.py
@@ -8,13 +8,13 @@ def test_incremental(genins):
     response = [genins.columns[0]]
     model = cl.DevelopmentML(
         Pipeline(
-            steps = [
+            steps=[
                 ('design_matrix', PatsyFormula('C(development)')),
                 ('model', LinearRegression(fit_intercept=False))
             ]
         ),
         y_ml=response,
-        fit_incrementals=False
+        fit_incrementals=False,
     ).fit(genins)
     assert abs(model.triangle_ml_.loc[:, :, '2010', :] - genins.mean()).max() < 1e2
 
@@ -22,42 +22,54 @@ def test_incremental(genins):
 def test_misc(genins):
     model = cl.DevelopmentML(
         Pipeline(
-            steps = [
+            steps=[
                 ('design_matrix', PatsyFormula('C(development)')),
                 ('model', LinearRegression(fit_intercept=False))
             ]
         ),
-        weighted_step = ['model'],
-        fit_incrementals = False
-    ).fit(genins, sample_weight=genins/genins)
+        weighted_step=['model'],
+        fit_incrementals=False,
+    ).fit(genins, sample_weight=genins / genins)
     assert abs(model.triangle_ml_.loc[:, :, '2010', :] - genins.mean()).max() < 1e2
 
 
 def test_grain():   
-    grains={'Y': 2, '2Q': 4, 'Q': 8 ,'M': 24}
+    grains={'Y': 2, '2Q': 4, 'Q': 8, 'M': 24}
     for period in grains.keys():
         tframe = pd.DataFrame()
-        devdates=pd.date_range(start='2000-01-01', end='2002-01-01', freq=period+'S', inclusive='left')
+        devdates=pd.date_range(
+            start='2000-01-01', end='2002-01-01', freq=period + 'S', inclusive='left'
+        )
         for ind, sdate in enumerate(devdates):
-            tframe=pd.concat([tframe, pd.DataFrame({'origin': [sdate] * (len(devdates) - ind),
-            'development': pd.date_range(start=sdate, end='2002-01-01', freq=period + 'S', inclusive='left'),
-            'loss': [100] * (len(devdates) - ind)})])
+            tframe=pd.concat([
+                tframe,
+                pd.DataFrame({
+                    'origin': [sdate] * (len(devdates) - ind),
+                    'development': pd.date_range(
+                        start=sdate,
+                        end='2002-01-01',
+                        freq=period + 'S',
+                        inclusive='left',
+                    ),
+                    'loss': [100] * (len(devdates) - ind),
+                })
+            ])
         tri = cl.Triangle(
             tframe,
-            origin = 'origin',
-            development = 'development',
-            columns = 'loss',
-            cumulative = False,
+            origin='origin',
+            development='development',
+            columns='loss',
+            cumulative=False,
         )
         model = cl.DevelopmentML(
             Pipeline(
                 steps=[
                     ('design_matrix', PatsyFormula('C(development)')),
-                    ('model', LinearRegression(fit_intercept=False))
+                    ('model', LinearRegression(fit_intercept=False)),
                 ]
             ),
             weighted_step = ['model'],
-            fit_incrementals=False
+            fit_incrementals=False,
         ).fit(tri)
-        assert grains[period] == len(model.triangle_ml_.development) 
+        assert grains[period] == len(model.triangle_ml_.development)
         assert grains[period] == len(model.triangle_ml_.origin)

--- a/chainladder/development/tests/test_learning.py
+++ b/chainladder/development/tests/test_learning.py
@@ -6,32 +6,58 @@ import pandas as pd
 
 def test_incremental(genins):
     response = [genins.columns[0]]
-    model = cl.DevelopmentML(Pipeline(steps=[
-        ('design_matrix', PatsyFormula('C(development)')),
-        ('model', LinearRegression(fit_intercept=False))]),
-                y_ml=response,fit_incrementals=False).fit(genins)
-    assert abs(model.triangle_ml_.loc[:,:,'2010',:] - genins.mean()).max() < 1e2
+    model = cl.DevelopmentML(
+        Pipeline(
+            steps = [
+                ('design_matrix', PatsyFormula('C(development)')),
+                ('model', LinearRegression(fit_intercept=False))
+            ]
+        ),
+        y_ml=response,
+        fit_incrementals=False
+    ).fit(genins)
+    assert abs(model.triangle_ml_.loc[:, :, '2010', :] - genins.mean()).max() < 1e2
+
 
 def test_misc(genins):
-    model = cl.DevelopmentML(Pipeline(steps=[
-        ('design_matrix', PatsyFormula('C(development)')),
-        ('model', LinearRegression(fit_intercept=False))]),
-                weighted_step = ['model'], fit_incrementals=False).fit(genins, sample_weight=genins/genins)
-    assert abs(model.triangle_ml_.loc[:,:,'2010',:] - genins.mean()).max() < 1e2
-    
+    model = cl.DevelopmentML(
+        Pipeline(
+            steps = [
+                ('design_matrix', PatsyFormula('C(development)')),
+                ('model', LinearRegression(fit_intercept=False))
+            ]
+        ),
+        weighted_step = ['model'],
+        fit_incrementals = False
+    ).fit(genins, sample_weight=genins/genins)
+    assert abs(model.triangle_ml_.loc[:, :, '2010', :] - genins.mean()).max() < 1e2
+
+
 def test_grain():   
-    grains={'Y':2,'2Q':4,'Q':8,'M':24}
+    grains={'Y': 2, '2Q': 4, 'Q': 8 ,'M': 24}
     for period in grains.keys():
         tframe = pd.DataFrame()
-        devdates=pd.date_range(start='2000-01-01',end='2002-01-01',freq=period+'S',inclusive='left')
+        devdates=pd.date_range(start='2000-01-01', end='2002-01-01', freq=period+'S', inclusive='left')
         for ind, sdate in enumerate(devdates):
-            tframe=pd.concat([tframe,pd.DataFrame({'origin':[sdate]*(len(devdates)-ind),
-            'development':pd.date_range(start=sdate,end='2002-01-01',freq=period+'S',inclusive='left'),
-            'loss':[100]*(len(devdates)-ind)})])
-        tri= cl.Triangle(tframe,origin='origin',development='development',columns='loss',cumulative=False)
-        model = cl.DevelopmentML(Pipeline(steps=[
-        ('design_matrix', PatsyFormula('C(development)')),
-        ('model', LinearRegression(fit_intercept=False))]),
-                weighted_step = ['model'], fit_incrementals=False).fit(tri)
+            tframe=pd.concat([tframe, pd.DataFrame({'origin': [sdate] * (len(devdates) - ind),
+            'development': pd.date_range(start=sdate, end='2002-01-01', freq=period + 'S', inclusive='left'),
+            'loss': [100] * (len(devdates) - ind)})])
+        tri = cl.Triangle(
+            tframe,
+            origin = 'origin',
+            development = 'development',
+            columns = 'loss',
+            cumulative = False,
+        )
+        model = cl.DevelopmentML(
+            Pipeline(
+                steps=[
+                    ('design_matrix', PatsyFormula('C(development)')),
+                    ('model', LinearRegression(fit_intercept=False))
+                ]
+            ),
+            weighted_step = ['model'],
+            fit_incrementals=False
+        ).fit(tri)
         assert grains[period] == len(model.triangle_ml_.development) 
         assert grains[period] == len(model.triangle_ml_.origin)


### PR DESCRIPTION
## Summary of Changes  


## Related GitHub Issue(s)  
#1216 

## Additional Context for Reviewers  




<!-- Do not edit anything below this. -->

## Checklist
- [ ] I passed tests locally for both code (`uv run pytest`) and documentation changes (`uv run --directory docs jb build . --builder=custom --custom-builder=doctest`)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Style-only edits in tests; behavior and assertions are unchanged.
> 
> **Overview**
> Applies **Ruff** formatting to `chainladder/development/tests/test_learning.py` so it matches project lint/style rules (related to #1216). No test logic or assertions change.
> 
> Updates are mechanical: double quotes, spacing around operators and commas, multi-line layout for `DevelopmentML`/`Pipeline` calls, blank lines between functions, and a trailing newline at EOF.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 52d1bf62ae20f1f0f24d692917d58bd658825aeb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->